### PR TITLE
fix the button being disabled on failure mode

### DIFF
--- a/apps/webservice/src/app/[workspaceSlug]/systems/[systemSlug]/deployments/[deploymentSlug]/releases/[versionId]/TargetReleaseTable.tsx
+++ b/apps/webservice/src/app/[workspaceSlug]/systems/[systemSlug]/deployments/[deploymentSlug]/releases/[versionId]/TargetReleaseTable.tsx
@@ -107,7 +107,7 @@ const validForceReleaseJobStatus = [
   "scheduled",
   "action_required",
   "skipped",
-  "failed",
+  "failure",
   "cancelled",
   "completed",
 ];


### PR DESCRIPTION
I was unable to test this 100% but this is the reason the button was disabled. 

Looks like localtunnel is down right now.
``` bash
export DEBUG="localtunnel:*" && lt --subdomain  light-pink-pianos
```