### PR TITLE
fix: release metadata in the v1/openapi.ts

### DIFF
--- a/apps/webservice/src/app/api/v1/openapi.ts
+++ b/apps/webservice/src/app/api/v1/openapi.ts
@@ -45,10 +45,7 @@ export const openapi: Swagger.SwaggerV3 = {
           config: { type: "object", additionalProperties: true },
           deploymentId: { type: "string", format: "uuid" },
           createdAt: { type: "string", format: "date-time" },
-          metadata: {
-            type: "object",
-            additionalProperties: { type: "string" },
-          },
+          metadata: { type: "object", additionalProperties: true },
         },
         required: [
           "id",

--- a/apps/webservice/src/app/api/v1/openapi.ts
+++ b/apps/webservice/src/app/api/v1/openapi.ts
@@ -45,6 +45,10 @@ export const openapi: Swagger.SwaggerV3 = {
           config: { type: "object", additionalProperties: true },
           deploymentId: { type: "string", format: "uuid" },
           createdAt: { type: "string", format: "date-time" },
+          metadata: {
+            type: "object",
+            additionalProperties: { type: "string" },
+          },
         },
         required: [
           "id",

--- a/apps/webservice/src/app/api/v1/releases/openapi.ts
+++ b/apps/webservice/src/app/api/v1/releases/openapi.ts
@@ -24,8 +24,7 @@ export const openapi: Swagger.SwaggerV3 = {
                   name: { type: "string" },
                   config: { type: "object", additionalProperties: true },
                   metadata: {
-                    type: "object",
-                    additionalProperties: { type: "string" },
+                    $ref: "#/components/schemas/Release/properties/metadata",
                   },
                 },
                 required: ["version", "deploymentId"],
@@ -44,10 +43,7 @@ export const openapi: Swagger.SwaggerV3 = {
                     id: { type: "string" },
                     version: { type: "string" },
                     metadata: {
-                      type: "object",
-                      additionalProperties: {
-                        type: "string",
-                      },
+                      $ref: "#/components/schemas/Release/properties/metadata",
                     },
                   },
                 },

--- a/integrations/github-get-job-inputs/src/index.ts
+++ b/integrations/github-get-job-inputs/src/index.ts
@@ -78,6 +78,7 @@ async function run() {
       setOutputAndLog("release_id", release?.id);
       setOutputAndLog("release_version", release?.version);
       setOutputsRecursively("release_config", release?.config);
+      setOutputsRecursively("release_metadata", release?.metadata);
 
       if (approval?.approver != null) {
         setOutputAndLog("approval_approver_id", approval.approver.id);

--- a/openapi.v1.json
+++ b/openapi.v1.json
@@ -1341,10 +1341,7 @@
                     "additionalProperties": true
                   },
                   "metadata": {
-                    "type": "object",
-                    "additionalProperties": {
-                      "type": "string"
-                    }
+                    "$ref": "#/components/schemas/Release/properties/metadata"
                   }
                 },
                 "required": [
@@ -1370,10 +1367,7 @@
                       "type": "string"
                     },
                     "metadata": {
-                      "type": "object",
-                      "additionalProperties": {
-                        "type": "string"
-                      }
+                      "$ref": "#/components/schemas/Release/properties/metadata"
                     }
                   }
                 }
@@ -2356,6 +2350,12 @@
           "createdAt": {
             "type": "string",
             "format": "date-time"
+          },
+          "metadata": {
+            "type": "object",
+            "additionalProperties": {
+              "type": "string"
+            }
           }
         },
         "required": [

--- a/openapi.v1.json
+++ b/openapi.v1.json
@@ -2353,9 +2353,7 @@
           },
           "metadata": {
             "type": "object",
-            "additionalProperties": {
-              "type": "string"
-            }
+            "additionalProperties": true
           }
         },
         "required": [

--- a/packages/node-sdk/src/schema.ts
+++ b/packages/node-sdk/src/schema.ts
@@ -383,7 +383,7 @@ export interface components {
       /** Format: date-time */
       createdAt: string;
       metadata?: {
-        [key: string]: string;
+        [key: string]: unknown;
       };
     };
     Environment: {

--- a/packages/node-sdk/src/schema.ts
+++ b/packages/node-sdk/src/schema.ts
@@ -382,6 +382,9 @@ export interface components {
       deploymentId: string;
       /** Format: date-time */
       createdAt: string;
+      metadata?: {
+        [key: string]: string;
+      };
     };
     Environment: {
       /** Format: uuid */
@@ -1249,9 +1252,7 @@ export interface operations {
           config?: {
             [key: string]: unknown;
           };
-          metadata?: {
-            [key: string]: string;
-          };
+          metadata?: components["schemas"]["Release"]["metadata"];
         };
       };
     };
@@ -1265,9 +1266,7 @@ export interface operations {
           "application/json": {
             id?: string;
             version?: string;
-            metadata?: {
-              [key: string]: string;
-            };
+            metadata?: components["schemas"]["Release"]["metadata"];
           };
         };
       };


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added a `metadata` property to the `Release` and `Resource` schemas, allowing for additional information.
  - Introduced new endpoints for deleting release channels and environments, as well as retrieving systems and resources.

- **Updated Features**
  - Standardized the `metadata` property across request and response schemas for the `/v1/releases` endpoint.
  - Enhanced the `GET` method for resources to include additional properties in the response.
  - Updated the `PATCH` method for job agents to include a request body schema.

- **Security Enhancements**
  - Added security requirements for certain endpoints to ensure protected operations.

- **Improvements**
  - Refined response descriptions and schemas for clarity, including success properties for delete operations.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->