### PR TITLE
fix: New permissions trigger new migration image

### DIFF
--- a/.github/workflows/packages-migrations.yaml
+++ b/.github/workflows/packages-migrations.yaml
@@ -6,12 +6,13 @@ on:
     paths:
       - packages/db/**
       - .github/workflows/packages-migrations.yaml
+      - packages/auth/index.ts
   push:
     branches: ["main"]
     paths:
       - packages/db/**
       - .github/workflows/packages-migrations.yaml
-
+      - packages/auth/index.ts
 jobs:
   build:
     runs-on: ubuntu-latest

--- a/.github/workflows/packages-migrations.yaml
+++ b/.github/workflows/packages-migrations.yaml
@@ -6,13 +6,13 @@ on:
     paths:
       - packages/db/**
       - .github/workflows/packages-migrations.yaml
-      - packages/auth/index.ts
+      - packages/validators/src/auth/index.ts
   push:
     branches: ["main"]
     paths:
       - packages/db/**
       - .github/workflows/packages-migrations.yaml
-      - packages/auth/index.ts
+      - packages/validators/src/auth/index.ts
 jobs:
   build:
     runs-on: ubuntu-latest

--- a/packages/validators/src/auth/index.ts
+++ b/packages/validators/src/auth/index.ts
@@ -79,6 +79,7 @@ export enum Permission {
 
   EnvironmentGet = "environment.get",
   EnvironmentUpdate = "environment.update",
+  EnvironmentList = "environment.list",
 
   ReleaseCreate = "release.create",
   ReleaseGet = "release.get",


### PR DESCRIPTION
since migration package upserts roles in `packages/auth/index.ts` it needs to be a path recognized by the build and push workflow

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Expanded automation triggers to ensure that changes in the authentication module now initiate build and test processes on both pull requests and pushes.
	- Introduced a new permission allowing controlled access to environment listing, enhancing user management and access control capabilities.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->