### PR TITLE
fix: Make channel endpoint backwards compatible and perform upsert if nonunique detected

### DIFF
--- a/apps/webservice/src/app/api/v1/release-channels/route.ts
+++ b/apps/webservice/src/app/api/v1/release-channels/route.ts
@@ -25,7 +25,7 @@ export const POST = request()
         .on({ type: "deployment", id: ctx.body.deploymentId }),
     ),
   )
-  .handle<{ body: z.infer<typeof schema> }>(async ({ db, body }) => {
+  .handle<{ body: z.infer<typeof schema> }>(({ db, body }) => {
     const versionSelector = body.versionSelector ?? body.releaseFilter;
 
     return db


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Enhanced the deployment channel API to accept an optional parameter, offering greater flexibility in deployment version selection.

- **Refactor**
  - Simplified the creation and update process by automating conflict resolution, which now updates channel details when duplicates are encountered.

These improvements streamline how deployment version channels are managed and ensure seamless responses in JSON format.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->