### PR TITLE
fix: Don't display the managed aws integration unless the server can …

### DIFF
--- a/apps/webservice/src/app/[workspaceSlug]/(appv2)/resources/(sidebar)/providers/integrations/page.tsx
+++ b/apps/webservice/src/app/[workspaceSlug]/(appv2)/resources/(sidebar)/providers/integrations/page.tsx
@@ -98,6 +98,8 @@ const ResourceProviders: React.FC<{ workspaceSlug: string }> = async ({
   const workspace = await api.workspace.bySlug(workspaceSlug);
   if (workspace == null) return notFound();
   const azureAppClientId = env.AZURE_APP_CLIENT_ID;
+  const currentAwsAccountId =
+    await api.workspace.integrations.aws.currentAwsAccountId();
   return (
     <div className="flex h-full flex-col">
       <PageHeader className="z-10">
@@ -124,24 +126,26 @@ const ResourceProviders: React.FC<{ workspaceSlug: string }> = async ({
             run anything.
           </p>
           <div className="mt-8 grid grid-cols-3 gap-6">
-            <ResourceProviderCard>
-              <ResourceProviderContent>
-                <ResourceProviderHeading>
-                  <SiAmazon className="mx-auto text-4xl text-orange-300" />
-                  <div className="font-semibold">Amazon</div>
-                </ResourceProviderHeading>
-                <p className="text-xs text-muted-foreground">
-                  Grant our account the correct permissions and we will manage
-                  running the resource provider for you.
-                </p>
+            {currentAwsAccountId != null && (
+              <ResourceProviderCard>
+                <ResourceProviderContent>
+                  <ResourceProviderHeading>
+                    <SiAmazon className="mx-auto text-4xl text-orange-300" />
+                    <div className="font-semibold">Amazon</div>
+                  </ResourceProviderHeading>
+                  <p className="text-xs text-muted-foreground">
+                    Grant our account the correct permissions and we will manage
+                    running the resource provider for you.
+                  </p>
 
-                <ResourceProviderBadges>
-                  <K8sBadge />
-                </ResourceProviderBadges>
-              </ResourceProviderContent>
+                  <ResourceProviderBadges>
+                    <K8sBadge />
+                  </ResourceProviderBadges>
+                </ResourceProviderContent>
 
-              <AwsActionButton workspace={workspace} />
-            </ResourceProviderCard>
+                <AwsActionButton workspace={workspace} />
+              </ResourceProviderCard>
+            )}
 
             <ResourceProviderCard>
               <ResourceProviderContent>

--- a/apps/webservice/src/app/[workspaceSlug]/(appv2)/settings/workspace/integrations/page.tsx
+++ b/apps/webservice/src/app/[workspaceSlug]/(appv2)/settings/workspace/integrations/page.tsx
@@ -7,6 +7,8 @@ import {
 
 import { Card } from "@ctrlplane/ui/card";
 
+import { api } from "~/trpc/server";
+
 export const metadata = { title: "Integrations - Settings" };
 
 const IntegrationCard: React.FC<{
@@ -38,6 +40,9 @@ export default async function IntegrationsPage(props: {
   const params = await props.params;
   const { workspaceSlug } = params;
 
+  const currentAwsAccountId =
+    await api.workspace.integrations.aws.currentAwsAccountId();
+
   return (
     <div className="container mx-auto max-w-3xl space-y-8 overflow-auto pt-8">
       <div className="space-y-1">
@@ -61,17 +66,20 @@ export default async function IntegrationsPage(props: {
           </IntegrationContent>
         </IntegrationCard>
 
-        <IntegrationCard integration="aws" workspaceSlug={workspaceSlug}>
-          <IntegrationContent>
-            <IntegrationHeading>
-              <SiAmazon className="text-4xl text-orange-400" />
-              <span className="font-semibold">AWS</span>
-            </IntegrationHeading>
-            <p className="text-left text-sm text-muted-foreground">
-              Sync deployment resources, trigger AWS workflows and more.
-            </p>
-          </IntegrationContent>
-        </IntegrationCard>
+        {currentAwsAccountId != null && (
+          <IntegrationCard integration="aws" workspaceSlug={workspaceSlug}>
+            <IntegrationContent>
+              <IntegrationHeading>
+                <SiAmazon className="text-4xl text-orange-400" />
+                <span className="font-semibold">AWS</span>
+              </IntegrationHeading>
+              <p className="text-left text-sm text-muted-foreground">
+                Sync deployment resources, trigger AWS workflows and more.{" "}
+                {currentAwsAccountId}
+              </p>
+            </IntegrationContent>
+          </IntegrationCard>
+        )}
 
         <IntegrationCard integration="google" workspaceSlug={workspaceSlug}>
           <IntegrationContent>

--- a/apps/webservice/src/app/[workspaceSlug]/(appv2)/settings/workspace/overview/page.tsx
+++ b/apps/webservice/src/app/[workspaceSlug]/(appv2)/settings/workspace/overview/page.tsx
@@ -14,6 +14,8 @@ import {
 
 import { Button } from "@ctrlplane/ui/button";
 
+import { api } from "~/trpc/server";
+
 export const metadata = { title: "Overview - Workspace" };
 
 export default async function OverviewPage(props: {
@@ -21,6 +23,10 @@ export default async function OverviewPage(props: {
 }) {
   const params = await props.params;
   const { workspaceSlug } = params;
+
+  const currentAwsAccountId =
+    await api.workspace.integrations.aws.currentAwsAccountId();
+
   return (
     <div className="scrollbar-thin scrollbar-thumb-neutral-700 scrollbar-track-neutral-800 container mx-auto max-w-7xl space-y-8 overflow-auto pt-8">
       <div className="space-y-1">
@@ -166,26 +172,28 @@ export default async function OverviewPage(props: {
               </div>
             </div>
           </div>
-          <div className="space-y-2 border-b pb-2">
-            <div className="flex flex-grow gap-3">
-              <SiAmazon className="h-5 w-5 text-orange-400" />
-              <div className="space-y-2">
-                <div>AWS</div>
-                <div className="text-xs text-muted-foreground">
-                  Sync deployment resources, trigger AWS workflows and more.
-                </div>
-                <div>
-                  <Link
-                    href={`/${workspaceSlug}/settings/workspace/integrations/aws`}
-                  >
-                    <Button variant="secondary" size="sm">
-                      Open
-                    </Button>
-                  </Link>
+          {currentAwsAccountId != null && (
+            <div className="space-y-2 border-b pb-2">
+              <div className="flex flex-grow gap-3">
+                <SiAmazon className="h-5 w-5 text-orange-400" />
+                <div className="space-y-2">
+                  <div>AWS</div>
+                  <div className="text-xs text-muted-foreground">
+                    Sync deployment resources, trigger AWS workflows and more.
+                  </div>
+                  <div>
+                    <Link
+                      href={`/${workspaceSlug}/settings/workspace/integrations/aws`}
+                    >
+                      <Button variant="secondary" size="sm">
+                        Open
+                      </Button>
+                    </Link>
+                  </div>
                 </div>
               </div>
             </div>
-          </div>
+          )}
         </div>
       </div>
 

--- a/packages/api/src/router/workspace-integrations.ts
+++ b/packages/api/src/router/workspace-integrations.ts
@@ -328,5 +328,12 @@ export const integrationsRouter = createTRPCRouter({
           .returning()
           .then(takeFirst);
       }),
+
+    currentAwsAccountId: protectedProcedure.query(async () =>
+      stsClient
+        .send(new GetCallerIdentityCommand({}))
+        .then((response) => response.Account ?? null)
+        .catch(() => null),
+    ),
   }),
 });


### PR DESCRIPTION
…get a caller identity


ref INFRA-610

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - AWS integration panels now display conditionally: they appear only when valid AWS account details are available.
  - The integration sections across various pages (resources, settings, and overview) now show updated information, ensuring users see AWS details only when applicable.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->