### PR TITLE
fix: Revert deploymentVersionChannel to releaseChannel

### DIFF
--- a/apps/webservice/src/app/api/v1/environments/openapi.ts
+++ b/apps/webservice/src/app/api/v1/environments/openapi.ts
@@ -41,7 +41,7 @@ export const openapi: Swagger.SwaggerV3 = {
                   policyId: {
                     type: "string",
                   },
-                  deploymentVersionChannels: {
+                  releaseChannels: {
                     type: "array",
                     items: {
                       type: "string",

--- a/apps/webservice/src/app/api/v1/environments/route.ts
+++ b/apps/webservice/src/app/api/v1/environments/route.ts
@@ -15,7 +15,7 @@ import { parseBody } from "../body-parser";
 import { request } from "../middleware";
 
 const body = schema.createEnvironment.extend({
-  deploymentVersionChannels: z.array(z.string()),
+  releaseChannels: z.array(z.string()),
   expiresAt: z.coerce
     .date()
     .min(new Date(), "Expires at must be in the future")
@@ -48,7 +48,11 @@ export const POST = request()
 
       try {
         return ctx.db.transaction(async (tx) => {
-          const { deploymentVersionChannels, metadata, ...rest } = ctx.body;
+          const {
+            releaseChannels: deploymentVersionChannels,
+            metadata,
+            ...rest
+          } = ctx.body;
 
           const channels = await tx
             .select()

--- a/openapi.v1.json
+++ b/openapi.v1.json
@@ -572,7 +572,7 @@
                   "policyId": {
                     "type": "string"
                   },
-                  "deploymentVersionChannels": {
+                  "releaseChannels": {
                     "type": "array",
                     "items": {
                       "type": "string"

--- a/packages/node-sdk/src/schema.ts
+++ b/packages/node-sdk/src/schema.ts
@@ -1237,7 +1237,7 @@ export interface operations {
             [key: string]: unknown;
           };
           policyId?: string;
-          deploymentVersionChannels?: string[];
+          releaseChannels?: string[];
           metadata?: {
             [key: string]: string;
           };


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Refactor**
  - Renamed the field used in the environment creation API from its previous name to **releaseChannels** for improved clarity. This update is consistently applied across the API specification and public SDK.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->