### PR TITLE
fix: Add tenant and subscription to aks cluster config

### DIFF
--- a/apps/event-worker/src/resource-scan/azure/aks.ts
+++ b/apps/event-worker/src/resource-scan/azure/aks.ts
@@ -46,9 +46,13 @@ export const getAksResources = async (
     clusters.push(cluster);
   }
 
-  const { resourceProviderId: providerId } = azureProvider;
   const resourcePromises = clusters.map((cluster) =>
-    convertManagedClusterToResource(workspace.id, providerId, cluster, client),
+    convertManagedClusterToResource(
+      workspace.id,
+      azureProvider,
+      cluster,
+      client,
+    ),
   );
   const resources = await Promise.all(resourcePromises);
   return resources.filter(isPresent);

--- a/packages/validators/src/resources/kubernetes-v1.ts
+++ b/packages/validators/src/resources/kubernetes-v1.ts
@@ -30,6 +30,8 @@ const clusterConfig = z.object({
       method: z.literal("azure/aks"),
       resourceGroup: z.string(),
       clusterName: z.string(),
+      tenantId: z.string(),
+      subscriptionId: z.string(),
     }),
     z.object({
       method: z.literal("exec"),


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Azure Kubernetes configurations now require additional authentication details (tenant and subscription IDs) to enhance integration reliability.

- **Refactor**
  - Improved handling of Azure provider information in resource scanning to ensure more robust and consistent processing.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->