### PR TITLE
fix: Use left join to capture null metadata combinations

### DIFF
--- a/packages/api/src/router/resource-metadata-group.ts
+++ b/packages/api/src/router/resource-metadata-group.ts
@@ -140,13 +140,15 @@ export const resourceMetadataGroupRouter = createTRPCRouter({
       const resourceMetadataAggBase = ctx.db
         .select({
           id: resource.id,
-          metadata: sql<Record<string, string>>`jsonb_object_agg(
+          metadata: sql<Record<string, string>>`COALESCE(jsonb_object_agg(
             ${resourceMetadata.key},
             ${resourceMetadata.value}
-          )`.as("metadata"),
+          ) FILTER (WHERE ${resourceMetadata.key} IS NOT NULL), '{}'::jsonb)`.as(
+            "metadata",
+          ),
         })
         .from(resource)
-        .innerJoin(
+        .leftJoin(
           resourceMetadata,
           and(
             eq(resource.id, resourceMetadata.resourceId),


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
	- Improved how resource metadata is aggregated so that only valid metadata entries are shown.
	- Ensured that resources without metadata are now included with a sensible default display.


<!-- end of auto-generated comment: release notes by coderabbit.ai -->