### PR TITLE
fix: Deployment resource drawer

### DIFF
--- a/apps/webservice/src/app/[workspaceSlug]/(app)/(targets)/targets/[targetId]/visualize/nodes/DeploymentNode.tsx
+++ b/apps/webservice/src/app/[workspaceSlug]/(app)/(targets)/targets/[targetId]/visualize/nodes/DeploymentNode.tsx
@@ -6,7 +6,7 @@ import { Handle, Position } from "reactflow";
 import { cn } from "@ctrlplane/ui";
 import { JobStatus, JobStatusReadable } from "@ctrlplane/validators/jobs";
 
-import { useJobDrawer } from "~/app/[workspaceSlug]/(app)/_components/job-drawer/useJobDrawer";
+import { useDeploymentEnvResourceDrawer } from "~/app/[workspaceSlug]/(app)/_components/deployment-resource-drawer/useDeploymentResourceDrawer";
 import { api } from "~/trpc/react";
 import { ReleaseIcon } from "../../ReleaseCell";
 
@@ -19,7 +19,7 @@ type DeploymentNodeProps = NodeProps<{
 
 export const DeploymentNode: React.FC<DeploymentNodeProps> = ({ data }) => {
   const { deployment, environment, resource } = data;
-  const { setJobId } = useJobDrawer();
+  const { setDeploymentEnvResourceId } = useDeploymentEnvResourceDrawer();
 
   const resourceId = resource.id;
   const environmentId = environment.id;
@@ -49,16 +49,15 @@ export const DeploymentNode: React.FC<DeploymentNodeProps> = ({ data }) => {
     <>
       <div
         className={cn(
-          "relative flex h-[70px] w-[250px] items-center gap-2 rounded-md border border-neutral-800 bg-neutral-900/30 px-4",
+          "relative flex h-[70px] w-[250px] cursor-pointer items-center gap-2 rounded-md border border-neutral-800 bg-neutral-900/30 px-4",
           isInProgress && "border-blue-500",
           isPending && "border-neutral-500",
           isCompleted && "border-green-500",
           releaseJobTrigger == null && "border-neutral-800",
-          releaseJobTrigger != null && "cursor-pointer",
         )}
-        onClick={() => {
-          if (releaseJobTrigger != null) setJobId(releaseJobTrigger.job.id);
-        }}
+        onClick={() =>
+          setDeploymentEnvResourceId(deployment.id, environment.id, resource.id)
+        }
       >
         <ReleaseIcon job={releaseJobTrigger?.job} />
         <div className="flex min-w-0 flex-1 flex-col items-start">

--- a/apps/webservice/src/app/[workspaceSlug]/(app)/_components/deployment-resource-drawer/DeploymentResourceDrawer.tsx
+++ b/apps/webservice/src/app/[workspaceSlug]/(app)/_components/deployment-resource-drawer/DeploymentResourceDrawer.tsx
@@ -24,22 +24,22 @@ export const DeploymentResourceDrawer: React.FC = () => {
     deploymentId != null && environmentId != null && resourceId != null;
   const setIsOpen = () => setDeploymentEnvResourceId(null, null, null);
 
-  const deploymentQ = api.deployment.byId.useQuery(deploymentId ?? "", {
-    enabled: isOpen,
-  });
-  const deployment = deploymentQ.data;
+  const { data: deployment, ...deploymentQ } = api.deployment.byId.useQuery(
+    deploymentId ?? "",
+    { enabled: isOpen },
+  );
 
-  const resourceQ = api.resource.byId.useQuery(resourceId ?? "", {
-    enabled: isOpen,
-  });
-  const resource = resourceQ.data;
+  const { data: resource, ...resourceQ } = api.resource.byId.useQuery(
+    resourceId ?? "",
+    { enabled: isOpen },
+  );
 
-  const environmentQ = api.environment.byId.useQuery(environmentId ?? "", {
-    enabled: isOpen,
-  });
-  const environment = environmentQ.data;
+  const { data: environment, ...environmentQ } = api.environment.byId.useQuery(
+    environmentId ?? "",
+    { enabled: isOpen },
+  );
 
-  const releaseWithTriggersQ =
+  const { data: releaseWithTriggersData, ...releaseWithTriggersQ } =
     api.job.config.byDeploymentEnvAndResource.useQuery(
       {
         deploymentId: deploymentId ?? "",
@@ -48,7 +48,7 @@ export const DeploymentResourceDrawer: React.FC = () => {
       },
       { enabled: isOpen, refetchInterval: 5_000 },
     );
-  const releaseWithTriggers = releaseWithTriggersQ.data ?? [];
+  const releaseWithTriggers = releaseWithTriggersData ?? [];
 
   const loading =
     deploymentQ.isLoading ||

--- a/apps/webservice/src/app/[workspaceSlug]/(app)/_components/deployment-resource-drawer/DeploymentResourceDrawer.tsx
+++ b/apps/webservice/src/app/[workspaceSlug]/(app)/_components/deployment-resource-drawer/DeploymentResourceDrawer.tsx
@@ -1,0 +1,107 @@
+"use client";
+
+import { IconLoader2, IconShip } from "@tabler/icons-react";
+
+import {
+  Drawer,
+  DrawerContent,
+  DrawerDescription,
+  DrawerTitle,
+} from "@ctrlplane/ui/drawer";
+
+import { api } from "~/trpc/react";
+import { ReleaseTable } from "./ReleaseTable";
+import { useDeploymentEnvResourceDrawer } from "./useDeploymentResourceDrawer";
+
+export const DeploymentResourceDrawer: React.FC = () => {
+  const {
+    deploymentId,
+    environmentId,
+    resourceId,
+    setDeploymentEnvResourceId,
+  } = useDeploymentEnvResourceDrawer();
+  const isOpen =
+    deploymentId != null && environmentId != null && resourceId != null;
+  const setIsOpen = () => setDeploymentEnvResourceId(null, null, null);
+
+  const deploymentQ = api.deployment.byId.useQuery(deploymentId ?? "", {
+    enabled: isOpen,
+  });
+  const deployment = deploymentQ.data;
+
+  const resourceQ = api.resource.byId.useQuery(resourceId ?? "", {
+    enabled: isOpen,
+  });
+  const resource = resourceQ.data;
+
+  const environmentQ = api.environment.byId.useQuery(environmentId ?? "", {
+    enabled: isOpen,
+  });
+  const environment = environmentQ.data;
+
+  const releaseWithTriggersQ =
+    api.job.config.byDeploymentEnvAndResource.useQuery(
+      {
+        deploymentId: deploymentId ?? "",
+        environmentId: environmentId ?? "",
+        resourceId: resourceId ?? "",
+      },
+      { enabled: isOpen, refetchInterval: 5_000 },
+    );
+  const releaseWithTriggers = releaseWithTriggersQ.data ?? [];
+
+  const loading =
+    deploymentQ.isLoading ||
+    resourceQ.isLoading ||
+    environmentQ.isLoading ||
+    releaseWithTriggersQ.isLoading;
+
+  return (
+    <Drawer open={isOpen} onOpenChange={setIsOpen}>
+      <DrawerContent
+        showBar={false}
+        className="scrollbar-thin scrollbar-thumb-neutral-800 scrollbar-track-neutral-900 left-auto right-0 top-0 mt-0 h-screen w-2/3 max-w-7xl overflow-auto rounded-none focus-visible:outline-none"
+      >
+        {loading && (
+          <div className="flex h-full w-full items-center justify-center">
+            <IconLoader2 className="h-8 w-8 animate-spin" />
+            {/*
+              Drawer component throws an error if the title and description are not present, so just render empty elements.
+              Technically shadcn recommends using the VisuallyHidden radix component, but this fixes without any additional dependencies.
+             */}
+            <DrawerTitle />
+            <DrawerDescription />
+          </div>
+        )}
+        {!loading &&
+          deployment != null &&
+          resource != null &&
+          environment != null && (
+            <>
+              <DrawerTitle className="flex flex-col gap-2 border-b p-6">
+                <div className="flex items-center gap-2">
+                  <div className="flex-shrink-0 rounded bg-amber-500/20 p-1 text-amber-400">
+                    <IconShip className="h-4 w-4" />
+                  </div>
+                  {deployment.name}
+                </div>
+                <div className="flex flex-col gap-1 text-xs text-muted-foreground">
+                  <span>Resource: {resource.name}</span>
+                  <span>Environment: {environment.name}</span>
+                </div>
+              </DrawerTitle>
+
+              <div className="flex flex-col gap-4 p-6">
+                <ReleaseTable
+                  releasesWithTriggers={releaseWithTriggers}
+                  environment={environment}
+                  deployment={deployment}
+                  resource={resource}
+                />
+              </div>
+            </>
+          )}
+      </DrawerContent>
+    </Drawer>
+  );
+};

--- a/apps/webservice/src/app/[workspaceSlug]/(app)/_components/deployment-resource-drawer/ReleaseTable.tsx
+++ b/apps/webservice/src/app/[workspaceSlug]/(app)/_components/deployment-resource-drawer/ReleaseTable.tsx
@@ -40,17 +40,15 @@ export const ReleaseTable: React.FC<ReleaseTableProps> = ({
         </TableRow>
       </TableHeader>
       <TableBody>
-        {releasesWithTriggers.map((release) => {
-          return (
-            <ReleaseRows
-              release={release}
-              environment={environment}
-              deployment={deployment}
-              resource={resource}
-              key={release.id}
-            />
-          );
-        })}
+        {releasesWithTriggers.map((release) => (
+          <ReleaseRows
+            release={release}
+            environment={environment}
+            deployment={deployment}
+            resource={resource}
+            key={release.id}
+          />
+        ))}
         {releasesWithTriggers.length === 0 && (
           <TableRow>
             <TableCell

--- a/apps/webservice/src/app/[workspaceSlug]/(app)/_components/deployment-resource-drawer/ReleaseTable.tsx
+++ b/apps/webservice/src/app/[workspaceSlug]/(app)/_components/deployment-resource-drawer/ReleaseTable.tsx
@@ -1,0 +1,67 @@
+import type { RouterOutputs } from "@ctrlplane/api";
+import type * as SCHEMA from "@ctrlplane/db/schema";
+
+import {
+  Table,
+  TableBody,
+  TableCell,
+  TableHead,
+  TableHeader,
+  TableRow,
+} from "@ctrlplane/ui/table";
+
+import { ReleaseRows } from "./TableRow";
+
+type ReleaseWithTriggers =
+  RouterOutputs["job"]["config"]["byDeploymentEnvAndResource"][number];
+
+type ReleaseTableProps = {
+  releasesWithTriggers: ReleaseWithTriggers[];
+  environment: SCHEMA.Environment & { system: SCHEMA.System };
+  deployment: SCHEMA.Deployment;
+  resource: SCHEMA.Resource;
+};
+
+export const ReleaseTable: React.FC<ReleaseTableProps> = ({
+  releasesWithTriggers,
+  environment,
+  deployment,
+  resource,
+}) => (
+  <div className="rounded-md border border-neutral-800">
+    <Table className="table-fixed">
+      <TableHeader>
+        <TableRow>
+          <TableHead>Release</TableHead>
+          <TableHead>Status</TableHead>
+          <TableHead>Created</TableHead>
+          <TableHead>Links</TableHead>
+          <TableHead />
+        </TableRow>
+      </TableHeader>
+      <TableBody>
+        {releasesWithTriggers.map((release) => {
+          return (
+            <ReleaseRows
+              release={release}
+              environment={environment}
+              deployment={deployment}
+              resource={resource}
+              key={release.id}
+            />
+          );
+        })}
+        {releasesWithTriggers.length === 0 && (
+          <TableRow>
+            <TableCell
+              colSpan={5}
+              className="text-center text-muted-foreground"
+            >
+              No releases found
+            </TableCell>
+          </TableRow>
+        )}
+      </TableBody>
+    </Table>
+  </div>
+);

--- a/apps/webservice/src/app/[workspaceSlug]/(app)/_components/deployment-resource-drawer/TableRow.tsx
+++ b/apps/webservice/src/app/[workspaceSlug]/(app)/_components/deployment-resource-drawer/TableRow.tsx
@@ -19,6 +19,11 @@ import {
   CollapsibleContent,
   CollapsibleTrigger,
 } from "@ctrlplane/ui/collapsible";
+import {
+  HoverCard,
+  HoverCardContent,
+  HoverCardTrigger,
+} from "@ctrlplane/ui/hover-card";
 import { TableCell, TableRow } from "@ctrlplane/ui/table";
 import { ReservedMetadataKey } from "@ctrlplane/validators/conditions";
 import { JobStatusReadable } from "@ctrlplane/validators/jobs";
@@ -140,7 +145,58 @@ const LinksCell: React.FC<LinksCellProps> = ({ releaseJobTrigger }) => {
       </TableCell>
     );
 
-  return <TableCell />;
+  const firstThreeLinks = Object.entries(links).slice(0, 3);
+  const remainingLinks = Object.entries(links).slice(3);
+
+  return (
+    <TableCell className="py-0">
+      <div
+        className="flex flex-wrap gap-2"
+        onClick={(e) => e.stopPropagation()}
+      >
+        {firstThreeLinks.map(([label, url]) => (
+          <Link
+            key={label}
+            href={url}
+            target="_blank"
+            rel="noopener noreferrer"
+            className={cn(
+              buttonVariants({
+                variant: "secondary",
+                size: "sm",
+              }),
+            )}
+          >
+            <IconExternalLink className="h-4 w-4" />
+            {label}
+          </Link>
+        ))}
+        <HoverCard>
+          <HoverCardTrigger asChild>
+            <Button variant="secondary" size="sm" className="h-6">
+              +{remainingLinks.length} more
+            </Button>
+          </HoverCardTrigger>
+          <HoverCardContent
+            className="flex max-w-40 flex-col gap-1 p-2"
+            align="start"
+          >
+            {remainingLinks.map(([label, url]) => (
+              <Link
+                key={label}
+                href={url}
+                target="_blank"
+                rel="noopener noreferrer"
+                className="truncate text-sm underline-offset-1 hover:underline"
+              >
+                {label}
+              </Link>
+            ))}
+          </HoverCardContent>
+        </HoverCard>
+      </div>
+    </TableCell>
+  );
 };
 
 type DropdownCellProps = {

--- a/apps/webservice/src/app/[workspaceSlug]/(app)/_components/deployment-resource-drawer/TableRow.tsx
+++ b/apps/webservice/src/app/[workspaceSlug]/(app)/_components/deployment-resource-drawer/TableRow.tsx
@@ -273,27 +273,24 @@ const ReleaseJobTriggerParentRow: React.FC<ReleaseJobTriggerParentRowProps> = ({
       className="cursor-pointer"
     >
       <TableCell>
-        <div
-          className="flex items-center gap-2"
-          onClick={(e) => e.stopPropagation()}
-        >
-          {isExpandable && (
+        {isExpandable && (
+          <div onClick={(e) => e.stopPropagation()}>
             <CollapsibleTrigger asChild>
-              <Button variant="ghost" size="icon" className="h-5 w-5">
-                <IconChevronRight
-                  className={cn(
-                    "h-3 w-3 text-muted-foreground transition-all",
-                    isExpanded && "rotate-90",
-                  )}
-                />
-              </Button>
+              <div className="flex items-center gap-2">
+                <Button variant="ghost" size="icon" className="h-5 w-5">
+                  <IconChevronRight
+                    className={cn(
+                      "h-3 w-3 text-muted-foreground transition-all",
+                      isExpanded && "rotate-90",
+                    )}
+                  />
+                </Button>
+                <span className="truncate">{release.name}</span>
+              </div>
             </CollapsibleTrigger>
-          )}
-
-          <span className={cn("truncate", !isExpandable && "pl-7")}>
-            {release.name}
-          </span>
-        </div>
+          </div>
+        )}
+        {!isExpandable && <span className="truncate pl-7">{release.name}</span>}
       </TableCell>
       <StatusCell
         releaseJobTrigger={releaseJobTrigger}

--- a/apps/webservice/src/app/[workspaceSlug]/(app)/_components/deployment-resource-drawer/TableRow.tsx
+++ b/apps/webservice/src/app/[workspaceSlug]/(app)/_components/deployment-resource-drawer/TableRow.tsx
@@ -1,0 +1,352 @@
+import type { RouterOutputs } from "@ctrlplane/api";
+import type * as SCHEMA from "@ctrlplane/db/schema";
+import type { JobStatus } from "@ctrlplane/validators/jobs";
+import { useState } from "react";
+import Link from "next/link";
+import { useParams, useRouter } from "next/navigation";
+import {
+  IconChevronRight,
+  IconDots,
+  IconExternalLink,
+  IconLoader2,
+} from "@tabler/icons-react";
+import { formatDistanceToNowStrict } from "date-fns";
+
+import { cn } from "@ctrlplane/ui";
+import { Button, buttonVariants } from "@ctrlplane/ui/button";
+import {
+  Collapsible,
+  CollapsibleContent,
+  CollapsibleTrigger,
+} from "@ctrlplane/ui/collapsible";
+import { TableCell, TableRow } from "@ctrlplane/ui/table";
+import { ReservedMetadataKey } from "@ctrlplane/validators/conditions";
+import { JobStatusReadable } from "@ctrlplane/validators/jobs";
+
+import { api } from "~/trpc/react";
+import { JobDropdownMenu } from "../../systems/[systemSlug]/deployments/[deploymentSlug]/releases/[versionId]/JobDropdownMenu";
+import { DeployButton } from "../../systems/[systemSlug]/deployments/DeployButton";
+import { JobTableStatusIcon } from "../JobTableStatusIcon";
+
+type ReleaseJobTrigger = SCHEMA.ReleaseJobTrigger & {
+  job: SCHEMA.Job;
+};
+
+type StatusCellProps = {
+  releaseJobTrigger?: ReleaseJobTrigger;
+  releaseId: string;
+  environmentId: string;
+};
+
+const StatusCell: React.FC<StatusCellProps> = ({
+  releaseJobTrigger,
+  releaseId,
+  environmentId,
+}) => (
+  <TableCell className="py-0">
+    {releaseJobTrigger != null && (
+      <div className="flex items-center gap-2">
+        <JobTableStatusIcon status={releaseJobTrigger.job.status} />
+        <span className="text-xs">
+          {JobStatusReadable[releaseJobTrigger.job.status]}
+        </span>
+      </div>
+    )}
+    {releaseJobTrigger == null && (
+      <div onClick={(e) => e.stopPropagation()}>
+        <DeployButton
+          releaseId={releaseId}
+          environmentId={environmentId}
+          className="h-6 w-20"
+        />
+      </div>
+    )}
+  </TableCell>
+);
+
+type CreatedCellProps = {
+  releaseJobTrigger?: ReleaseJobTrigger;
+};
+
+const CreatedCell: React.FC<CreatedCellProps> = ({ releaseJobTrigger }) => (
+  <TableCell>
+    {releaseJobTrigger != null && (
+      <span className="text-xs">
+        {formatDistanceToNowStrict(releaseJobTrigger.createdAt, {
+          addSuffix: true,
+        })}
+      </span>
+    )}
+    {releaseJobTrigger == null && (
+      <span className="text-xs text-muted-foreground">Not deployed</span>
+    )}
+  </TableCell>
+);
+
+type LinksCellProps = {
+  releaseJobTrigger?: ReleaseJobTrigger;
+};
+
+const LinksCell: React.FC<LinksCellProps> = ({ releaseJobTrigger }) => {
+  const jobQ = api.job.config.byId.useQuery(releaseJobTrigger?.job.id ?? "", {
+    enabled: releaseJobTrigger != null,
+    refetchInterval: 5_000,
+  });
+  const job = jobQ.data;
+  const linksMetadata = job?.job.metadata.find(
+    (m) => m.key === String(ReservedMetadataKey.Links),
+  );
+  const links =
+    linksMetadata != null
+      ? (JSON.parse(linksMetadata.value) as Record<string, string>)
+      : null;
+
+  if (jobQ.isLoading)
+    return (
+      <TableCell>
+        <IconLoader2 className="h-4 w-4 animate-spin text-muted-foreground" />
+      </TableCell>
+    );
+
+  if (links == null) return <TableCell />;
+
+  const numLinks = Object.keys(links).length;
+  if (numLinks <= 3)
+    return (
+      <TableCell className="py-0">
+        <div
+          className="flex flex-wrap gap-2"
+          onClick={(e) => e.stopPropagation()}
+        >
+          {Object.entries(links).map(([label, url]) => (
+            <Link
+              key={label}
+              href={url}
+              target="_blank"
+              rel="noopener noreferrer"
+              className={cn(
+                buttonVariants({
+                  variant: "secondary",
+                  size: "sm",
+                }),
+                "h-6 max-w-20 gap-1 truncate px-2 py-0",
+              )}
+            >
+              <IconExternalLink className="h-4 w-4" />
+              {label}
+            </Link>
+          ))}
+        </div>
+      </TableCell>
+    );
+
+  return <TableCell />;
+};
+
+type DropdownCellProps = {
+  releaseJobTrigger?: ReleaseJobTrigger;
+  release: SCHEMA.Release;
+  environmentId: string;
+  resource: SCHEMA.Resource;
+  deployment: SCHEMA.Deployment;
+};
+
+const DropdownCell: React.FC<DropdownCellProps> = ({
+  releaseJobTrigger,
+  release,
+  environmentId,
+  resource,
+  deployment,
+}) => (
+  <TableCell>
+    <div className="flex justify-end">
+      {releaseJobTrigger != null && (
+        <JobDropdownMenu
+          release={release}
+          environmentId={environmentId}
+          target={resource}
+          deployment={deployment}
+          job={{
+            id: releaseJobTrigger.job.id,
+            status: releaseJobTrigger.job.status as JobStatus,
+          }}
+          isPassingReleaseChannel
+        >
+          <Button variant="ghost" size="icon" className="h-5 w-5">
+            <IconDots className="h-4 w-4" />
+          </Button>
+        </JobDropdownMenu>
+      )}
+    </div>
+  </TableCell>
+);
+
+type ReleaseJobTriggerRowProps = {
+  releaseJobTrigger?: ReleaseJobTrigger;
+  release: SCHEMA.Release;
+  environment: SCHEMA.Environment & { system: SCHEMA.System };
+  deployment: SCHEMA.Deployment;
+  resource: SCHEMA.Resource;
+};
+
+type ReleaseJobTriggerParentRowProps = ReleaseJobTriggerRowProps & {
+  isExpandable: boolean;
+  isExpanded: boolean;
+};
+
+const ReleaseJobTriggerParentRow: React.FC<ReleaseJobTriggerParentRowProps> = ({
+  releaseJobTrigger,
+  release,
+  environment,
+  deployment,
+  resource,
+  isExpandable,
+  isExpanded,
+}) => {
+  const router = useRouter();
+  const { workspaceSlug } = useParams<{ workspaceSlug: string }>();
+
+  return (
+    <TableRow
+      key={releaseJobTrigger?.id ?? release.id}
+      onClick={() =>
+        router.push(
+          `/${workspaceSlug}/systems/${environment.system.slug}/deployments/${deployment.slug}/releases/${release.id}`,
+        )
+      }
+      className="cursor-pointer"
+    >
+      <TableCell>
+        <div
+          className="flex items-center gap-2"
+          onClick={(e) => e.stopPropagation()}
+        >
+          {isExpandable && (
+            <CollapsibleTrigger asChild>
+              <Button variant="ghost" size="icon" className="h-5 w-5">
+                <IconChevronRight
+                  className={cn(
+                    "h-3 w-3 text-muted-foreground transition-all",
+                    isExpanded && "rotate-90",
+                  )}
+                />
+              </Button>
+            </CollapsibleTrigger>
+          )}
+
+          <span className={cn("truncate", !isExpandable && "pl-7")}>
+            {release.name}
+          </span>
+        </div>
+      </TableCell>
+      <StatusCell
+        releaseJobTrigger={releaseJobTrigger}
+        releaseId={release.id}
+        environmentId={environment.id}
+      />
+      <CreatedCell releaseJobTrigger={releaseJobTrigger} />
+      <LinksCell releaseJobTrigger={releaseJobTrigger} />
+      <DropdownCell
+        releaseJobTrigger={releaseJobTrigger}
+        release={release}
+        environmentId={environment.id}
+        deployment={deployment}
+        resource={resource}
+      />
+    </TableRow>
+  );
+};
+
+const ReleaseJobTriggerChildRow: React.FC<ReleaseJobTriggerRowProps> = ({
+  releaseJobTrigger,
+  release,
+  environment,
+  deployment,
+  resource,
+}) => {
+  const router = useRouter();
+  const { workspaceSlug } = useParams<{ workspaceSlug: string }>();
+
+  return (
+    <TableRow
+      key={releaseJobTrigger?.id ?? release.id}
+      onClick={() =>
+        router.push(
+          `/${workspaceSlug}/systems/${environment.system.slug}/deployments/${deployment.slug}/releases/${release.id}`,
+        )
+      }
+      className="cursor-pointer"
+    >
+      <TableCell />
+      <StatusCell
+        releaseJobTrigger={releaseJobTrigger}
+        releaseId={release.id}
+        environmentId={environment.id}
+      />
+      <CreatedCell releaseJobTrigger={releaseJobTrigger} />
+      <LinksCell releaseJobTrigger={releaseJobTrigger} />
+      <DropdownCell
+        releaseJobTrigger={releaseJobTrigger}
+        release={release}
+        environmentId={environment.id}
+        deployment={deployment}
+        resource={resource}
+      />
+    </TableRow>
+  );
+};
+
+type Release =
+  RouterOutputs["job"]["config"]["byDeploymentEnvAndResource"][number];
+
+type ReleaseRowsProps = {
+  release: Release;
+  environment: SCHEMA.Environment & { system: SCHEMA.System };
+  deployment: SCHEMA.Deployment;
+  resource: SCHEMA.Resource;
+};
+
+export const ReleaseRows: React.FC<ReleaseRowsProps> = ({
+  release,
+  environment,
+  deployment,
+  resource,
+}) => {
+  const [open, setOpen] = useState(false);
+  const { releaseJobTriggers } = release;
+  const hasOtherReleaseJobTriggers = releaseJobTriggers.length > 1;
+
+  return (
+    <Collapsible asChild open={open} onOpenChange={setOpen}>
+      <>
+        <ReleaseJobTriggerParentRow
+          release={release}
+          environment={environment}
+          deployment={deployment}
+          resource={resource}
+          releaseJobTrigger={releaseJobTriggers[0]}
+          isExpandable={hasOtherReleaseJobTriggers}
+          isExpanded={open}
+          key={releaseJobTriggers[0]?.id ?? `${release.id}-parent`}
+        />
+        <CollapsibleContent asChild>
+          <>
+            {releaseJobTriggers.map((trigger, idx) => {
+              if (idx === 0) return null;
+              return (
+                <ReleaseJobTriggerChildRow
+                  release={release}
+                  releaseJobTrigger={trigger}
+                  environment={environment}
+                  deployment={deployment}
+                  resource={resource}
+                  key={trigger.id}
+                />
+              );
+            })}
+          </>
+        </CollapsibleContent>
+      </>
+    </Collapsible>
+  );
+};

--- a/apps/webservice/src/app/[workspaceSlug]/(app)/_components/deployment-resource-drawer/useDeploymentResourceDrawer.ts
+++ b/apps/webservice/src/app/[workspaceSlug]/(app)/_components/deployment-resource-drawer/useDeploymentResourceDrawer.ts
@@ -1,14 +1,13 @@
 "use client";
 
 import { useMemo } from "react";
+import { z } from "zod";
 
 import { useQueryParams } from "../useQueryParams";
 
 const param = "deployment_env_resource_id";
 
 const DELIMITER = "--";
-const UUID_REGEX =
-  /^[0-9a-f]{8}-[0-9a-f]{4}-4[0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}$/i;
 
 export const useDeploymentEnvResourceDrawer = () => {
   const { getParam, setParams } = useQueryParams();
@@ -28,9 +27,9 @@ export const useDeploymentEnvResourceDrawer = () => {
       return { deploymentId: null, environmentId: null, resourceId: null };
 
     if (
-      !UUID_REGEX.test(rawDeploymentId) ||
-      !UUID_REGEX.test(rawEnvironmentId) ||
-      !UUID_REGEX.test(rawResourceId)
+      !z.string().uuid().safeParse(rawDeploymentId).success ||
+      !z.string().uuid().safeParse(rawEnvironmentId).success ||
+      !z.string().uuid().safeParse(rawResourceId).success
     )
       return { deploymentId: null, environmentId: null, resourceId: null };
 

--- a/apps/webservice/src/app/[workspaceSlug]/(app)/_components/deployment-resource-drawer/useDeploymentResourceDrawer.ts
+++ b/apps/webservice/src/app/[workspaceSlug]/(app)/_components/deployment-resource-drawer/useDeploymentResourceDrawer.ts
@@ -57,7 +57,7 @@ export const useDeploymentEnvResourceDrawer = () => {
         deploymentId == null || environmentId == null || resourceId == null
           ? null
           : encodeURIComponent(
-              `${deploymentId}${DELIMITER}${environmentId}${DELIMITER}${resourceId}`,
+              [deploymentId, environmentId, resourceId].join(DELIMITER),
             ),
     });
   return {

--- a/apps/webservice/src/app/[workspaceSlug]/(app)/_components/deployment-resource-drawer/useDeploymentResourceDrawer.ts
+++ b/apps/webservice/src/app/[workspaceSlug]/(app)/_components/deployment-resource-drawer/useDeploymentResourceDrawer.ts
@@ -1,0 +1,70 @@
+"use client";
+
+import { useMemo } from "react";
+
+import { useQueryParams } from "../useQueryParams";
+
+const param = "deployment_env_resource_id";
+
+const DELIMITER = "--";
+const UUID_REGEX =
+  /^[0-9a-f]{8}-[0-9a-f]{4}-4[0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}$/i;
+
+export const useDeploymentEnvResourceDrawer = () => {
+  const { getParam, setParams } = useQueryParams();
+  const deploymentResourceId = getParam(param);
+
+  const { deploymentId, environmentId, resourceId } = useMemo(() => {
+    if (deploymentResourceId == null)
+      return { deploymentId: null, environmentId: null, resourceId: null };
+
+    const [rawDeploymentId, rawEnvironmentId, rawResourceId] =
+      decodeURIComponent(deploymentResourceId).split(DELIMITER);
+    if (
+      rawDeploymentId == null ||
+      rawEnvironmentId == null ||
+      rawResourceId == null
+    )
+      return { deploymentId: null, environmentId: null, resourceId: null };
+
+    if (
+      !UUID_REGEX.test(rawDeploymentId) ||
+      !UUID_REGEX.test(rawEnvironmentId) ||
+      !UUID_REGEX.test(rawResourceId)
+    )
+      return { deploymentId: null, environmentId: null, resourceId: null };
+
+    return {
+      deploymentId: rawDeploymentId,
+      environmentId: rawEnvironmentId,
+      resourceId: rawResourceId,
+    };
+  }, [deploymentResourceId]);
+
+  /**
+   * Will set param to null if either deploymentId, environmentId, or resourceId is null.
+   *
+   * @param deploymentId - The deployment ID to set.
+   * @param environmentId - The environment ID to set.
+   * @param resourceId - The resource ID to set.
+   */
+  const setDeploymentEnvResourceId = (
+    deploymentId: string | null,
+    environmentId: string | null,
+    resourceId: string | null,
+  ) =>
+    setParams({
+      [param]:
+        deploymentId == null || environmentId == null || resourceId == null
+          ? null
+          : encodeURIComponent(
+              `${deploymentId}${DELIMITER}${environmentId}${DELIMITER}${resourceId}`,
+            ),
+    });
+  return {
+    deploymentId,
+    environmentId,
+    resourceId,
+    setDeploymentEnvResourceId,
+  };
+};

--- a/apps/webservice/src/app/[workspaceSlug]/(app)/layout.tsx
+++ b/apps/webservice/src/app/[workspaceSlug]/(app)/layout.tsx
@@ -5,6 +5,7 @@ import { auth } from "@ctrlplane/auth";
 import { SidebarInset } from "@ctrlplane/ui/sidebar";
 
 import { api } from "~/trpc/server";
+import { DeploymentResourceDrawer } from "./_components/deployment-resource-drawer/DeploymentResourceDrawer";
 import { EnvironmentDrawer } from "./_components/environment-drawer/EnvironmentDrawer";
 import { EnvironmentPolicyDrawer } from "./_components/environment-policy-drawer/EnvironmentPolicyDrawer";
 import { JobDrawer } from "./_components/job-drawer/JobDrawer";
@@ -46,7 +47,7 @@ export default async function WorkspaceLayout({
       <EnvironmentPolicyDrawer />
       <VariableSetDrawer />
       <JobDrawer />
-
+      <DeploymentResourceDrawer />
       <TerminalDrawer />
     </AppSidebarPopoverProvider>
   );

--- a/apps/webservice/src/app/[workspaceSlug]/(app)/systems/[systemSlug]/deployments/DeployButton.tsx
+++ b/apps/webservice/src/app/[workspaceSlug]/(app)/systems/[systemSlug]/deployments/DeployButton.tsx
@@ -10,7 +10,8 @@ import { api } from "~/trpc/react";
 export const DeployButton: React.FC<{
   releaseId: string;
   environmentId: string;
-}> = ({ releaseId, environmentId }) => {
+  className?: string;
+}> = ({ releaseId, environmentId, className }) => {
   const deploy = api.release.deploy.toEnvironment.useMutation();
   const router = useRouter();
 
@@ -18,6 +19,7 @@ export const DeployButton: React.FC<{
     <Button
       className={cn(
         "w-full border-dashed border-neutral-800/50 bg-transparent text-center text-neutral-800 hover:border-blue-400 hover:bg-transparent hover:text-blue-400",
+        className,
       )}
       variant="outline"
       size="sm"

--- a/apps/webservice/src/app/[workspaceSlug]/(app)/systems/[systemSlug]/deployments/[deploymentSlug]/releases/[versionId]/JobDropdownMenu.tsx
+++ b/apps/webservice/src/app/[workspaceSlug]/(app)/systems/[systemSlug]/deployments/[deploymentSlug]/releases/[versionId]/JobDropdownMenu.tsx
@@ -91,6 +91,7 @@ const OverrideJobStatusDialog: React.FC<{
       })
       .then(() => utils.job.config.byReleaseId.invalidate())
       .then(() => utils.job.config.byId.invalidate(job.id))
+      .then(() => utils.job.config.byDeploymentEnvAndResource.invalidate())
       .then(() => setOpen(false))
       .then(() => onClose()),
   );
@@ -104,7 +105,7 @@ const OverrideJobStatusDialog: React.FC<{
       }}
     >
       <DialogTrigger asChild>{children}</DialogTrigger>
-      <DialogContent>
+      <DialogContent onClick={(e) => e.stopPropagation()}>
         <Form {...form}>
           <form onSubmit={onSubmit} className="space-y-4">
             <DialogHeader>
@@ -183,13 +184,14 @@ const ForceReleaseTargetDialog: React.FC<{
   children,
 }) => {
   const forceRelease = api.release.deploy.toResource.useMutation();
+  const utils = api.useUtils();
   const router = useRouter();
   const [open, setOpen] = useState(false);
 
   return (
     <AlertDialog open={open} onOpenChange={setOpen}>
       <AlertDialogTrigger asChild>{children}</AlertDialogTrigger>
-      <AlertDialogContent>
+      <AlertDialogContent onClick={(e) => e.stopPropagation()}>
         <AlertDialogHeader>
           <AlertDialogTitle>
             Are you sure you want to force release?
@@ -218,6 +220,9 @@ const ForceReleaseTargetDialog: React.FC<{
                   environmentId: environmentId,
                   isForcedRelease: true,
                 })
+                .then(() =>
+                  utils.job.config.byDeploymentEnvAndResource.invalidate(),
+                )
                 .then(() => router.refresh())
                 .then(() => setOpen(false))
                 .then(() => onClose())
@@ -238,12 +243,13 @@ const RedeployReleaseDialog: React.FC<{
   children: React.ReactNode;
 }> = ({ release, environmentId, target, children }) => {
   const router = useRouter();
+  const utils = api.useUtils();
   const redeploy = api.release.deploy.toResource.useMutation();
   const [isOpen, setIsOpen] = useState(false);
   return (
     <Dialog open={isOpen} onOpenChange={setIsOpen}>
       <DialogTrigger asChild>{children}</DialogTrigger>
-      <DialogContent>
+      <DialogContent onClick={(e) => e.stopPropagation()}>
         <DialogHeader>
           <DialogTitle>
             Redeploy{" "}
@@ -267,6 +273,9 @@ const RedeployReleaseDialog: React.FC<{
                   resourceId: target.id,
                   releaseId: release.id,
                 })
+                .then(() =>
+                  utils.job.config.byDeploymentEnvAndResource.invalidate(),
+                )
                 .then(() => router.refresh())
                 .then(() => setIsOpen(false))
             }
@@ -302,7 +311,7 @@ export const JobDropdownMenu: React.FC<{
     <DropdownMenu open={open} onOpenChange={setOpen}>
       <DropdownMenuTrigger asChild>{children}</DropdownMenuTrigger>
       {target != null && (
-        <DropdownMenuContent align="end">
+        <DropdownMenuContent align="end" onClick={(e) => e.stopPropagation()}>
           {isActive && (
             <TooltipProvider>
               <Tooltip>

--- a/packages/api/src/router/job.ts
+++ b/packages/api/src/router/job.ts
@@ -321,7 +321,7 @@ const releaseJobTriggerRouter = createTRPCRouter({
           .perform(Permission.DeploymentGet)
           .on({ type: "deployment", id: deploymentId });
         const canUserGetEnvironmentPromise = canUser
-          .perform(Permission.SystemGet)
+          .perform(Permission.EnvironmentGet)
           .on({ type: "environment", id: environmentId });
         const canUserGetResourcePromise = canUser
           .perform(Permission.ResourceGet)
@@ -330,10 +330,7 @@ const releaseJobTriggerRouter = createTRPCRouter({
           canUserGetDeploymentPromise,
           canUserGetEnvironmentPromise,
           canUserGetResourcePromise,
-        ]).then(
-          ([deployment, environment, resource]) =>
-            deployment && environment && resource,
-        );
+        ]).then((results) => results.every(Boolean));
       },
     })
     .query(async ({ ctx, input }) => {

--- a/packages/api/src/router/job.ts
+++ b/packages/api/src/router/job.ts
@@ -315,23 +315,18 @@ const releaseJobTriggerRouter = createTRPCRouter({
       }),
     )
     .meta({
-      authorizationCheck: ({ canUser, input }) => {
-        const { deploymentId, environmentId, resourceId } = input;
-        const canUserGetDeploymentPromise = canUser
-          .perform(Permission.DeploymentGet)
-          .on({ type: "deployment", id: deploymentId });
-        const canUserGetEnvironmentPromise = canUser
-          .perform(Permission.EnvironmentGet)
-          .on({ type: "environment", id: environmentId });
-        const canUserGetResourcePromise = canUser
-          .perform(Permission.ResourceGet)
-          .on({ type: "resource", id: resourceId });
-        return Promise.all([
-          canUserGetDeploymentPromise,
-          canUserGetEnvironmentPromise,
-          canUserGetResourcePromise,
-        ]).then((results) => results.every(Boolean));
-      },
+      authorizationCheck: ({ canUser, input }) =>
+        canUser
+          .perform(
+            Permission.DeploymentGet,
+            Permission.EnvironmentGet,
+            Permission.ResourceGet,
+          )
+          .on(
+            { type: "deployment", id: input.deploymentId },
+            { type: "environment", id: input.environmentId },
+            { type: "resource", id: input.resourceId },
+          ),
     })
     .query(async ({ ctx, input }) => {
       const { deploymentId, environmentId, resourceId } = input;

--- a/packages/validators/src/auth/index.ts
+++ b/packages/validators/src/auth/index.ts
@@ -74,6 +74,7 @@ export enum Permission {
   DeploymentVariableUpdate = "deploymentVariable.update",
   DeploymentVariableDelete = "deploymentVariable.delete",
 
+  EnvironmentGet = "environment.get",
   EnvironmentUpdate = "environment.update",
 
   ReleaseCreate = "release.create",


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
	- Introduced the `DeploymentResourceDrawer` component for managing deployment resources.
	- Added `ReleaseTable` component to display associated releases in a structured format.
	- New `TableRow` components for rendering rows in the release table.
	- Enhanced `DeployButton` to accept custom styling via an optional `className` prop.
	- Implemented job status update cache invalidation in the `JobDropdownMenu`.
	- Added a new permission constant `EnvironmentGet` for authorization checks.
	- Introduced a new procedure `byDeploymentEnvAndResource` for querying job triggers based on deployment, environment, and resource IDs.

- **Bug Fixes**
	- Improved responsiveness of UI to job and release status changes through cache invalidation logic.

- **Documentation**
	- Updated method signatures and component descriptions to reflect new functionalities.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->