### PR TITLE
fix: Use open-api formatting not express

### DIFF
--- a/apps/webservice/src/app/api/v1/workspaces/[workspaceId]/deployments/openapi.ts
+++ b/apps/webservice/src/app/api/v1/workspaces/[workspaceId]/deployments/openapi.ts
@@ -7,7 +7,7 @@ export const openapi: Swagger.SwaggerV3 = {
     version: "1.0.0",
   },
   paths: {
-    "/v1/workspaces/:workspaceId/deployments": {
+    "/v1/workspaces/{workspaceId}/deployments": {
       parameters: [
         {
           name: "workspaceId",

--- a/apps/webservice/src/app/api/v1/workspaces/[workspaceId]/environments/openapi.ts
+++ b/apps/webservice/src/app/api/v1/workspaces/[workspaceId]/environments/openapi.ts
@@ -7,7 +7,7 @@ export const openapi: Swagger.SwaggerV3 = {
     version: "1.0.0",
   },
   paths: {
-    "/v1/workspaces/:workspaceId/environments": {
+    "/v1/workspaces/{workspaceId}/environments": {
       parameters: [
         {
           name: "workspaceId",

--- a/apps/webservice/src/app/api/v1/workspaces/[workspaceId]/resources/openapi.ts
+++ b/apps/webservice/src/app/api/v1/workspaces/[workspaceId]/resources/openapi.ts
@@ -7,7 +7,7 @@ export const openapi: Swagger.SwaggerV3 = {
     version: "1.0.0",
   },
   paths: {
-    "/v1/workspaces/:workspaceId/resources": {
+    "/v1/workspaces/{workspaceId}/resources": {
       parameters: [
         {
           name: "workspaceId",

--- a/apps/webservice/src/app/api/v1/workspaces/[workspaceId]/systems/openapi.ts
+++ b/apps/webservice/src/app/api/v1/workspaces/[workspaceId]/systems/openapi.ts
@@ -4,7 +4,7 @@ export const openapi: Swagger.SwaggerV3 = {
   openapi: "3.0.0",
   info: { title: "Ctrlplane API", version: "1.0.0" },
   paths: {
-    "/v1/workspaces/:workspaceId/systems": {
+    "/v1/workspaces/{workspaceId}/systems": {
       parameters: [
         {
           name: "workspaceId",

--- a/openapi.v1.json
+++ b/openapi.v1.json
@@ -2364,7 +2364,7 @@
         }
       }
     },
-    "/v1/workspaces/:workspaceId/deployments": {
+    "/v1/workspaces/{workspaceId}/deployments": {
       "parameters": [
         {
           "name": "workspaceId",
@@ -2401,7 +2401,7 @@
         }
       }
     },
-    "/v1/workspaces/:workspaceId/environments": {
+    "/v1/workspaces/{workspaceId}/environments": {
       "parameters": [
         {
           "name": "workspaceId",
@@ -2808,7 +2808,7 @@
         }
       }
     },
-    "/v1/workspaces/:workspaceId/resources": {
+    "/v1/workspaces/{workspaceId}/resources": {
       "parameters": [
         {
           "name": "workspaceId",
@@ -2845,7 +2845,7 @@
         }
       }
     },
-    "/v1/workspaces/:workspaceId/systems": {
+    "/v1/workspaces/{workspaceId}/systems": {
       "parameters": [
         {
           "name": "workspaceId",


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Documentation**
	- Standardized the API endpoint paths to use curly-brace notation for parameters across deployments, environments, resources, and systems. This change ensures that the API documentation adheres to OpenAPI 3.0 conventions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->