### PR TITLE
Update GitHub Action Workflow to Build Multi-Architecture Docker Images

### DIFF
--- a/.github/workflows/apps-webservice.yaml
+++ b/.github/workflows/apps-webservice.yaml
@@ -22,6 +22,11 @@ jobs:
     permissions:
       contents: read
       id-token: write
+
+    strategy:
+      matrix:
+        platform: [linux/amd64, linux/arm64]
+
     steps:
       - uses: actions/checkout@v4
 
@@ -51,12 +56,14 @@ jobs:
         with:
           push: false
           file: apps/webservice/Dockerfile
+          platforms: ${{ matrix.platform }}
           tags: ${{ steps.meta.outputs.tags }}
 
       - name: Build and Push
         uses: docker/build-push-action@v6
-        if: github.ref == 'refs/heads/main'
+        if: github.ref == 'refs/heads/main' && github.event.pull_request.head.repo.full_name == github.repository
         with:
           push: true
           file: apps/webservice/Dockerfile
+          platforms: ${{ matrix.platform }}
           tags: ${{ steps.meta.outputs.tags }}


### PR DESCRIPTION
This PR updates the GitHub Actions workflow to support building Docker images for multiple architectures (e.g., `linux/amd64`, `linux/arm64`). It includes the following changes:
- Configured `docker/setup-buildx-action` for multi-platform builds.
- Added matrix strategy for architecture selection.
- Conditional steps for building and pushing images based on branch and event type.

**Note**: Please do not merge this PR. If you agree with the changes and resolution, I will apply the same updates to the other workflows.