### PR TITLE
fix: Show parent nodes for job relationships

### DIFF
--- a/apps/webservice/src/app/[workspaceSlug]/(app)/(targets)/targets/[targetId]/visualize/ResourceVisualizationDiagram.tsx
+++ b/apps/webservice/src/app/[workspaceSlug]/(app)/(targets)/targets/[targetId]/visualize/ResourceVisualizationDiagram.tsx
@@ -30,6 +30,7 @@ export const ResourceVisualizationDiagram: React.FC<
   const setReactFlowInstance = useLayoutAndFitView(nodes, {
     direction: "LR",
     extraEdgeLength: 50,
+    focusedNodeId: relationships.resource.id,
   });
 
   return (

--- a/apps/webservice/src/app/[workspaceSlug]/(app)/(targets)/targets/[targetId]/visualize/nodes/ResourceNode.tsx
+++ b/apps/webservice/src/app/[workspaceSlug]/(app)/(targets)/targets/[targetId]/visualize/nodes/ResourceNode.tsx
@@ -1,6 +1,8 @@
 import type { NodeProps } from "reactflow";
 import { Handle, Position } from "reactflow";
 
+import { cn } from "@ctrlplane/ui";
+
 import { useTargetDrawer } from "~/app/[workspaceSlug]/(app)/_components/target-drawer/useTargetDrawer";
 import { TargetIcon as ResourceIcon } from "~/app/[workspaceSlug]/(app)/_components/TargetIcon";
 
@@ -10,6 +12,7 @@ type ResourceNodeProps = NodeProps<{
   id: string;
   kind: string;
   version: string;
+  isBaseNode: boolean;
 }>;
 export const ResourceNode: React.FC<ResourceNodeProps> = (node) => {
   const { data } = node;
@@ -17,7 +20,10 @@ export const ResourceNode: React.FC<ResourceNodeProps> = (node) => {
   return (
     <>
       <div
-        className="flex w-[250px] cursor-pointer flex-col gap-2 rounded-md border bg-neutral-900/30 px-4 py-3"
+        className={cn(
+          "flex w-[250px] cursor-pointer flex-col gap-2 rounded-md border bg-neutral-900/30 px-4 py-3",
+          data.isBaseNode && "border-2 border-neutral-600",
+        )}
         onClick={() => setResourceId(data.id)}
       >
         <div className="flex items-center gap-2">

--- a/apps/webservice/src/app/[workspaceSlug]/(app)/(targets)/targets/[targetId]/visualize/nodes/ResourceNode.tsx
+++ b/apps/webservice/src/app/[workspaceSlug]/(app)/(targets)/targets/[targetId]/visualize/nodes/ResourceNode.tsx
@@ -22,7 +22,7 @@ export const ResourceNode: React.FC<ResourceNodeProps> = (node) => {
       <div
         className={cn(
           "flex w-[250px] cursor-pointer flex-col gap-2 rounded-md border bg-neutral-900/30 px-4 py-3",
-          data.isBaseNode && "border-2 border-neutral-600",
+          data.isBaseNode && "bg-neutral-800/60",
         )}
         onClick={() => setResourceId(data.id)}
       >

--- a/apps/webservice/src/app/[workspaceSlug]/(app)/(targets)/targets/[targetId]/visualize/nodes/nodes.ts
+++ b/apps/webservice/src/app/[workspaceSlug]/(app)/(targets)/targets/[targetId]/visualize/nodes/nodes.ts
@@ -27,7 +27,11 @@ const getResourceNodes = (relationships: Relationships) =>
   relationships.nodes.map((r) => ({
     id: r.id,
     type: NodeType.Resource,
-    data: { ...r, label: r.identifier },
+    data: {
+      ...r,
+      label: r.identifier,
+      isBaseNode: r.id === relationships.resource.id,
+    },
     position: { x: 0, y: 0 },
   }));
 

--- a/apps/webservice/src/app/[workspaceSlug]/(app)/_components/reactflow/layout.ts
+++ b/apps/webservice/src/app/[workspaceSlug]/(app)/_components/reactflow/layout.ts
@@ -70,6 +70,7 @@ type LayoutConfig = {
   nodesep?: number;
   padding?: number;
   maxZoom?: number;
+  focusedNodeId?: string;
 };
 
 export const useLayoutAndFitView = (nodes: Node[], config?: LayoutConfig) => {
@@ -99,6 +100,14 @@ export const useLayoutAndFitView = (nodes: Node[], config?: LayoutConfig) => {
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [reactFlowInstance]);
 
+  const setDefaultView = useCallback(() => {
+    reactFlowInstance?.fitView({
+      padding: config?.padding ?? 0.12,
+      maxZoom: config?.maxZoom ?? 1,
+    });
+    setIsViewFitted(true);
+  }, [reactFlowInstance, config]);
+
   useEffect(() => {
     if (
       reactFlowInstance != null &&
@@ -106,13 +115,36 @@ export const useLayoutAndFitView = (nodes: Node[], config?: LayoutConfig) => {
       isLayouted &&
       !isViewFitted
     ) {
+      if (config?.focusedNodeId == null) {
+        setDefaultView();
+        return;
+      }
+
+      const focusedNode = nodes.find((n) => n.id === config.focusedNodeId);
+      if (focusedNode == null) {
+        setDefaultView();
+        return;
+      }
+
       reactFlowInstance.fitView({
-        padding: config?.padding ?? 0.12,
-        maxZoom: config?.maxZoom ?? 1,
+        padding: config.padding ?? 0.12,
+        maxZoom: config.maxZoom ?? 2,
       });
+      reactFlowInstance.setCenter(
+        focusedNode.position.x + 100,
+        focusedNode.position.y + 100,
+        { zoom: 1.5, duration: 500 },
+      );
       setIsViewFitted(true);
     }
-  }, [reactFlowInstance, nodes, isLayouted, isViewFitted, config]);
+  }, [
+    reactFlowInstance,
+    nodes,
+    isLayouted,
+    isViewFitted,
+    config,
+    setDefaultView,
+  ]);
 
   return setReactFlowInstance;
 };


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
	- Enhanced visual differentiation of resource nodes with the addition of a new property, `isBaseNode`.
	- New functionality to retrieve parent nodes for resource nodes, improving hierarchical relationships management.
	- Added the ability to focus on a specific node in the Resource Visualization Diagram, enhancing user navigation.

- **Bug Fixes**
	- Improved error handling in the relationships query to gracefully manage cases with no parent nodes.

- **Documentation**
	- Updated function names for clarity regarding child node retrieval.
	- Introduced new optional property `focusedNodeId` for dynamic view adjustments in the layout management.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->