### PR TITLE
refactor: upsert resource endpoint only upserts one resource

### DIFF
--- a/apps/webservice/src/app/api/v1/resources/openapi.ts
+++ b/apps/webservice/src/app/api/v1/resources/openapi.ts
@@ -9,47 +9,36 @@ export const openapi: Swagger.SwaggerV3 = {
   paths: {
     "/v1/resources": {
       post: {
-        summary: "Create or update multiple resources",
-        operationId: "upsertResources",
+        summary: "Create or update a resource",
+        operationId: "upsertResource",
         requestBody: {
           required: true,
           content: {
             "application/json": {
               schema: {
                 type: "object",
-                required: ["workspaceId", "resources"],
+                required: [
+                  "workspaceId",
+                  "name",
+                  "kind",
+                  "identifier",
+                  "version",
+                  "config",
+                ],
                 properties: {
-                  workspaceId: {
-                    type: "string",
-                    format: "uuid",
+                  workspaceId: { type: "string", format: "uuid" },
+                  name: { type: "string" },
+                  kind: { type: "string" },
+                  identifier: { type: "string" },
+                  version: { type: "string" },
+                  config: { type: "object" },
+                  metadata: {
+                    type: "object",
+                    additionalProperties: { type: "string" },
                   },
-                  resources: {
+                  variables: {
                     type: "array",
-                    items: {
-                      type: "object",
-                      required: [
-                        "name",
-                        "kind",
-                        "identifier",
-                        "version",
-                        "config",
-                      ],
-                      properties: {
-                        name: { type: "string" },
-                        kind: { type: "string" },
-                        identifier: { type: "string" },
-                        version: { type: "string" },
-                        config: { type: "object" },
-                        metadata: {
-                          type: "object",
-                          additionalProperties: { type: "string" },
-                        },
-                        variables: {
-                          type: "array",
-                          items: { $ref: "#/components/schemas/Variable" },
-                        },
-                      },
-                    },
+                    items: { $ref: "#/components/schemas/Variable" },
                   },
                 },
               },
@@ -58,15 +47,10 @@ export const openapi: Swagger.SwaggerV3 = {
         },
         responses: {
           200: {
-            description: "All of the cats",
+            description: "The created or updated resource",
             content: {
               "application/json": {
-                schema: {
-                  type: "object",
-                  properties: {
-                    count: { type: "number" },
-                  },
-                },
+                schema: { $ref: "#/components/schemas/Resource" },
               },
             },
           },

--- a/apps/webservice/src/app/api/v1/resources/route.ts
+++ b/apps/webservice/src/app/api/v1/resources/route.ts
@@ -1,12 +1,11 @@
-import type * as schema from "@ctrlplane/db/schema";
 import { NextResponse } from "next/server";
+import { INTERNAL_SERVER_ERROR } from "http-status";
 import { z } from "zod";
 
-import { selector, upsertResources } from "@ctrlplane/db";
+import { and, eq, selector, upsertResources } from "@ctrlplane/db";
 import { db } from "@ctrlplane/db/client";
-import { createResource } from "@ctrlplane/db/schema";
+import * as schema from "@ctrlplane/db/schema";
 import { Channel, getQueue } from "@ctrlplane/events";
-import { groupResourcesByHook } from "@ctrlplane/job-dispatch";
 import { logger } from "@ctrlplane/logger";
 import { Permission } from "@ctrlplane/validators/auth";
 
@@ -16,31 +15,25 @@ import { request } from "../middleware";
 
 const log = logger.child({ module: "v1/resources" });
 
-const patchBodySchema = z.object({
-  workspaceId: z.string().uuid(),
-  resources: z.array(
-    createResource
-      .omit({ lockedAt: true, providerId: true, workspaceId: true })
-      .extend({
-        metadata: z.record(z.string()).optional(),
-        variables: z
-          .array(
-            z.object({
-              key: z.string(),
-              value: z.union([z.string(), z.number(), z.boolean(), z.null()]),
-              sensitive: z.boolean(),
-            }),
-          )
-          .optional()
-          .refine(
-            (vars) =>
-              vars == null ||
-              new Set(vars.map((v) => v.key)).size === vars.length,
-            "Duplicate variable keys are not allowed",
-          ),
-      }),
-  ),
-});
+const patchBodySchema = schema.createResource
+  .omit({ lockedAt: true, providerId: true })
+  .extend({
+    metadata: z.record(z.string()).optional(),
+    variables: z
+      .array(
+        z.object({
+          key: z.string(),
+          value: z.union([z.string(), z.number(), z.boolean(), z.null()]),
+          sensitive: z.boolean(),
+        }),
+      )
+      .optional()
+      .refine(
+        (vars) =>
+          vars == null || new Set(vars.map((v) => v.key)).size === vars.length,
+        "Duplicate variable keys are not allowed",
+      ),
+  });
 
 export const POST = request()
   .use(authn)
@@ -55,43 +48,30 @@ export const POST = request()
   .handle<{ user: schema.User; body: z.infer<typeof patchBodySchema> }>(
     async (ctx) => {
       try {
-        if (ctx.body.resources.length === 0)
+        const existingResource = await db.query.resource.findFirst({
+          where: and(
+            eq(schema.resource.identifier, ctx.body.identifier),
+            eq(schema.resource.workspaceId, ctx.body.workspaceId),
+          ),
+        });
+
+        const [insertedResource] = await upsertResources(db, [ctx.body]);
+        if (insertedResource == null)
           return NextResponse.json(
-            { error: "No resources provided" },
-            { status: 400 },
+            { error: "Failed to update resources" },
+            { status: INTERNAL_SERVER_ERROR },
           );
-
-        // since this endpoint is not scoped to a provider, we will ignore deleted resources
-        // as someone may be calling this endpoint to do a pure upsert
-        const { workspaceId } = ctx.body;
-        const { toInsert, toUpdate } = await groupResourcesByHook(
-          db,
-          ctx.body.resources.map((r) => ({ ...r, workspaceId })),
-        );
-
-        const [insertedResources, updatedResources] = await Promise.all([
-          upsertResources(db, toInsert),
-          upsertResources(db, toUpdate),
-        ]);
-        const insertJobs = insertedResources.map((r) => ({
-          name: r.id,
-          data: r,
-        }));
-        const updateJobs = updatedResources.map((r) => ({
-          name: r.id,
-          data: r,
-        }));
-
+        const queueChannel =
+          existingResource != null
+            ? Channel.UpdatedResource
+            : Channel.NewResource;
+        const queue = getQueue(queueChannel);
         selector()
           .compute()
-          .allResourceSelectors(workspaceId)
-          .then(() => {
-            getQueue(Channel.NewResource).addBulk(insertJobs);
-            getQueue(Channel.UpdatedResource).addBulk(updateJobs);
-          });
+          .allResourceSelectors(ctx.body.workspaceId)
+          .then(() => queue.add(insertedResource.id, insertedResource));
 
-        const count = insertedResources.length + updatedResources.length;
-        return NextResponse.json({ count });
+        return NextResponse.json(insertedResource, { status: 200 });
       } catch (err) {
         const error = err instanceof Error ? err : new Error(String(err));
         log.error(`Error updating resources: ${error}`);

--- a/e2e/api/schema.ts
+++ b/e2e/api/schema.ts
@@ -4,3694 +4,3680 @@
  */
 
 export interface paths {
-  "/api/v1/cloud-locations/{provider}": {
-    parameters: {
-      query?: never;
-      header?: never;
-      path?: never;
-      cookie?: never;
+    "/api/v1/cloud-locations/{provider}": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        /**
+         * Get all regions for a specific cloud provider
+         * @description Returns geographic data for all regions of a specific cloud provider
+         */
+        get: operations["getCloudProviderRegions"];
+        put?: never;
+        post?: never;
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
     };
-    /**
-     * Get all regions for a specific cloud provider
-     * @description Returns geographic data for all regions of a specific cloud provider
-     */
-    get: operations["getCloudProviderRegions"];
-    put?: never;
-    post?: never;
-    delete?: never;
-    options?: never;
-    head?: never;
-    patch?: never;
-    trace?: never;
-  };
-  "/v1/deployment-version-channels": {
-    parameters: {
-      query?: never;
-      header?: never;
-      path?: never;
-      cookie?: never;
+    "/v1/deployment-version-channels": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        get?: never;
+        put?: never;
+        /** Create a deployment version channel */
+        post: operations["createDeploymentVersionChannel"];
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
     };
-    get?: never;
-    put?: never;
-    /** Create a deployment version channel */
-    post: operations["createDeploymentVersionChannel"];
-    delete?: never;
-    options?: never;
-    head?: never;
-    patch?: never;
-    trace?: never;
-  };
-  "/v1/deployment-versions/{deploymentVersionId}": {
-    parameters: {
-      query?: never;
-      header?: never;
-      path?: never;
-      cookie?: never;
+    "/v1/deployment-versions/{deploymentVersionId}": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        get?: never;
+        put?: never;
+        post?: never;
+        delete?: never;
+        options?: never;
+        head?: never;
+        /** Updates a deployment version */
+        patch: operations["updateDeploymentVersion"];
+        trace?: never;
     };
-    get?: never;
-    put?: never;
-    post?: never;
-    delete?: never;
-    options?: never;
-    head?: never;
-    /** Updates a deployment version */
-    patch: operations["updateDeploymentVersion"];
-    trace?: never;
-  };
-  "/v1/deployment-versions": {
-    parameters: {
-      query?: never;
-      header?: never;
-      path?: never;
-      cookie?: never;
+    "/v1/deployment-versions": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        get?: never;
+        put?: never;
+        /** Upserts a deployment version */
+        post: operations["upsertDeploymentVersion"];
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
     };
-    get?: never;
-    put?: never;
-    /** Upserts a deployment version */
-    post: operations["upsertDeploymentVersion"];
-    delete?: never;
-    options?: never;
-    head?: never;
-    patch?: never;
-    trace?: never;
-  };
-  "/v1/deployments/{deploymentId}/deployment-version-channels/name/{name}": {
-    parameters: {
-      query?: never;
-      header?: never;
-      path?: never;
-      cookie?: never;
+    "/v1/deployments/{deploymentId}/deployment-version-channels/name/{name}": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        get?: never;
+        put?: never;
+        post?: never;
+        /** Delete a deployment version channel */
+        delete: operations["deleteDeploymentVersionChannel"];
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
     };
-    get?: never;
-    put?: never;
-    post?: never;
-    /** Delete a deployment version channel */
-    delete: operations["deleteDeploymentVersionChannel"];
-    options?: never;
-    head?: never;
-    patch?: never;
-    trace?: never;
-  };
-  "/v1/deployments/{deploymentId}": {
-    parameters: {
-      query?: never;
-      header?: never;
-      path?: never;
-      cookie?: never;
+    "/v1/deployments/{deploymentId}": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        /** Get a deployment */
+        get: operations["getDeployment"];
+        put?: never;
+        post?: never;
+        /** Delete a deployment */
+        delete: operations["deleteDeployment"];
+        options?: never;
+        head?: never;
+        /** Update a deployment */
+        patch: operations["updateDeployment"];
+        trace?: never;
     };
-    /** Get a deployment */
-    get: operations["getDeployment"];
-    put?: never;
-    post?: never;
-    /** Delete a deployment */
-    delete: operations["deleteDeployment"];
-    options?: never;
-    head?: never;
-    /** Update a deployment */
-    patch: operations["updateDeployment"];
-    trace?: never;
-  };
-  "/v1/deployments/{deploymentId}/release-channels/name/{name}": {
-    parameters: {
-      query?: never;
-      header?: never;
-      path?: never;
-      cookie?: never;
+    "/v1/deployments/{deploymentId}/release-channels/name/{name}": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        get?: never;
+        put?: never;
+        post?: never;
+        /** Delete a release channel */
+        delete: operations["deleteReleaseChannel"];
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
     };
-    get?: never;
-    put?: never;
-    post?: never;
-    /** Delete a release channel */
-    delete: operations["deleteReleaseChannel"];
-    options?: never;
-    head?: never;
-    patch?: never;
-    trace?: never;
-  };
-  "/v1/deployments/{deploymentId}/resources": {
-    parameters: {
-      query?: never;
-      header?: never;
-      path?: never;
-      cookie?: never;
+    "/v1/deployments/{deploymentId}/resources": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        /** Get resources for a deployment */
+        get: operations["getResourcesForDeployment"];
+        put?: never;
+        post?: never;
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
     };
-    /** Get resources for a deployment */
-    get: operations["getResourcesForDeployment"];
-    put?: never;
-    post?: never;
-    delete?: never;
-    options?: never;
-    head?: never;
-    patch?: never;
-    trace?: never;
-  };
-  "/v1/deployments": {
-    parameters: {
-      query?: never;
-      header?: never;
-      path?: never;
-      cookie?: never;
+    "/v1/deployments": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        get?: never;
+        put?: never;
+        /** Create a deployment */
+        post: operations["createDeployment"];
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
     };
-    get?: never;
-    put?: never;
-    /** Create a deployment */
-    post: operations["createDeployment"];
-    delete?: never;
-    options?: never;
-    head?: never;
-    patch?: never;
-    trace?: never;
-  };
-  "/v1/environments/{environmentId}": {
-    parameters: {
-      query?: never;
-      header?: never;
-      path?: never;
-      cookie?: never;
+    "/v1/environments/{environmentId}": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        /** Get an environment */
+        get: operations["getEnvironment"];
+        put?: never;
+        post?: never;
+        /** Delete an environment */
+        delete: operations["deleteEnvironment"];
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
     };
-    /** Get an environment */
-    get: operations["getEnvironment"];
-    put?: never;
-    post?: never;
-    /** Delete an environment */
-    delete: operations["deleteEnvironment"];
-    options?: never;
-    head?: never;
-    patch?: never;
-    trace?: never;
-  };
-  "/v1/environments/{environmentId}/resources": {
-    parameters: {
-      query?: never;
-      header?: never;
-      path?: never;
-      cookie?: never;
+    "/v1/environments/{environmentId}/resources": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        /** Get resources for an environment */
+        get: operations["getResourcesForEnvironment"];
+        put?: never;
+        post?: never;
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
     };
-    /** Get resources for an environment */
-    get: operations["getResourcesForEnvironment"];
-    put?: never;
-    post?: never;
-    delete?: never;
-    options?: never;
-    head?: never;
-    patch?: never;
-    trace?: never;
-  };
-  "/v1/environments": {
-    parameters: {
-      query?: never;
-      header?: never;
-      path?: never;
-      cookie?: never;
+    "/v1/environments": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        get?: never;
+        put?: never;
+        /** Create an environment */
+        post: operations["createEnvironment"];
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
     };
-    get?: never;
-    put?: never;
-    /** Create an environment */
-    post: operations["createEnvironment"];
-    delete?: never;
-    options?: never;
-    head?: never;
-    patch?: never;
-    trace?: never;
-  };
-  "/v1/job-agents/{agentId}/jobs/running": {
-    parameters: {
-      query?: never;
-      header?: never;
-      path?: never;
-      cookie?: never;
+    "/v1/job-agents/{agentId}/jobs/running": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        /** Get a agents running jobs */
+        get: operations["getAgentRunningJobs"];
+        put?: never;
+        post?: never;
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
     };
-    /** Get a agents running jobs */
-    get: operations["getAgentRunningJobs"];
-    put?: never;
-    post?: never;
-    delete?: never;
-    options?: never;
-    head?: never;
-    patch?: never;
-    trace?: never;
-  };
-  "/v1/job-agents/{agentId}/queue/acknowledge": {
-    parameters: {
-      query?: never;
-      header?: never;
-      path?: never;
-      cookie?: never;
+    "/v1/job-agents/{agentId}/queue/acknowledge": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        get?: never;
+        put?: never;
+        /**
+         * Acknowledge a job for an agent
+         * @description Marks a job as acknowledged by the agent
+         */
+        post: operations["acknowledgeAgentJob"];
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
     };
-    get?: never;
-    put?: never;
-    /**
-     * Acknowledge a job for an agent
-     * @description Marks a job as acknowledged by the agent
-     */
-    post: operations["acknowledgeAgentJob"];
-    delete?: never;
-    options?: never;
-    head?: never;
-    patch?: never;
-    trace?: never;
-  };
-  "/v1/job-agents/{agentId}/queue/next": {
-    parameters: {
-      query?: never;
-      header?: never;
-      path?: never;
-      cookie?: never;
+    "/v1/job-agents/{agentId}/queue/next": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        /** Get the next jobs */
+        get: operations["getNextJobs"];
+        put?: never;
+        post?: never;
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
     };
-    /** Get the next jobs */
-    get: operations["getNextJobs"];
-    put?: never;
-    post?: never;
-    delete?: never;
-    options?: never;
-    head?: never;
-    patch?: never;
-    trace?: never;
-  };
-  "/v1/job-agents/name": {
-    parameters: {
-      query?: never;
-      header?: never;
-      path?: never;
-      cookie?: never;
+    "/v1/job-agents/name": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        get?: never;
+        put?: never;
+        post?: never;
+        delete?: never;
+        options?: never;
+        head?: never;
+        /** Upserts the agent */
+        patch: operations["upsertJobAgent"];
+        trace?: never;
     };
-    get?: never;
-    put?: never;
-    post?: never;
-    delete?: never;
-    options?: never;
-    head?: never;
-    /** Upserts the agent */
-    patch: operations["upsertJobAgent"];
-    trace?: never;
-  };
-  "/v1/jobs/{jobId}/acknowledge": {
-    parameters: {
-      query?: never;
-      header?: never;
-      path?: never;
-      cookie?: never;
+    "/v1/jobs/{jobId}/acknowledge": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        get?: never;
+        put?: never;
+        /** Acknowledge a job */
+        post: operations["acknowledgeJob"];
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
     };
-    get?: never;
-    put?: never;
-    /** Acknowledge a job */
-    post: operations["acknowledgeJob"];
-    delete?: never;
-    options?: never;
-    head?: never;
-    patch?: never;
-    trace?: never;
-  };
-  "/v1/jobs/{jobId}": {
-    parameters: {
-      query?: never;
-      header?: never;
-      path?: never;
-      cookie?: never;
+    "/v1/jobs/{jobId}": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        /** Get a Job */
+        get: operations["getJob"];
+        put?: never;
+        post?: never;
+        delete?: never;
+        options?: never;
+        head?: never;
+        /** Update a job */
+        patch: operations["updateJob"];
+        trace?: never;
     };
-    /** Get a Job */
-    get: operations["getJob"];
-    put?: never;
-    post?: never;
-    delete?: never;
-    options?: never;
-    head?: never;
-    /** Update a job */
-    patch: operations["updateJob"];
-    trace?: never;
-  };
-  "/v1/policies/{policyId}": {
-    parameters: {
-      query?: never;
-      header?: never;
-      path?: never;
-      cookie?: never;
+    "/v1/policies/{policyId}": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        get?: never;
+        put?: never;
+        post?: never;
+        /** Delete a policy */
+        delete: operations["deletePolicy"];
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
     };
-    get?: never;
-    put?: never;
-    post?: never;
-    /** Delete a policy */
-    delete: operations["deletePolicy"];
-    options?: never;
-    head?: never;
-    patch?: never;
-    trace?: never;
-  };
-  "/v1/policies/{policyId}/release-targets": {
-    parameters: {
-      query?: never;
-      header?: never;
-      path?: never;
-      cookie?: never;
+    "/v1/policies/{policyId}/release-targets": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        /** Get release targets for a policy */
+        get: operations["getReleaseTargetsForPolicy"];
+        put?: never;
+        post?: never;
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
     };
-    /** Get release targets for a policy */
-    get: operations["getReleaseTargetsForPolicy"];
-    put?: never;
-    post?: never;
-    delete?: never;
-    options?: never;
-    head?: never;
-    patch?: never;
-    trace?: never;
-  };
-  "/v1/policies": {
-    parameters: {
-      query?: never;
-      header?: never;
-      path?: never;
-      cookie?: never;
+    "/v1/policies": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        get?: never;
+        put?: never;
+        /** Upsert a policy */
+        post: operations["upsertPolicy"];
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
     };
-    get?: never;
-    put?: never;
-    /** Upsert a policy */
-    post: operations["upsertPolicy"];
-    delete?: never;
-    options?: never;
-    head?: never;
-    patch?: never;
-    trace?: never;
-  };
-  "/v1/relationship/job-to-resource": {
-    parameters: {
-      query?: never;
-      header?: never;
-      path?: never;
-      cookie?: never;
+    "/v1/relationship/job-to-resource": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        get?: never;
+        put?: never;
+        /** Create a relationship between a job and a resource */
+        post: operations["createJobToResourceRelationship"];
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
     };
-    get?: never;
-    put?: never;
-    /** Create a relationship between a job and a resource */
-    post: operations["createJobToResourceRelationship"];
-    delete?: never;
-    options?: never;
-    head?: never;
-    patch?: never;
-    trace?: never;
-  };
-  "/v1/relationship/resource-to-resource": {
-    parameters: {
-      query?: never;
-      header?: never;
-      path?: never;
-      cookie?: never;
+    "/v1/relationship/resource-to-resource": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        get?: never;
+        put?: never;
+        /** Create a relationship between two resources */
+        post: operations["createResourceToResourceRelationship"];
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
     };
-    get?: never;
-    put?: never;
-    /** Create a relationship between two resources */
-    post: operations["createResourceToResourceRelationship"];
-    delete?: never;
-    options?: never;
-    head?: never;
-    patch?: never;
-    trace?: never;
-  };
-  "/v1/release-channels": {
-    parameters: {
-      query?: never;
-      header?: never;
-      path?: never;
-      cookie?: never;
+    "/v1/release-channels": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        get?: never;
+        put?: never;
+        /** Create a release channel */
+        post: operations["createReleaseChannel"];
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
     };
-    get?: never;
-    put?: never;
-    /** Create a release channel */
-    post: operations["createReleaseChannel"];
-    delete?: never;
-    options?: never;
-    head?: never;
-    patch?: never;
-    trace?: never;
-  };
-  "/v1/releases/{releaseId}": {
-    parameters: {
-      query?: never;
-      header?: never;
-      path?: never;
-      cookie?: never;
+    "/v1/releases/{releaseId}": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        get?: never;
+        put?: never;
+        post?: never;
+        delete?: never;
+        options?: never;
+        head?: never;
+        /** Updates a release */
+        patch: operations["updateRelease"];
+        trace?: never;
     };
-    get?: never;
-    put?: never;
-    post?: never;
-    delete?: never;
-    options?: never;
-    head?: never;
-    /** Updates a release */
-    patch: operations["updateRelease"];
-    trace?: never;
-  };
-  "/v1/releases": {
-    parameters: {
-      query?: never;
-      header?: never;
-      path?: never;
-      cookie?: never;
+    "/v1/releases": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        get?: never;
+        put?: never;
+        /** Upserts a release */
+        post: operations["upsertRelease"];
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
     };
-    get?: never;
-    put?: never;
-    /** Upserts a release */
-    post: operations["upsertRelease"];
-    delete?: never;
-    options?: never;
-    head?: never;
-    patch?: never;
-    trace?: never;
-  };
-  "/v1/resource-providers/{providerId}/set": {
-    parameters: {
-      query?: never;
-      header?: never;
-      path?: never;
-      cookie?: never;
+    "/v1/resource-providers/{providerId}/set": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        get?: never;
+        put?: never;
+        post?: never;
+        delete?: never;
+        options?: never;
+        head?: never;
+        /** Sets the resource for a provider. */
+        patch: operations["setResourceProvidersResources"];
+        trace?: never;
     };
-    get?: never;
-    put?: never;
-    post?: never;
-    delete?: never;
-    options?: never;
-    head?: never;
-    /** Sets the resource for a provider. */
-    patch: operations["setResourceProvidersResources"];
-    trace?: never;
-  };
-  "/v1/resource-schemas": {
-    parameters: {
-      query?: never;
-      header?: never;
-      path?: never;
-      cookie?: never;
+    "/v1/resource-schemas": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        get?: never;
+        put?: never;
+        /** Create a resource schema */
+        post: operations["createResourceSchema"];
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
     };
-    get?: never;
-    put?: never;
-    /** Create a resource schema */
-    post: operations["createResourceSchema"];
-    delete?: never;
-    options?: never;
-    head?: never;
-    patch?: never;
-    trace?: never;
-  };
-  "/v1/resource-schemas/{schemaId}": {
-    parameters: {
-      query?: never;
-      header?: never;
-      path?: never;
-      cookie?: never;
+    "/v1/resource-schemas/{schemaId}": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        get?: never;
+        put?: never;
+        post?: never;
+        /** Delete a resource schema */
+        delete: operations["deleteResourceSchema"];
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
     };
-    get?: never;
-    put?: never;
-    post?: never;
-    /** Delete a resource schema */
-    delete: operations["deleteResourceSchema"];
-    options?: never;
-    head?: never;
-    patch?: never;
-    trace?: never;
-  };
-  "/v1/resources/{resourceId}": {
-    parameters: {
-      query?: never;
-      header?: never;
-      path?: never;
-      cookie?: never;
+    "/v1/resources/{resourceId}": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        /** Get a resource */
+        get: operations["getResource"];
+        put?: never;
+        post?: never;
+        /** Delete a resource */
+        delete: operations["deleteResource"];
+        options?: never;
+        head?: never;
+        /** Update a resource */
+        patch: operations["updateResource"];
+        trace?: never;
     };
-    /** Get a resource */
-    get: operations["getResource"];
-    put?: never;
-    post?: never;
-    /** Delete a resource */
-    delete: operations["deleteResource"];
-    options?: never;
-    head?: never;
-    /** Update a resource */
-    patch: operations["updateResource"];
-    trace?: never;
-  };
-  "/v1/resources": {
-    parameters: {
-      query?: never;
-      header?: never;
-      path?: never;
-      cookie?: never;
+    "/v1/resources": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        get?: never;
+        put?: never;
+        /** Create or update a resource */
+        post: operations["upsertResource"];
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
     };
-    get?: never;
-    put?: never;
-    /** Create or update multiple resources */
-    post: operations["upsertResources"];
-    delete?: never;
-    options?: never;
-    head?: never;
-    patch?: never;
-    trace?: never;
-  };
-  "/v1/systems/{systemId}/environments/{name}": {
-    parameters: {
-      query?: never;
-      header?: never;
-      path?: never;
-      cookie?: never;
+    "/v1/systems/{systemId}/environments/{name}": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        get?: never;
+        put?: never;
+        post?: never;
+        /** Delete an environment */
+        delete: operations["deleteEnvironmentByName"];
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
     };
-    get?: never;
-    put?: never;
-    post?: never;
-    /** Delete an environment */
-    delete: operations["deleteEnvironmentByName"];
-    options?: never;
-    head?: never;
-    patch?: never;
-    trace?: never;
-  };
-  "/v1/systems/{systemId}": {
-    parameters: {
-      query?: never;
-      header?: never;
-      path?: never;
-      cookie?: never;
+    "/v1/systems/{systemId}": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        /** Get a system */
+        get: operations["getSystem"];
+        put?: never;
+        post?: never;
+        /** Delete a system */
+        delete: operations["deleteSystem"];
+        options?: never;
+        head?: never;
+        /** Update a system */
+        patch: operations["updateSystem"];
+        trace?: never;
     };
-    /** Get a system */
-    get: operations["getSystem"];
-    put?: never;
-    post?: never;
-    /** Delete a system */
-    delete: operations["deleteSystem"];
-    options?: never;
-    head?: never;
-    /** Update a system */
-    patch: operations["updateSystem"];
-    trace?: never;
-  };
-  "/v1/systems": {
-    parameters: {
-      query?: never;
-      header?: never;
-      path?: never;
-      cookie?: never;
+    "/v1/systems": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        get?: never;
+        put?: never;
+        /** Create a system */
+        post: operations["createSystem"];
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
     };
-    get?: never;
-    put?: never;
-    /** Create a system */
-    post: operations["createSystem"];
-    delete?: never;
-    options?: never;
-    head?: never;
-    patch?: never;
-    trace?: never;
-  };
-  "/v1/workspaces/{workspaceId}/deployments": {
-    parameters: {
-      query?: never;
-      header?: never;
-      path: {
-        /** @description The ID of the workspace */
-        workspaceId: string;
-      };
-      cookie?: never;
+    "/v1/workspaces/{workspaceId}/deployments": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path: {
+                /** @description The ID of the workspace */
+                workspaceId: string;
+            };
+            cookie?: never;
+        };
+        /** List all deployments */
+        get: operations["listDeployments"];
+        put?: never;
+        post?: never;
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
     };
-    /** List all deployments */
-    get: operations["listDeployments"];
-    put?: never;
-    post?: never;
-    delete?: never;
-    options?: never;
-    head?: never;
-    patch?: never;
-    trace?: never;
-  };
-  "/v1/workspaces/{workspaceId}/environments": {
-    parameters: {
-      query?: never;
-      header?: never;
-      path: {
-        /** @description The ID of the workspace */
-        workspaceId: string;
-      };
-      cookie?: never;
+    "/v1/workspaces/{workspaceId}/environments": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path: {
+                /** @description The ID of the workspace */
+                workspaceId: string;
+            };
+            cookie?: never;
+        };
+        /** List all environments */
+        get: operations["listEnvironments"];
+        put?: never;
+        post?: never;
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
     };
-    /** List all environments */
-    get: operations["listEnvironments"];
-    put?: never;
-    post?: never;
-    delete?: never;
-    options?: never;
-    head?: never;
-    patch?: never;
-    trace?: never;
-  };
-  "/v1/workspaces/{workspaceId}": {
-    parameters: {
-      query?: never;
-      header?: never;
-      path?: never;
-      cookie?: never;
+    "/v1/workspaces/{workspaceId}": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        /** Get a workspace */
+        get: operations["getWorkspace"];
+        put?: never;
+        post?: never;
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
     };
-    /** Get a workspace */
-    get: operations["getWorkspace"];
-    put?: never;
-    post?: never;
-    delete?: never;
-    options?: never;
-    head?: never;
-    patch?: never;
-    trace?: never;
-  };
-  "/v1/workspaces/{workspaceId}/policies/{name}": {
-    parameters: {
-      query?: never;
-      header?: never;
-      path?: never;
-      cookie?: never;
+    "/v1/workspaces/{workspaceId}/policies/{name}": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        get?: never;
+        put?: never;
+        post?: never;
+        /** Delete a policy by name */
+        delete: operations["deletePolicyByName"];
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
     };
-    get?: never;
-    put?: never;
-    post?: never;
-    /** Delete a policy by name */
-    delete: operations["deletePolicyByName"];
-    options?: never;
-    head?: never;
-    patch?: never;
-    trace?: never;
-  };
-  "/v1/workspaces/{workspaceId}/resource-providers/name/{name}": {
-    parameters: {
-      query?: never;
-      header?: never;
-      path?: never;
-      cookie?: never;
+    "/v1/workspaces/{workspaceId}/resource-providers/name/{name}": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        /** Upserts a resource provider. */
+        get: operations["upsertResourceProvider"];
+        put?: never;
+        post?: never;
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
     };
-    /** Upserts a resource provider. */
-    get: operations["upsertResourceProvider"];
-    put?: never;
-    post?: never;
-    delete?: never;
-    options?: never;
-    head?: never;
-    patch?: never;
-    trace?: never;
-  };
-  "/v1/workspaces/{workspaceId}/resources/identifier/{identifier}": {
-    parameters: {
-      query?: never;
-      header?: never;
-      path?: never;
-      cookie?: never;
+    "/v1/workspaces/{workspaceId}/resources/identifier/{identifier}": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        /** Get a resource by identifier */
+        get: operations["getResourceByIdentifier"];
+        put?: never;
+        post?: never;
+        /** Delete a resource by identifier */
+        delete: operations["deleteResourceByIdentifier"];
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
     };
-    /** Get a resource by identifier */
-    get: operations["getResourceByIdentifier"];
-    put?: never;
-    post?: never;
-    /** Delete a resource by identifier */
-    delete: operations["deleteResourceByIdentifier"];
-    options?: never;
-    head?: never;
-    patch?: never;
-    trace?: never;
-  };
-  "/v1/workspaces/{workspaceId}/resources": {
-    parameters: {
-      query?: never;
-      header?: never;
-      path: {
-        /** @description The ID of the workspace */
-        workspaceId: string;
-      };
-      cookie?: never;
+    "/v1/workspaces/{workspaceId}/resources": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path: {
+                /** @description The ID of the workspace */
+                workspaceId: string;
+            };
+            cookie?: never;
+        };
+        /** List all resources */
+        get: operations["listResources"];
+        put?: never;
+        post?: never;
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
     };
-    /** List all resources */
-    get: operations["listResources"];
-    put?: never;
-    post?: never;
-    delete?: never;
-    options?: never;
-    head?: never;
-    patch?: never;
-    trace?: never;
-  };
-  "/v1/workspaces/{workspaceId}/systems": {
-    parameters: {
-      query?: never;
-      header?: never;
-      path: {
-        /** @description The ID of the workspace */
-        workspaceId: string;
-      };
-      cookie?: never;
+    "/v1/workspaces/{workspaceId}/systems": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path: {
+                /** @description The ID of the workspace */
+                workspaceId: string;
+            };
+            cookie?: never;
+        };
+        /** List all systems */
+        get: operations["listSystems"];
+        put?: never;
+        post?: never;
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
     };
-    /** List all systems */
-    get: operations["listSystems"];
-    put?: never;
-    post?: never;
-    delete?: never;
-    options?: never;
-    head?: never;
-    patch?: never;
-    trace?: never;
-  };
-  "/v1/workspaces/slug/{workspaceSlug}": {
-    parameters: {
-      query?: never;
-      header?: never;
-      path?: never;
-      cookie?: never;
+    "/v1/workspaces/slug/{workspaceSlug}": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        /** Get a workspace by slug */
+        get: operations["getWorkspaceBySlug"];
+        put?: never;
+        post?: never;
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
     };
-    /** Get a workspace by slug */
-    get: operations["getWorkspaceBySlug"];
-    put?: never;
-    post?: never;
-    delete?: never;
-    options?: never;
-    head?: never;
-    patch?: never;
-    trace?: never;
-  };
 }
 export type webhooks = Record<string, never>;
 export interface components {
-  schemas: {
-    CloudRegionGeoData: {
-      /**
-       * @description Timezone of the region in UTC format
-       * @example UTC+1
-       */
-      timezone: string;
-      /**
-       * Format: float
-       * @description Latitude coordinate for the region
-       * @example 50.1109
-       */
-      latitude: number;
-      /**
-       * Format: float
-       * @description Longitude coordinate for the region
-       * @example 8.6821
-       */
-      longitude: number;
-    };
-    JobWithTrigger: components["schemas"]["Job"] & {
-      release?: components["schemas"]["Release"];
-      deploymentVersion?: components["schemas"]["DeploymentVersion"];
-      deployment?: components["schemas"]["Deployment"];
-      runbook?: components["schemas"]["Runbook"];
-      resource?: components["schemas"]["Resource"];
-      environment?: components["schemas"]["Environment"];
-      variables: Record<string, never>;
-      approval?: {
-        id: string;
-        /** @enum {string} */
-        status: "pending" | "approved" | "rejected";
-        /** @description Null when status is pending, contains approver details when approved or rejected */
-        approver?: {
-          id: string;
-          name: string;
-        } | null;
-      } | null;
-    };
-    Workspace: {
-      /**
-       * Format: uuid
-       * @description The workspace ID
-       */
-      id: string;
-      /** @description The name of the workspace */
-      name: string;
-      /** @description The slug of the workspace */
-      slug: string;
-      /**
-       * @description The email of the Google service account attached to the workspace
-       * @example ctrlplane@ctrlplane-workspace.iam.gserviceaccount.com
-       */
-      googleServiceAccountEmail?: string | null;
-      /**
-       * @description The ARN of the AWS role attached to the workspace
-       * @example arn:aws:iam::123456789012:role/ctrlplane-workspace-role
-       */
-      awsRoleArn?: string | null;
-    };
-    System: {
-      /**
-       * Format: uuid
-       * @description The system ID
-       */
-      id: string;
-      /**
-       * Format: uuid
-       * @description The workspace ID of the system
-       */
-      workspaceId: string;
-      /** @description The name of the system */
-      name: string;
-      /** @description The slug of the system */
-      slug: string;
-      /** @description The description of the system */
-      description?: string;
-    };
-    Deployment: {
-      /** Format: uuid */
-      id: string;
-      name: string;
-      slug: string;
-      description: string;
-      /** Format: uuid */
-      systemId: string;
-      /** Format: uuid */
-      jobAgentId?: string | null;
-      jobAgentConfig: {
-        [key: string]: unknown;
-      };
-      retryCount?: number;
-      timeout?: number | null;
-    };
-    /** @description Schema for updating a deployment (all fields optional) */
-    UpdateDeployment: {
-      [key: string]: unknown;
-    } & (WithRequired<components["schemas"]["Deployment"], "id"> & {
-      [key: string]: unknown;
-    });
-    Release: {
-      /** Format: uuid */
-      id: string;
-      name: string;
-      version: string;
-      config: {
-        [key: string]: unknown;
-      };
-      jobAgentConfig: {
-        [key: string]: unknown;
-      };
-      /** Format: uuid */
-      deploymentId: string;
-      /** Format: date-time */
-      createdAt: string;
-      metadata?: {
-        [key: string]: unknown;
-      };
-    };
-    DeploymentVersion: {
-      /** Format: uuid */
-      id: string;
-      name: string;
-      tag: string;
-      config: {
-        [key: string]: unknown;
-      };
-      jobAgentConfig: {
-        [key: string]: unknown;
-      };
-      /** Format: uuid */
-      deploymentId: string;
-      /** Format: date-time */
-      createdAt: string;
-      metadata?: {
-        [key: string]: unknown;
-      };
-    };
-    Policy: {
-      /**
-       * Format: uuid
-       * @description The policy ID
-       */
-      id: string;
-      /**
-       * Format: uuid
-       * @description The system ID
-       */
-      systemId: string;
-      /** @description The name of the policy */
-      name: string;
-      /** @description The description of the policy */
-      description?: string | null;
-      /**
-       * @description The approval requirement of the policy
-       * @enum {string}
-       */
-      approvalRequirement: "manual" | "automatic";
-      /**
-       * @description If a policy depends on an environment, whether or not the policy requires all, some, or optional successful releases in the environment
-       * @enum {string}
-       */
-      successType: "some" | "all" | "optional";
-      /** @description If a policy depends on an environment, the minimum number of successful releases in the environment */
-      successMinimum: number;
-      /** @description The maximum number of concurrent releases in the environment */
-      concurrencyLimit?: number | null;
-      /** @description The duration of the rollout in milliseconds */
-      rolloutDuration: number;
-      /** @description The minimum interval between releases in milliseconds */
-      minimumReleaseInterval: number;
-      /**
-       * @description If a new release is created, whether it will wait for the current release to finish before starting, or cancel the current release
-       * @enum {string}
-       */
-      releaseSequencing: "wait" | "cancel";
-    };
-    Environment: {
-      /** Format: uuid */
-      id: string;
-      /** Format: uuid */
-      systemId: string;
-      name: string;
-      description?: string;
-      /** Format: uuid */
-      policyId?: string | null;
-      resourceSelector?: {
-        [key: string]: unknown;
-      } | null;
-      /**
-       * @description The directory path of the environment
-       * @default
-       * @example my/env/path
-       */
-      directory: string;
-      /** Format: date-time */
-      createdAt: string;
-      metadata?: {
-        [key: string]: string;
-      };
-      policy?: components["schemas"]["Policy"];
-    };
-    Runbook: {
-      /** Format: uuid */
-      id: string;
-      name: string;
-      /** Format: uuid */
-      systemId: string;
-      /** Format: uuid */
-      jobAgentId: string;
-    };
-    Resource: {
-      /** Format: uuid */
-      id: string;
-      name: string;
-      version: string;
-      kind: string;
-      identifier: string;
-      config: {
-        [key: string]: unknown;
-      };
-      metadata: {
-        [key: string]: unknown;
-      };
-      /** Format: date-time */
-      createdAt: string;
-      /** Format: date-time */
-      updatedAt: string;
-      /** Format: uuid */
-      workspaceId: string;
-    };
-    /** @enum {string} */
-    JobStatus:
-      | "successful"
-      | "cancelled"
-      | "skipped"
-      | "in_progress"
-      | "action_required"
-      | "pending"
-      | "failure"
-      | "invalid_job_agent"
-      | "invalid_integration"
-      | "external_run_not_found";
-    Job: {
-      /** Format: uuid */
-      id: string;
-      status: components["schemas"]["JobStatus"];
-      /** @description External job identifier (e.g. GitHub workflow run ID) */
-      externalId?: string | null;
-      /** Format: date-time */
-      createdAt: string;
-      /** Format: date-time */
-      updatedAt: string;
-      /** Format: date-time */
-      startedAt?: string | null;
-      /** Format: date-time */
-      completedAt?: string | null;
-      /** Format: uuid */
-      jobAgentId?: string;
-      /** @description Configuration for the Job Agent */
-      jobAgentConfig: {
-        [key: string]: unknown;
-      };
-      message?: string;
-      reason?: string;
-    };
-    Variable: {
-      key: string;
-      value: string | number | boolean;
-      sensitive?: boolean;
-    };
-    PolicyTarget: {
-      deploymentSelector?: {
-        [key: string]: unknown;
-      } | null;
-      environmentSelector?: {
-        [key: string]: unknown;
-      } | null;
-      resourceSelector?: {
-        [key: string]: unknown;
-      } | null;
-    };
-    DenyWindow: {
-      timeZone: string;
-      rrule: {
-        [key: string]: unknown;
-      };
-      /** Format: date-time */
-      dtend?: string;
-    };
-    DeploymentVersionSelector: {
-      name: string;
-      deploymentVersionSelector: {
-        [key: string]: unknown;
-      };
-      description?: string;
-    };
-    VersionAnyApproval: {
-      requiredApprovalsCount: number;
-    };
-    VersionUserApproval: {
-      userId: string;
-    };
-    VersionRoleApproval: {
-      roleId: string;
-      requiredApprovalsCount: number;
-    };
-    Policy1: {
-      /** Format: uuid */
-      id: string;
-      name: string;
-      description?: string;
-      priority: number;
-      /** Format: date-time */
-      createdAt: string;
-      enabled: boolean;
-      /** Format: uuid */
-      workspaceId: string;
-      targets: components["schemas"]["PolicyTarget"][];
-      denyWindows: components["schemas"]["DenyWindow"][];
-      deploymentVersionSelector?: components["schemas"]["DeploymentVersionSelector"];
-      versionAnyApprovals?: components["schemas"]["VersionAnyApproval"][];
-      versionUserApprovals: components["schemas"]["VersionUserApproval"][];
-      versionRoleApprovals: components["schemas"]["VersionRoleApproval"][];
-    };
-  };
-  responses: never;
-  parameters: never;
-  requestBodies: never;
-  headers: never;
-  pathItems: never;
-}
-export type $defs = Record<string, never>;
-export interface operations {
-  getCloudProviderRegions: {
-    parameters: {
-      query?: never;
-      header?: never;
-      path: {
-        /** @description Cloud provider (aws, gcp, azure) */
-        provider: "aws" | "gcp" | "azure";
-      };
-      cookie?: never;
-    };
-    requestBody?: never;
-    responses: {
-      /** @description Successfully returned geographic data for cloud provider regions */
-      200: {
-        headers: {
-          [name: string]: unknown;
+    schemas: {
+        CloudRegionGeoData: {
+            /**
+             * @description Timezone of the region in UTC format
+             * @example UTC+1
+             */
+            timezone: string;
+            /**
+             * Format: float
+             * @description Latitude coordinate for the region
+             * @example 50.1109
+             */
+            latitude: number;
+            /**
+             * Format: float
+             * @description Longitude coordinate for the region
+             * @example 8.6821
+             */
+            longitude: number;
         };
-        content: {
-          "application/json": {
-            [key: string]: components["schemas"]["CloudRegionGeoData"];
-          };
+        JobWithTrigger: components["schemas"]["Job"] & {
+            release?: components["schemas"]["Release"];
+            deploymentVersion?: components["schemas"]["DeploymentVersion"];
+            deployment?: components["schemas"]["Deployment"];
+            runbook?: components["schemas"]["Runbook"];
+            resource?: components["schemas"]["Resource"];
+            environment?: components["schemas"]["Environment"];
+            variables: Record<string, never>;
+            approval?: {
+                id: string;
+                /** @enum {string} */
+                status: "pending" | "approved" | "rejected";
+                /** @description Null when status is pending, contains approver details when approved or rejected */
+                approver?: {
+                    id: string;
+                    name: string;
+                } | null;
+            } | null;
         };
-      };
-      /** @description Cloud provider not found */
-      404: {
-        headers: {
-          [name: string]: unknown;
-        };
-        content: {
-          "application/json": {
-            /** @example Cloud provider 'unknown' not found */
-            error?: string;
-          };
-        };
-      };
-    };
-  };
-  createDeploymentVersionChannel: {
-    parameters: {
-      query?: never;
-      header?: never;
-      path?: never;
-      cookie?: never;
-    };
-    requestBody: {
-      content: {
-        "application/json": {
-          deploymentId: string;
-          name: string;
-          description?: string | null;
-          versionSelector: {
-            [key: string]: unknown;
-          };
-        };
-      };
-    };
-    responses: {
-      /** @description Deployment version channel created successfully */
-      200: {
-        headers: {
-          [name: string]: unknown;
-        };
-        content: {
-          "application/json": {
+        Workspace: {
+            /**
+             * Format: uuid
+             * @description The workspace ID
+             */
             id: string;
-            deploymentId: string;
+            /** @description The name of the workspace */
             name: string;
-            description?: string | null;
-            /** Format: date-time */
-            createdAt: string;
-            versionSelector?: {
-              [key: string]: unknown;
-            };
-          };
+            /** @description The slug of the workspace */
+            slug: string;
+            /**
+             * @description The email of the Google service account attached to the workspace
+             * @example ctrlplane@ctrlplane-workspace.iam.gserviceaccount.com
+             */
+            googleServiceAccountEmail?: string | null;
+            /**
+             * @description The ARN of the AWS role attached to the workspace
+             * @example arn:aws:iam::123456789012:role/ctrlplane-workspace-role
+             */
+            awsRoleArn?: string | null;
         };
-      };
-      /** @description Unauthorized */
-      401: {
-        headers: {
-          [name: string]: unknown;
-        };
-        content: {
-          "application/json": {
-            error: string;
-          };
-        };
-      };
-      /** @description Forbidden */
-      403: {
-        headers: {
-          [name: string]: unknown;
-        };
-        content: {
-          "application/json": {
-            error: string;
-          };
-        };
-      };
-      /** @description Deployment version channel already exists */
-      409: {
-        headers: {
-          [name: string]: unknown;
-        };
-        content: {
-          "application/json": {
-            error: string;
+        System: {
+            /**
+             * Format: uuid
+             * @description The system ID
+             */
             id: string;
-          };
+            /**
+             * Format: uuid
+             * @description The workspace ID of the system
+             */
+            workspaceId: string;
+            /** @description The name of the system */
+            name: string;
+            /** @description The slug of the system */
+            slug: string;
+            /** @description The description of the system */
+            description?: string;
         };
-      };
-      /** @description Failed to create deployment version channel */
-      500: {
-        headers: {
-          [name: string]: unknown;
-        };
-        content: {
-          "application/json": {
-            error: string;
-          };
-        };
-      };
-    };
-  };
-  updateDeploymentVersion: {
-    parameters: {
-      query?: never;
-      header?: never;
-      path: {
-        /** @description The deployment version ID */
-        deploymentVersionId: string;
-      };
-      cookie?: never;
-    };
-    requestBody: {
-      content: {
-        "application/json": {
-          tag?: string;
-          deploymentId?: string;
-          /** Format: date-time */
-          createdAt?: string;
-          name?: string;
-          config?: {
-            [key: string]: unknown;
-          };
-          jobAgentConfig?: {
-            [key: string]: unknown;
-          };
-          /** @enum {string} */
-          status?: "ready" | "building" | "failed";
-          message?: string;
-          metadata?: {
-            [key: string]: string;
-          };
-        };
-      };
-    };
-    responses: {
-      /** @description OK */
-      200: {
-        headers: {
-          [name: string]: unknown;
-        };
-        content: {
-          "application/json": components["schemas"]["DeploymentVersion"];
-        };
-      };
-    };
-  };
-  upsertDeploymentVersion: {
-    parameters: {
-      query?: never;
-      header?: never;
-      path?: never;
-      cookie?: never;
-    };
-    requestBody: {
-      content: {
-        "application/json": {
-          tag: string;
-          deploymentId: string;
-          /** Format: date-time */
-          createdAt?: string;
-          name?: string;
-          config?: {
-            [key: string]: unknown;
-          };
-          jobAgentConfig?: {
-            [key: string]: unknown;
-          };
-          /** @enum {string} */
-          status?: "ready" | "building" | "failed";
-          message?: string;
-          metadata?: {
-            [key: string]: string;
-          };
-        };
-      };
-    };
-    responses: {
-      /** @description OK */
-      200: {
-        headers: {
-          [name: string]: unknown;
-        };
-        content: {
-          "application/json": components["schemas"]["DeploymentVersion"];
-        };
-      };
-      /** @description Deployment version already exists */
-      409: {
-        headers: {
-          [name: string]: unknown;
-        };
-        content: {
-          "application/json": {
-            error?: string;
-            id?: string;
-          };
-        };
-      };
-    };
-  };
-  deleteDeploymentVersionChannel: {
-    parameters: {
-      query?: never;
-      header?: never;
-      path: {
-        deploymentId: string;
-        name: string;
-      };
-      cookie?: never;
-    };
-    requestBody?: never;
-    responses: {
-      /** @description Deployment version channel deleted */
-      200: {
-        headers: {
-          [name: string]: unknown;
-        };
-        content: {
-          "application/json": {
-            message: string;
-          };
-        };
-      };
-      /** @description Permission denied */
-      403: {
-        headers: {
-          [name: string]: unknown;
-        };
-        content: {
-          "application/json": {
-            error: string;
-          };
-        };
-      };
-      /** @description Deployment version channel not found */
-      404: {
-        headers: {
-          [name: string]: unknown;
-        };
-        content: {
-          "application/json": {
-            error: string;
-          };
-        };
-      };
-      /** @description Failed to delete deployment version channel */
-      500: {
-        headers: {
-          [name: string]: unknown;
-        };
-        content: {
-          "application/json": {
-            error: string;
-          };
-        };
-      };
-    };
-  };
-  getDeployment: {
-    parameters: {
-      query?: never;
-      header?: never;
-      path: {
-        deploymentId: string;
-      };
-      cookie?: never;
-    };
-    requestBody?: never;
-    responses: {
-      /** @description Deployment found */
-      200: {
-        headers: {
-          [name: string]: unknown;
-        };
-        content: {
-          "application/json": components["schemas"]["Deployment"];
-        };
-      };
-      /** @description Deployment not found */
-      404: {
-        headers: {
-          [name: string]: unknown;
-        };
-        content: {
-          "application/json": {
-            error: string;
-          };
-        };
-      };
-    };
-  };
-  deleteDeployment: {
-    parameters: {
-      query?: never;
-      header?: never;
-      path: {
-        deploymentId: string;
-      };
-      cookie?: never;
-    };
-    requestBody?: never;
-    responses: {
-      /** @description Deployment deleted */
-      200: {
-        headers: {
-          [name: string]: unknown;
-        };
-        content: {
-          "application/json": components["schemas"]["Deployment"];
-        };
-      };
-      /** @description Deployment not found */
-      404: {
-        headers: {
-          [name: string]: unknown;
-        };
-        content: {
-          "application/json": {
-            error: string;
-          };
-        };
-      };
-      /** @description Failed to delete deployment */
-      500: {
-        headers: {
-          [name: string]: unknown;
-        };
-        content: {
-          "application/json": {
-            error: string;
-          };
-        };
-      };
-    };
-  };
-  updateDeployment: {
-    parameters: {
-      query?: never;
-      header?: never;
-      path: {
-        deploymentId: string;
-      };
-      cookie?: never;
-    };
-    requestBody: {
-      content: {
-        "application/json": components["schemas"]["UpdateDeployment"];
-      };
-    };
-    responses: {
-      /** @description Deployment updated */
-      200: {
-        headers: {
-          [name: string]: unknown;
-        };
-        content: {
-          "application/json": components["schemas"]["Deployment"];
-        };
-      };
-      /** @description Deployment not found */
-      404: {
-        headers: {
-          [name: string]: unknown;
-        };
-        content: {
-          "application/json": {
-            error: string;
-          };
-        };
-      };
-      /** @description Failed to update deployment */
-      500: {
-        headers: {
-          [name: string]: unknown;
-        };
-        content: {
-          "application/json": {
-            error: string;
-          };
-        };
-      };
-    };
-  };
-  deleteReleaseChannel: {
-    parameters: {
-      query?: never;
-      header?: never;
-      path: {
-        deploymentId: string;
-        name: string;
-      };
-      cookie?: never;
-    };
-    requestBody?: never;
-    responses: {
-      /** @description Release channel deleted */
-      200: {
-        headers: {
-          [name: string]: unknown;
-        };
-        content: {
-          "application/json": {
-            message: string;
-          };
-        };
-      };
-      /** @description Permission denied */
-      403: {
-        headers: {
-          [name: string]: unknown;
-        };
-        content: {
-          "application/json": {
-            error: string;
-          };
-        };
-      };
-      /** @description Release channel not found */
-      404: {
-        headers: {
-          [name: string]: unknown;
-        };
-        content: {
-          "application/json": {
-            error: string;
-          };
-        };
-      };
-      /** @description Failed to delete release channel */
-      500: {
-        headers: {
-          [name: string]: unknown;
-        };
-        content: {
-          "application/json": {
-            error: string;
-          };
-        };
-      };
-    };
-  };
-  getResourcesForDeployment: {
-    parameters: {
-      query?: never;
-      header?: never;
-      path: {
-        /** @description UUID of the deployment */
-        deploymentId: string;
-      };
-      cookie?: never;
-    };
-    requestBody?: never;
-    responses: {
-      /** @description OK */
-      200: {
-        headers: {
-          [name: string]: unknown;
-        };
-        content: {
-          "application/json": {
-            resources?: {
-              id?: string;
-              name?: string;
-              identifier?: string;
-              kind?: string;
-              version?: string;
-            }[];
-            count?: number;
-          };
-        };
-      };
-      /** @description Internal Server Error */
-      500: {
-        headers: {
-          [name: string]: unknown;
-        };
-        content: {
-          "application/json": {
-            error?: string;
-          };
-        };
-      };
-    };
-  };
-  createDeployment: {
-    parameters: {
-      query?: never;
-      header?: never;
-      path?: never;
-      cookie?: never;
-    };
-    requestBody?: {
-      content: {
-        "application/json": {
-          /**
-           * Format: uuid
-           * @description The ID of the system to create the deployment for
-           * @example 123e4567-e89b-12d3-a456-426614174000
-           */
-          systemId: string;
-          /**
-           * @description The name of the deployment
-           * @example My Deployment
-           */
-          name: string;
-          /**
-           * @description The slug of the deployment
-           * @example my-deployment
-           */
-          slug: string;
-          /**
-           * @description The description of the deployment
-           * @example This is a deployment for my system
-           */
-          description?: string;
-          /**
-           * Format: uuid
-           * @description The ID of the job agent to use for the deployment
-           * @example 123e4567-e89b-12d3-a456-426614174000
-           */
-          jobAgentId?: string;
-          /**
-           * @description The configuration for the job agent
-           * @example {
-           *       "key": "value"
-           *     }
-           */
-          jobAgentConfig?: Record<string, never>;
-          /**
-           * @description The number of times to retry the deployment
-           * @example 3
-           */
-          retryCount?: number;
-          /**
-           * @description The timeout for the deployment
-           * @example 60
-           */
-          timeout?: number;
-          /**
-           * @description The resource selector for the deployment
-           * @example {
-           *       "key": "value"
-           *     }
-           */
-          resourceSelector?: Record<string, never>;
-        };
-      };
-    };
-    responses: {
-      /** @description Deployment created */
-      201: {
-        headers: {
-          [name: string]: unknown;
-        };
-        content: {
-          "application/json": components["schemas"]["Deployment"];
-        };
-      };
-      /** @description Deployment already exists */
-      409: {
-        headers: {
-          [name: string]: unknown;
-        };
-        content: {
-          "application/json": {
-            error: string;
+        Deployment: {
             /** Format: uuid */
             id: string;
-          };
+            name: string;
+            slug: string;
+            description: string;
+            /** Format: uuid */
+            systemId: string;
+            /** Format: uuid */
+            jobAgentId?: string | null;
+            jobAgentConfig: {
+                [key: string]: unknown;
+            };
+            retryCount?: number;
+            timeout?: number | null;
         };
-      };
-      /** @description Failed to create deployment */
-      500: {
-        headers: {
-          [name: string]: unknown;
-        };
-        content: {
-          "application/json": {
-            error: string;
-          };
-        };
-      };
-    };
-  };
-  getEnvironment: {
-    parameters: {
-      query?: never;
-      header?: never;
-      path: {
-        /** @description UUID of the environment */
-        environmentId: string;
-      };
-      cookie?: never;
-    };
-    requestBody?: never;
-    responses: {
-      /** @description Successful response */
-      200: {
-        headers: {
-          [name: string]: unknown;
-        };
-        content: {
-          "application/json": components["schemas"]["Environment"];
-        };
-      };
-      /** @description Environment not found */
-      404: {
-        headers: {
-          [name: string]: unknown;
-        };
-        content: {
-          "application/json": {
-            /** @example Environment not found */
-            error: string;
-          };
-        };
-      };
-    };
-  };
-  deleteEnvironment: {
-    parameters: {
-      query?: never;
-      header?: never;
-      path: {
-        /** @description UUID of the environment */
-        environmentId: string;
-      };
-      cookie?: never;
-    };
-    requestBody?: never;
-    responses: {
-      /** @description Environment deleted successfully */
-      200: {
-        headers: {
-          [name: string]: unknown;
-        };
-        content?: never;
-      };
-    };
-  };
-  getResourcesForEnvironment: {
-    parameters: {
-      query?: never;
-      header?: never;
-      path: {
-        /** @description UUID of the environment */
-        environmentId: string;
-      };
-      cookie?: never;
-    };
-    requestBody?: never;
-    responses: {
-      /** @description OK */
-      200: {
-        headers: {
-          [name: string]: unknown;
-        };
-        content: {
-          "application/json": {
-            resources?: {
-              id?: string;
-              name?: string;
-              identifier?: string;
-              kind?: string;
-              version?: string;
-            }[];
-            count?: number;
-          };
-        };
-      };
-      /** @description Internal Server Error */
-      500: {
-        headers: {
-          [name: string]: unknown;
-        };
-        content: {
-          "application/json": {
-            error?: string;
-          };
-        };
-      };
-    };
-  };
-  createEnvironment: {
-    parameters: {
-      query?: never;
-      header?: never;
-      path?: never;
-      cookie?: never;
-    };
-    requestBody: {
-      content: {
-        "application/json": {
-          /**
-           * @description The directory path of the environment
-           * @default
-           * @example my/env/path
-           */
-          directory?: string;
-          systemId: string;
-          name: string;
-          description?: string;
-          resourceSelector?: {
+        /** @description Schema for updating a deployment (all fields optional) */
+        UpdateDeployment: {
             [key: string]: unknown;
-          };
-          policyId?: string;
-          releaseChannels?: string[];
-          deploymentVersionChannels?: string[];
-          metadata?: {
-            [key: string]: string;
-          };
-        };
-      };
-    };
-    responses: {
-      /** @description Environment created successfully */
-      200: {
-        headers: {
-          [name: string]: unknown;
-        };
-        content: {
-          "application/json": components["schemas"]["Environment"];
-        };
-      };
-      /** @description Environment already exists */
-      409: {
-        headers: {
-          [name: string]: unknown;
-        };
-        content: {
-          "application/json": {
-            error?: string;
-            id?: string;
-          };
-        };
-      };
-      /** @description Failed to create environment */
-      500: {
-        headers: {
-          [name: string]: unknown;
-        };
-        content: {
-          "application/json": {
-            error: string;
-          };
-        };
-      };
-    };
-  };
-  getAgentRunningJobs: {
-    parameters: {
-      query?: never;
-      header?: never;
-      path: {
-        /** @description The execution ID */
-        agentId: string;
-      };
-      cookie?: never;
-    };
-    requestBody?: never;
-    responses: {
-      /** @description OK */
-      200: {
-        headers: {
-          [name: string]: unknown;
-        };
-        content: {
-          "application/json": components["schemas"]["Job"][];
-        };
-      };
-    };
-  };
-  acknowledgeAgentJob: {
-    parameters: {
-      query?: never;
-      header?: never;
-      path: {
-        /** @description The ID of the job agent */
-        agentId: string;
-      };
-      cookie?: never;
-    };
-    requestBody?: never;
-    responses: {
-      /** @description Successfully acknowledged job */
-      200: {
-        headers: {
-          [name: string]: unknown;
-        };
-        content: {
-          "application/json": {
-            job?: components["schemas"]["Job"];
-          };
-        };
-      };
-      /** @description Unauthorized */
-      401: {
-        headers: {
-          [name: string]: unknown;
-        };
-        content: {
-          "application/json": {
-            error?: string;
-          };
-        };
-      };
-      /** @description Workspace not found */
-      404: {
-        headers: {
-          [name: string]: unknown;
-        };
-        content: {
-          "application/json": {
-            error?: string;
-          };
-        };
-      };
-    };
-  };
-  getNextJobs: {
-    parameters: {
-      query?: never;
-      header?: never;
-      path: {
-        /** @description The agent ID */
-        agentId: string;
-      };
-      cookie?: never;
-    };
-    requestBody?: never;
-    responses: {
-      /** @description OK */
-      200: {
-        headers: {
-          [name: string]: unknown;
-        };
-        content: {
-          "application/json": {
-            jobs?: components["schemas"]["Job"][];
-          };
-        };
-      };
-    };
-  };
-  upsertJobAgent: {
-    parameters: {
-      query?: never;
-      header?: never;
-      path?: never;
-      cookie?: never;
-    };
-    requestBody: {
-      content: {
-        "application/json": {
-          workspaceId: string;
-          name: string;
-          type: string;
-        };
-      };
-    };
-    responses: {
-      /** @description Successfully retrieved or created the agent */
-      200: {
-        headers: {
-          [name: string]: unknown;
-        };
-        content: {
-          "application/json": {
+        } & (WithRequired<components["schemas"]["Deployment"], "id"> & {
+            [key: string]: unknown;
+        });
+        Release: {
+            /** Format: uuid */
             id: string;
             name: string;
-            workspaceId: string;
-          };
+            version: string;
+            config: {
+                [key: string]: unknown;
+            };
+            jobAgentConfig: {
+                [key: string]: unknown;
+            };
+            /** Format: uuid */
+            deploymentId: string;
+            /** Format: date-time */
+            createdAt: string;
+            metadata?: {
+                [key: string]: unknown;
+            };
         };
-      };
-      /** @description Internal server error */
-      500: {
-        headers: {
-          [name: string]: unknown;
-        };
-        content?: never;
-      };
-    };
-  };
-  acknowledgeJob: {
-    parameters: {
-      query?: never;
-      header?: never;
-      path: {
-        /** @description The job ID */
-        jobId: string;
-      };
-      cookie?: never;
-    };
-    requestBody?: never;
-    responses: {
-      /** @description OK */
-      200: {
-        headers: {
-          [name: string]: unknown;
-        };
-        content: {
-          "application/json": {
-            sucess: boolean;
-          };
-        };
-      };
-      /** @description Unauthorized */
-      401: {
-        headers: {
-          [name: string]: unknown;
-        };
-        content: {
-          "application/json": {
-            error: string;
-          };
-        };
-      };
-    };
-  };
-  getJob: {
-    parameters: {
-      query?: never;
-      header?: never;
-      path: {
-        /** @description The job ID */
-        jobId: string;
-      };
-      cookie?: never;
-    };
-    requestBody?: never;
-    responses: {
-      /** @description OK */
-      200: {
-        headers: {
-          [name: string]: unknown;
-        };
-        content: {
-          "application/json": components["schemas"]["JobWithTrigger"];
-        };
-      };
-      /** @description Not Found */
-      404: {
-        headers: {
-          [name: string]: unknown;
-        };
-        content: {
-          "application/json": {
-            /** @example Job not found. */
-            error?: string;
-          };
-        };
-      };
-    };
-  };
-  updateJob: {
-    parameters: {
-      query?: never;
-      header?: never;
-      path: {
-        /** @description The execution ID */
-        jobId: string;
-      };
-      cookie?: never;
-    };
-    requestBody: {
-      content: {
-        "application/json": {
-          status?: components["schemas"]["JobStatus"];
-          message?: string | null;
-          externalId?: string | null;
-        };
-      };
-    };
-    responses: {
-      /** @description OK */
-      200: {
-        headers: {
-          [name: string]: unknown;
-        };
-        content: {
-          "application/json": {
+        DeploymentVersion: {
+            /** Format: uuid */
             id: string;
-          };
+            name: string;
+            tag: string;
+            config: {
+                [key: string]: unknown;
+            };
+            jobAgentConfig: {
+                [key: string]: unknown;
+            };
+            /** Format: uuid */
+            deploymentId: string;
+            /** Format: date-time */
+            createdAt: string;
+            metadata?: {
+                [key: string]: unknown;
+            };
         };
-      };
-    };
-  };
-  deletePolicy: {
-    parameters: {
-      query?: never;
-      header?: never;
-      path: {
-        policyId: string;
-      };
-      cookie?: never;
-    };
-    requestBody?: never;
-    responses: {
-      /** @description OK */
-      200: {
-        headers: {
-          [name: string]: unknown;
+        Policy: {
+            /**
+             * Format: uuid
+             * @description The policy ID
+             */
+            id: string;
+            /**
+             * Format: uuid
+             * @description The system ID
+             */
+            systemId: string;
+            /** @description The name of the policy */
+            name: string;
+            /** @description The description of the policy */
+            description?: string | null;
+            /**
+             * @description The approval requirement of the policy
+             * @enum {string}
+             */
+            approvalRequirement: "manual" | "automatic";
+            /**
+             * @description If a policy depends on an environment, whether or not the policy requires all, some, or optional successful releases in the environment
+             * @enum {string}
+             */
+            successType: "some" | "all" | "optional";
+            /** @description If a policy depends on an environment, the minimum number of successful releases in the environment */
+            successMinimum: number;
+            /** @description The maximum number of concurrent releases in the environment */
+            concurrencyLimit?: number | null;
+            /** @description The duration of the rollout in milliseconds */
+            rolloutDuration: number;
+            /** @description The minimum interval between releases in milliseconds */
+            minimumReleaseInterval: number;
+            /**
+             * @description If a new release is created, whether it will wait for the current release to finish before starting, or cancel the current release
+             * @enum {string}
+             */
+            releaseSequencing: "wait" | "cancel";
         };
-        content: {
-          "application/json": {
-            count?: number;
-          };
+        Environment: {
+            /** Format: uuid */
+            id: string;
+            /** Format: uuid */
+            systemId: string;
+            name: string;
+            description?: string;
+            /** Format: uuid */
+            policyId?: string | null;
+            resourceSelector?: {
+                [key: string]: unknown;
+            } | null;
+            /**
+             * @description The directory path of the environment
+             * @default
+             * @example my/env/path
+             */
+            directory: string;
+            /** Format: date-time */
+            createdAt: string;
+            metadata?: {
+                [key: string]: string;
+            };
+            policy?: components["schemas"]["Policy"];
         };
-      };
-      /** @description Internal Server Error */
-      500: {
-        headers: {
-          [name: string]: unknown;
+        Runbook: {
+            /** Format: uuid */
+            id: string;
+            name: string;
+            /** Format: uuid */
+            systemId: string;
+            /** Format: uuid */
+            jobAgentId: string;
         };
-        content?: never;
-      };
-    };
-  };
-  getReleaseTargetsForPolicy: {
-    parameters: {
-      query?: never;
-      header?: never;
-      path: {
-        /** @description UUID of the policy */
-        policyId: string;
-      };
-      cookie?: never;
-    };
-    requestBody?: never;
-    responses: {
-      /** @description OK */
-      200: {
-        headers: {
-          [name: string]: unknown;
+        Resource: {
+            /** Format: uuid */
+            id: string;
+            name: string;
+            version: string;
+            kind: string;
+            identifier: string;
+            config: {
+                [key: string]: unknown;
+            };
+            metadata: {
+                [key: string]: unknown;
+            };
+            /** Format: date-time */
+            createdAt: string;
+            /** Format: date-time */
+            updatedAt: string;
+            /** Format: uuid */
+            workspaceId: string;
         };
-        content: {
-          "application/json": {
-            releaseTargets?: {
-              id?: string;
-              name?: string;
-              description?: string;
-              policyTarget?: {
-                id?: string;
-                name?: string;
-                policyId?: string;
-                description?: string;
-              };
-              resource?: {
-                id?: string;
-                name?: string;
-                identifier?: string;
-                kind?: string;
-                version?: string;
-              };
-              environment?: {
-                id?: string;
-                name?: string;
-              };
-            }[];
-            count?: number;
-          };
+        /** @enum {string} */
+        JobStatus: "successful" | "cancelled" | "skipped" | "in_progress" | "action_required" | "pending" | "failure" | "invalid_job_agent" | "invalid_integration" | "external_run_not_found";
+        Job: {
+            /** Format: uuid */
+            id: string;
+            status: components["schemas"]["JobStatus"];
+            /** @description External job identifier (e.g. GitHub workflow run ID) */
+            externalId?: string | null;
+            /** Format: date-time */
+            createdAt: string;
+            /** Format: date-time */
+            updatedAt: string;
+            /** Format: date-time */
+            startedAt?: string | null;
+            /** Format: date-time */
+            completedAt?: string | null;
+            /** Format: uuid */
+            jobAgentId?: string;
+            /** @description Configuration for the Job Agent */
+            jobAgentConfig: {
+                [key: string]: unknown;
+            };
+            message?: string;
+            reason?: string;
         };
-      };
-      /** @description Internal Server Error */
-      500: {
-        headers: {
-          [name: string]: unknown;
+        Variable: {
+            key: string;
+            value: string | number | boolean;
+            sensitive?: boolean;
         };
-        content: {
-          "application/json": {
-            error?: string;
-          };
+        PolicyTarget: {
+            deploymentSelector?: {
+                [key: string]: unknown;
+            } | null;
+            environmentSelector?: {
+                [key: string]: unknown;
+            } | null;
+            resourceSelector?: {
+                [key: string]: unknown;
+            } | null;
         };
-      };
-    };
-  };
-  upsertPolicy: {
-    parameters: {
-      query?: never;
-      header?: never;
-      path?: never;
-      cookie?: never;
-    };
-    requestBody: {
-      content: {
-        "application/json": {
-          name: string;
-          description?: string;
-          priority?: number;
-          enabled?: boolean;
-          workspaceId: string;
-          targets: components["schemas"]["PolicyTarget"][];
-          denyWindows?: {
+        DenyWindow: {
             timeZone: string;
-            rrule?: {
-              [key: string]: unknown;
+            rrule: {
+                [key: string]: unknown;
             };
             /** Format: date-time */
             dtend?: string;
-          }[];
-          deploymentVersionSelector?: components["schemas"]["DeploymentVersionSelector"];
-          versionAnyApprovals?: {
-            requiredApprovalsCount?: number;
-          }[];
-          versionUserApprovals?: components["schemas"]["VersionUserApproval"][];
-          versionRoleApprovals?: {
-            roleId: string;
-            requiredApprovalsCount?: number;
-          }[];
         };
-      };
-    };
-    responses: {
-      /** @description OK */
-      200: {
-        headers: {
-          [name: string]: unknown;
-        };
-        content: {
-          "application/json": components["schemas"]["Policy1"];
-        };
-      };
-      /** @description Internal Server Error */
-      500: {
-        headers: {
-          [name: string]: unknown;
-        };
-        content: {
-          "application/json": {
-            error?: string;
-          };
-        };
-      };
-    };
-  };
-  createJobToResourceRelationship: {
-    parameters: {
-      query?: never;
-      header?: never;
-      path?: never;
-      cookie?: never;
-    };
-    requestBody: {
-      content: {
-        "application/json": {
-          /**
-           * Format: uuid
-           * @description Unique identifier of the job
-           * @example 123e4567-e89b-12d3-a456-426614174000
-           */
-          jobId: string;
-          /**
-           * @description Unique identifier of the resource
-           * @example resource-123
-           */
-          resourceIdentifier: string;
-        };
-      };
-    };
-    responses: {
-      /** @description Relationship created successfully */
-      200: {
-        headers: {
-          [name: string]: unknown;
-        };
-        content: {
-          "application/json": {
-            /** @example Relationship created successfully */
-            message?: string;
-          };
-        };
-      };
-      /** @description Invalid request body */
-      400: {
-        headers: {
-          [name: string]: unknown;
-        };
-        content: {
-          "application/json": {
-            /** @example Invalid jobId format */
-            error?: string;
-          };
-        };
-      };
-      /** @description Job or resource not found */
-      404: {
-        headers: {
-          [name: string]: unknown;
-        };
-        content: {
-          "application/json": {
-            /** @example Job with specified ID not found */
-            error?: string;
-          };
-        };
-      };
-      /** @description Relationship already exists */
-      409: {
-        headers: {
-          [name: string]: unknown;
-        };
-        content: {
-          "application/json": {
-            /** @example Relationship between job and resource already exists */
-            error?: string;
-          };
-        };
-      };
-      /** @description Internal server error */
-      500: {
-        headers: {
-          [name: string]: unknown;
-        };
-        content: {
-          "application/json": {
-            /** @example Internal server error occurred */
-            error?: string;
-          };
-        };
-      };
-    };
-  };
-  createResourceToResourceRelationship: {
-    parameters: {
-      query?: never;
-      header?: never;
-      path?: never;
-      cookie?: never;
-    };
-    requestBody: {
-      content: {
-        "application/json": {
-          /**
-           * Format: uuid
-           * @description The workspace ID
-           * @example 123e4567-e89b-12d3-a456-426614174000
-           */
-          workspaceId: string;
-          /**
-           * @description The identifier of the resource to connect
-           * @example my-resource
-           */
-          fromIdentifier: string;
-          /**
-           * @description The identifier of the resource to connect to
-           * @example my-resource
-           */
-          toIdentifier: string;
-          /**
-           * @description The type of relationship
-           * @example depends_on
-           */
-          type: string;
-        };
-      };
-    };
-    responses: {
-      /** @description Relationship created */
-      200: {
-        headers: {
-          [name: string]: unknown;
-        };
-        content: {
-          "application/json": {
-            /** @example Relationship created successfully */
-            message?: string;
-          };
-        };
-      };
-      /** @description Invalid request body */
-      400: {
-        headers: {
-          [name: string]: unknown;
-        };
-        content: {
-          "application/json": {
-            error?: string;
-          };
-        };
-      };
-      /** @description Resource not found */
-      404: {
-        headers: {
-          [name: string]: unknown;
-        };
-        content: {
-          "application/json": {
-            error?: string;
-          };
-        };
-      };
-      /** @description Relationship already exists */
-      409: {
-        headers: {
-          [name: string]: unknown;
-        };
-        content: {
-          "application/json": {
-            error?: string;
-          };
-        };
-      };
-      /** @description Internal server error */
-      500: {
-        headers: {
-          [name: string]: unknown;
-        };
-        content: {
-          "application/json": {
-            error?: string;
-          };
-        };
-      };
-    };
-  };
-  createReleaseChannel: {
-    parameters: {
-      query?: never;
-      header?: never;
-      path?: never;
-      cookie?: never;
-    };
-    requestBody: {
-      content: {
-        "application/json": {
-          deploymentId: string;
-          name: string;
-          description?: string | null;
-          releaseSelector: {
-            [key: string]: unknown;
-          };
-        };
-      };
-    };
-    responses: {
-      /** @description Release channel created successfully */
-      200: {
-        headers: {
-          [name: string]: unknown;
-        };
-        content: {
-          "application/json": {
-            id: string;
-            deploymentId: string;
+        DeploymentVersionSelector: {
             name: string;
-            description?: string | null;
+            deploymentVersionSelector: {
+                [key: string]: unknown;
+            };
+            description?: string;
+        };
+        VersionAnyApproval: {
+            requiredApprovalsCount: number;
+        };
+        VersionUserApproval: {
+            userId: string;
+        };
+        VersionRoleApproval: {
+            roleId: string;
+            requiredApprovalsCount: number;
+        };
+        Policy1: {
+            /** Format: uuid */
+            id: string;
+            name: string;
+            description?: string;
+            priority: number;
             /** Format: date-time */
             createdAt: string;
-            releaseSelector?: {
-              [key: string]: unknown;
-            };
-          };
-        };
-      };
-      /** @description Unauthorized */
-      401: {
-        headers: {
-          [name: string]: unknown;
-        };
-        content: {
-          "application/json": {
-            error: string;
-          };
-        };
-      };
-      /** @description Forbidden */
-      403: {
-        headers: {
-          [name: string]: unknown;
-        };
-        content: {
-          "application/json": {
-            error: string;
-          };
-        };
-      };
-      /** @description Release channel already exists */
-      409: {
-        headers: {
-          [name: string]: unknown;
-        };
-        content: {
-          "application/json": {
-            error: string;
-            id: string;
-          };
-        };
-      };
-      /** @description Failed to create release channel */
-      500: {
-        headers: {
-          [name: string]: unknown;
-        };
-        content: {
-          "application/json": {
-            error: string;
-          };
-        };
-      };
-    };
-  };
-  updateRelease: {
-    parameters: {
-      query?: never;
-      header?: never;
-      path: {
-        /** @description The release ID */
-        releaseId: string;
-      };
-      cookie?: never;
-    };
-    requestBody: {
-      content: {
-        "application/json": {
-          version?: string;
-          deploymentId?: string;
-          /** Format: date-time */
-          createdAt?: string;
-          name?: string;
-          config?: {
-            [key: string]: unknown;
-          };
-          jobAgentConfig?: {
-            [key: string]: unknown;
-          };
-          /** @enum {string} */
-          status?: "ready" | "building" | "failed";
-          message?: string;
-          metadata?: {
-            [key: string]: string;
-          };
-        };
-      };
-    };
-    responses: {
-      /** @description OK */
-      200: {
-        headers: {
-          [name: string]: unknown;
-        };
-        content: {
-          "application/json": components["schemas"]["Release"];
-        };
-      };
-    };
-  };
-  upsertRelease: {
-    parameters: {
-      query?: never;
-      header?: never;
-      path?: never;
-      cookie?: never;
-    };
-    requestBody: {
-      content: {
-        "application/json": {
-          version: string;
-          deploymentId: string;
-          /** Format: date-time */
-          createdAt?: string;
-          name?: string;
-          config?: {
-            [key: string]: unknown;
-          };
-          jobAgentConfig?: {
-            [key: string]: unknown;
-          };
-          /** @enum {string} */
-          status?: "ready" | "building" | "failed";
-          message?: string;
-          metadata?: {
-            [key: string]: string;
-          };
-        };
-      };
-    };
-    responses: {
-      /** @description OK */
-      200: {
-        headers: {
-          [name: string]: unknown;
-        };
-        content: {
-          "application/json": components["schemas"]["Release"];
-        };
-      };
-      /** @description Release already exists */
-      409: {
-        headers: {
-          [name: string]: unknown;
-        };
-        content: {
-          "application/json": {
-            error?: string;
-            id?: string;
-          };
-        };
-      };
-    };
-  };
-  setResourceProvidersResources: {
-    parameters: {
-      query?: never;
-      header?: never;
-      path: {
-        /** @description UUID of the scanner */
-        providerId: string;
-      };
-      cookie?: never;
-    };
-    requestBody: {
-      content: {
-        "application/json": {
-          resources: {
-            identifier: string;
-            name: string;
-            version: string;
-            kind: string;
-            config: {
-              [key: string]: unknown;
-            };
-            metadata: {
-              [key: string]: string;
-            };
-          }[];
-        };
-      };
-    };
-    responses: {
-      /** @description Successfully updated the deployment resources */
-      200: {
-        headers: {
-          [name: string]: unknown;
-        };
-        content?: never;
-      };
-      /** @description Invalid request */
-      400: {
-        headers: {
-          [name: string]: unknown;
-        };
-        content?: never;
-      };
-      /** @description Deployment resources not found */
-      404: {
-        headers: {
-          [name: string]: unknown;
-        };
-        content?: never;
-      };
-      /** @description Internal server error */
-      500: {
-        headers: {
-          [name: string]: unknown;
-        };
-        content?: never;
-      };
-    };
-  };
-  createResourceSchema: {
-    parameters: {
-      query?: never;
-      header?: never;
-      path?: never;
-      cookie?: never;
-    };
-    requestBody: {
-      content: {
-        "application/json": {
-          /**
-           * Format: uuid
-           * @description The ID of the workspace
-           */
-          workspaceId: string;
-          /** @description Version of the schema */
-          version: string;
-          /** @description Kind of resource this schema is for */
-          kind: string;
-          /** @description The JSON schema definition */
-          jsonSchema: Record<string, never>;
-        };
-      };
-    };
-    responses: {
-      /** @description Resource schema created successfully */
-      201: {
-        headers: {
-          [name: string]: unknown;
-        };
-        content: {
-          "application/json": {
+            enabled: boolean;
             /** Format: uuid */
-            id?: string;
-            /** Format: uuid */
-            workspaceId?: string;
-            version?: string;
-            kind?: string;
-            jsonSchema?: Record<string, never>;
-          };
-        };
-      };
-      /** @description Invalid request body */
-      400: {
-        headers: {
-          [name: string]: unknown;
-        };
-        content: {
-          "application/json": {
-            error?: string;
-          };
-        };
-      };
-      /** @description Schema already exists for this version and kind */
-      409: {
-        headers: {
-          [name: string]: unknown;
-        };
-        content: {
-          "application/json": {
-            error?: string;
-            /** Format: uuid */
-            id?: string;
-          };
-        };
-      };
-    };
-  };
-  deleteResourceSchema: {
-    parameters: {
-      query?: never;
-      header?: never;
-      path: {
-        /** @description UUID of the schema to delete */
-        schemaId: string;
-      };
-      cookie?: never;
-    };
-    requestBody?: never;
-    responses: {
-      /** @description Schema deleted successfully */
-      200: {
-        headers: {
-          [name: string]: unknown;
-        };
-        content: {
-          "application/json": {
-            /** Format: uuid */
-            id?: string;
-          };
-        };
-      };
-      /** @description Schema not found */
-      404: {
-        headers: {
-          [name: string]: unknown;
-        };
-        content: {
-          "application/json": {
-            /** @example Schema not found */
-            error?: string;
-          };
-        };
-      };
-    };
-  };
-  getResource: {
-    parameters: {
-      query?: never;
-      header?: never;
-      path: {
-        /** @description The resource ID */
-        resourceId: string;
-      };
-      cookie?: never;
-    };
-    requestBody?: never;
-    responses: {
-      /** @description OK */
-      200: {
-        headers: {
-          [name: string]: unknown;
-        };
-        content: {
-          "application/json": {
-            id: string;
-            name: string;
             workspaceId: string;
-            kind: string;
-            identifier: string;
-            version: string;
-            config: {
-              [key: string]: unknown;
+            targets: components["schemas"]["PolicyTarget"][];
+            denyWindows: components["schemas"]["DenyWindow"][];
+            deploymentVersionSelector?: components["schemas"]["DeploymentVersionSelector"];
+            versionAnyApprovals?: components["schemas"]["VersionAnyApproval"][];
+            versionUserApprovals: components["schemas"]["VersionUserApproval"][];
+            versionRoleApprovals: components["schemas"]["VersionRoleApproval"][];
+        };
+    };
+    responses: never;
+    parameters: never;
+    requestBodies: never;
+    headers: never;
+    pathItems: never;
+}
+export type $defs = Record<string, never>;
+export interface operations {
+    getCloudProviderRegions: {
+        parameters: {
+            query?: never;
+            header?: never;
+            path: {
+                /** @description Cloud provider (aws, gcp, azure) */
+                provider: "aws" | "gcp" | "azure";
             };
-            /** Format: date-time */
-            lockedAt?: string | null;
-            /** Format: date-time */
-            updatedAt: string;
-            provider?: {
-              id?: string;
-              name?: string;
-            } | null;
-            metadata: {
-              [key: string]: string;
+            cookie?: never;
+        };
+        requestBody?: never;
+        responses: {
+            /** @description Successfully returned geographic data for cloud provider regions */
+            200: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": {
+                        [key: string]: components["schemas"]["CloudRegionGeoData"];
+                    };
+                };
             };
-            variable: {
-              [key: string]: string;
+            /** @description Cloud provider not found */
+            404: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": {
+                        /** @example Cloud provider 'unknown' not found */
+                        error?: string;
+                    };
+                };
             };
-          };
         };
-      };
-      /** @description Unauthorized */
-      401: {
-        headers: {
-          [name: string]: unknown;
-        };
-        content?: never;
-      };
-      /** @description Permission denied */
-      403: {
-        headers: {
-          [name: string]: unknown;
-        };
-        content?: never;
-      };
-      /** @description Resource not found */
-      404: {
-        headers: {
-          [name: string]: unknown;
-        };
-        content: {
-          "application/json": {
-            /** @example Resource not found */
-            error: string;
-          };
-        };
-      };
     };
-  };
-  deleteResource: {
-    parameters: {
-      query?: never;
-      header?: never;
-      path: {
-        /** @description The resource ID */
-        resourceId: string;
-      };
-      cookie?: never;
-    };
-    requestBody?: never;
-    responses: {
-      /** @description Resource deleted successfully */
-      200: {
-        headers: {
-          [name: string]: unknown;
+    createDeploymentVersionChannel: {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
         };
-        content: {
-          "application/json": {
-            success: boolean;
-          };
-        };
-      };
-      /** @description Unauthorized */
-      401: {
-        headers: {
-          [name: string]: unknown;
-        };
-        content?: never;
-      };
-      /** @description Permission denied */
-      403: {
-        headers: {
-          [name: string]: unknown;
-        };
-        content?: never;
-      };
-      /** @description Resource not found */
-      404: {
-        headers: {
-          [name: string]: unknown;
-        };
-        content: {
-          "application/json": {
-            error: string;
-          };
-        };
-      };
-    };
-  };
-  updateResource: {
-    parameters: {
-      query?: never;
-      header?: never;
-      path: {
-        resourceId: string;
-      };
-      cookie?: never;
-    };
-    requestBody: {
-      content: {
-        "application/json": {
-          name?: string;
-          version?: string;
-          kind?: string;
-          identifier?: string;
-          workspaceId?: string;
-          metadata?: {
-            [key: string]: string;
-          };
-          variables?: components["schemas"]["Variable"][];
-        };
-      };
-    };
-    responses: {
-      /** @description Resource updated successfully */
-      200: {
-        headers: {
-          [name: string]: unknown;
-        };
-        content: {
-          "application/json": {
-            id: string;
-            name: string;
-            workspaceId: string;
-            kind: string;
-            identifier: string;
-            version: string;
-            config: {
-              [key: string]: unknown;
+        requestBody: {
+            content: {
+                "application/json": {
+                    deploymentId: string;
+                    name: string;
+                    description?: string | null;
+                    versionSelector: {
+                        [key: string]: unknown;
+                    };
+                };
             };
-            metadata: {
-              [key: string]: string;
+        };
+        responses: {
+            /** @description Deployment version channel created successfully */
+            200: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": {
+                        id: string;
+                        deploymentId: string;
+                        name: string;
+                        description?: string | null;
+                        /** Format: date-time */
+                        createdAt: string;
+                        versionSelector?: {
+                            [key: string]: unknown;
+                        };
+                    };
+                };
             };
-          };
-        };
-      };
-      /** @description Unauthorized */
-      401: {
-        headers: {
-          [name: string]: unknown;
-        };
-        content?: never;
-      };
-      /** @description Permission denied */
-      403: {
-        headers: {
-          [name: string]: unknown;
-        };
-        content?: never;
-      };
-      /** @description Resource not found */
-      404: {
-        headers: {
-          [name: string]: unknown;
-        };
-        content: {
-          "application/json": {
-            error: string;
-          };
-        };
-      };
-    };
-  };
-  upsertResources: {
-    parameters: {
-      query?: never;
-      header?: never;
-      path?: never;
-      cookie?: never;
-    };
-    requestBody: {
-      content: {
-        "application/json": {
-          /** Format: uuid */
-          workspaceId: string;
-          resources: {
-            name: string;
-            kind: string;
-            identifier: string;
-            version: string;
-            config: Record<string, never>;
-            metadata?: {
-              [key: string]: string;
+            /** @description Unauthorized */
+            401: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": {
+                        error: string;
+                    };
+                };
             };
-            variables?: components["schemas"]["Variable"][];
-          }[];
-        };
-      };
-    };
-    responses: {
-      /** @description All of the cats */
-      200: {
-        headers: {
-          [name: string]: unknown;
-        };
-        content: {
-          "application/json": {
-            count?: number;
-          };
-        };
-      };
-    };
-  };
-  deleteEnvironmentByName: {
-    parameters: {
-      query?: never;
-      header?: never;
-      path: {
-        /** @description UUID of the system */
-        systemId: string;
-        /** @description Name of the environment */
-        name: string;
-      };
-      cookie?: never;
-    };
-    requestBody?: never;
-    responses: {
-      /** @description Environment deleted successfully */
-      200: {
-        headers: {
-          [name: string]: unknown;
-        };
-        content?: never;
-      };
-    };
-  };
-  getSystem: {
-    parameters: {
-      query?: never;
-      header?: never;
-      path: {
-        /** @description UUID of the system */
-        systemId: string;
-      };
-      cookie?: never;
-    };
-    requestBody?: never;
-    responses: {
-      /** @description System retrieved successfully */
-      200: {
-        headers: {
-          [name: string]: unknown;
-        };
-        content: {
-          "application/json": components["schemas"]["System"] & {
-            environments?: components["schemas"]["Environment"][];
-            deployments?: components["schemas"]["Deployment"][];
-          };
-        };
-      };
-    };
-  };
-  deleteSystem: {
-    parameters: {
-      query?: never;
-      header?: never;
-      path: {
-        systemId: string;
-      };
-      cookie?: never;
-    };
-    requestBody?: never;
-    responses: {
-      /** @description System deleted successfully */
-      200: {
-        headers: {
-          [name: string]: unknown;
-        };
-        content: {
-          "application/json": {
-            /** @example System deleted */
-            message?: string;
-          };
-        };
-      };
-      /** @description System not found */
-      404: {
-        headers: {
-          [name: string]: unknown;
-        };
-        content: {
-          "application/json": {
-            /** @example System not found */
-            error?: string;
-          };
-        };
-      };
-      /** @description Internal server error */
-      500: {
-        headers: {
-          [name: string]: unknown;
-        };
-        content: {
-          "application/json": {
-            /** @example Internal server error */
-            error?: string;
-          };
-        };
-      };
-    };
-  };
-  updateSystem: {
-    parameters: {
-      query?: never;
-      header?: never;
-      path: {
-        /** @description UUID of the system */
-        systemId: string;
-      };
-      cookie?: never;
-    };
-    requestBody: {
-      content: {
-        "application/json": {
-          /** @description Name of the system */
-          name?: string;
-          /** @description Slug of the system */
-          slug?: string;
-          /** @description Description of the system */
-          description?: string;
-          /**
-           * Format: uuid
-           * @description UUID of the workspace
-           */
-          workspaceId?: string;
-        };
-      };
-    };
-    responses: {
-      /** @description System updated successfully */
-      200: {
-        headers: {
-          [name: string]: unknown;
-        };
-        content: {
-          "application/json": components["schemas"]["System"];
-        };
-      };
-      /** @description System not found */
-      404: {
-        headers: {
-          [name: string]: unknown;
-        };
-        content: {
-          "application/json": {
-            /** @example System not found */
-            error?: string;
-          };
-        };
-      };
-      /** @description Internal server error */
-      500: {
-        headers: {
-          [name: string]: unknown;
-        };
-        content: {
-          "application/json": {
-            /** @example Internal server error */
-            error?: string;
-          };
-        };
-      };
-    };
-  };
-  createSystem: {
-    parameters: {
-      query?: never;
-      header?: never;
-      path?: never;
-      cookie?: never;
-    };
-    requestBody?: {
-      content: {
-        "application/json": {
-          /**
-           * Format: uuid
-           * @description The workspace ID of the system
-           */
-          workspaceId: string;
-          /** @description The name of the system */
-          name: string;
-          /** @description The slug of the system */
-          slug: string;
-          /** @description The description of the system */
-          description?: string;
-        };
-      };
-    };
-    responses: {
-      /** @description System created successfully */
-      201: {
-        headers: {
-          [name: string]: unknown;
-        };
-        content: {
-          "application/json": components["schemas"]["System"];
-        };
-      };
-      /** @description Bad request */
-      400: {
-        headers: {
-          [name: string]: unknown;
-        };
-        content: {
-          "application/json": {
-            error?: {
-              /** @enum {string} */
-              code: "invalid_type" | "invalid_literal" | "custom";
-              message: string;
-              path: (string | number)[];
-            }[];
-          };
-        };
-      };
-      /** @description Internal server error */
-      500: {
-        headers: {
-          [name: string]: unknown;
-        };
-        content: {
-          "application/json": {
-            /** @example Internal Server Error */
-            error?: string;
-          };
-        };
-      };
-    };
-  };
-  listDeployments: {
-    parameters: {
-      query?: never;
-      header?: never;
-      path: {
-        /** @description The ID of the workspace */
-        workspaceId: string;
-      };
-      cookie?: never;
-    };
-    requestBody?: never;
-    responses: {
-      /** @description All deployments */
-      200: {
-        headers: {
-          [name: string]: unknown;
-        };
-        content: {
-          "application/json": {
-            data?: components["schemas"]["Deployment"][];
-          };
-        };
-      };
-    };
-  };
-  listEnvironments: {
-    parameters: {
-      query?: never;
-      header?: never;
-      path: {
-        /** @description The ID of the workspace */
-        workspaceId: string;
-      };
-      cookie?: never;
-    };
-    requestBody?: never;
-    responses: {
-      /** @description All environments */
-      200: {
-        headers: {
-          [name: string]: unknown;
-        };
-        content: {
-          "application/json": {
-            data?: components["schemas"]["Environment"][];
-          };
-        };
-      };
-    };
-  };
-  getWorkspace: {
-    parameters: {
-      query?: never;
-      header?: never;
-      path: {
-        workspaceId: string;
-      };
-      cookie?: never;
-    };
-    requestBody?: never;
-    responses: {
-      /** @description Workspace found */
-      200: {
-        headers: {
-          [name: string]: unknown;
-        };
-        content: {
-          "application/json": components["schemas"]["Workspace"];
-        };
-      };
-      /** @description Workspace not found */
-      404: {
-        headers: {
-          [name: string]: unknown;
-        };
-        content: {
-          "application/json": {
-            error?: string;
-          };
-        };
-      };
-      /** @description Internal server error */
-      500: {
-        headers: {
-          [name: string]: unknown;
-        };
-        content: {
-          "application/json": {
-            error?: string;
-          };
-        };
-      };
-    };
-  };
-  deletePolicyByName: {
-    parameters: {
-      query?: never;
-      header?: never;
-      path: {
-        /** @description ID of the workspace */
-        workspaceId: string;
-        /** @description Name of the policy */
-        name: string;
-      };
-      cookie?: never;
-    };
-    requestBody?: never;
-    responses: {
-      /** @description Successfully deleted the policy */
-      200: {
-        headers: {
-          [name: string]: unknown;
-        };
-        content: {
-          "application/json": {
-            /** @example true */
-            success?: boolean;
-          };
-        };
-      };
-      /** @description Unauthorized */
-      401: {
-        headers: {
-          [name: string]: unknown;
-        };
-        content?: never;
-      };
-      /** @description Permission denied */
-      403: {
-        headers: {
-          [name: string]: unknown;
-        };
-        content?: never;
-      };
-      /** @description Policy not found */
-      404: {
-        headers: {
-          [name: string]: unknown;
-        };
-        content: {
-          "application/json": {
-            /** @example Policy not found */
-            error?: string;
-          };
-        };
-      };
-      /** @description Internal server error */
-      500: {
-        headers: {
-          [name: string]: unknown;
-        };
-        content?: never;
-      };
-    };
-  };
-  upsertResourceProvider: {
-    parameters: {
-      query?: never;
-      header?: never;
-      path: {
-        /** @description Name of the workspace */
-        workspaceId: string;
-        /** @description Name of the resource provider */
-        name: string;
-      };
-      cookie?: never;
-    };
-    requestBody?: never;
-    responses: {
-      /** @description Successfully retrieved or created the resource provider */
-      200: {
-        headers: {
-          [name: string]: unknown;
-        };
-        content: {
-          "application/json": {
-            id: string;
-            name: string;
-            workspaceId: string;
-          };
-        };
-      };
-      /** @description Unauthorized */
-      401: {
-        headers: {
-          [name: string]: unknown;
-        };
-        content?: never;
-      };
-      /** @description Permission denied */
-      403: {
-        headers: {
-          [name: string]: unknown;
-        };
-        content?: never;
-      };
-      /** @description Workspace not found */
-      404: {
-        headers: {
-          [name: string]: unknown;
-        };
-        content?: never;
-      };
-      /** @description Internal server error */
-      500: {
-        headers: {
-          [name: string]: unknown;
-        };
-        content?: never;
-      };
-    };
-  };
-  getResourceByIdentifier: {
-    parameters: {
-      query?: never;
-      header?: never;
-      path: {
-        /** @description ID of the workspace */
-        workspaceId: string;
-        /** @description Identifier of the resource */
-        identifier: string;
-      };
-      cookie?: never;
-    };
-    requestBody?: never;
-    responses: {
-      /** @description Successfully retrieved the resource */
-      200: {
-        headers: {
-          [name: string]: unknown;
-        };
-        content: {
-          "application/json": {
-            id: string;
-            identifier: string;
-            workspaceId: string;
-            providerId: string;
-            provider?: {
-              id?: string;
-              name?: string;
-              workspaceId?: string;
+            /** @description Forbidden */
+            403: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": {
+                        error: string;
+                    };
+                };
             };
-            variables?: {
-              id?: string;
-              key?: string;
-              value?: string;
-            }[];
-            metadata?: {
-              [key: string]: string;
+            /** @description Deployment version channel already exists */
+            409: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": {
+                        error: string;
+                        id: string;
+                    };
+                };
             };
-          };
+            /** @description Failed to create deployment version channel */
+            500: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": {
+                        error: string;
+                    };
+                };
+            };
         };
-      };
-      /** @description Unauthorized */
-      401: {
-        headers: {
-          [name: string]: unknown;
-        };
-        content?: never;
-      };
-      /** @description Permission denied */
-      403: {
-        headers: {
-          [name: string]: unknown;
-        };
-        content?: never;
-      };
-      /** @description Resource not found */
-      404: {
-        headers: {
-          [name: string]: unknown;
-        };
-        content: {
-          "application/json": {
-            /** @example Resource not found */
-            error?: string;
-          };
-        };
-      };
-      /** @description Internal server error */
-      500: {
-        headers: {
-          [name: string]: unknown;
-        };
-        content?: never;
-      };
     };
-  };
-  deleteResourceByIdentifier: {
-    parameters: {
-      query?: never;
-      header?: never;
-      path: {
-        /** @description ID of the workspace */
-        workspaceId: string;
-        /** @description Identifier of the resource */
-        identifier: string;
-      };
-      cookie?: never;
+    updateDeploymentVersion: {
+        parameters: {
+            query?: never;
+            header?: never;
+            path: {
+                /** @description The deployment version ID */
+                deploymentVersionId: string;
+            };
+            cookie?: never;
+        };
+        requestBody: {
+            content: {
+                "application/json": {
+                    tag?: string;
+                    deploymentId?: string;
+                    /** Format: date-time */
+                    createdAt?: string;
+                    name?: string;
+                    config?: {
+                        [key: string]: unknown;
+                    };
+                    jobAgentConfig?: {
+                        [key: string]: unknown;
+                    };
+                    /** @enum {string} */
+                    status?: "ready" | "building" | "failed";
+                    message?: string;
+                    metadata?: {
+                        [key: string]: string;
+                    };
+                };
+            };
+        };
+        responses: {
+            /** @description OK */
+            200: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["DeploymentVersion"];
+                };
+            };
+        };
     };
-    requestBody?: never;
-    responses: {
-      /** @description Successfully deleted the resource */
-      200: {
-        headers: {
-          [name: string]: unknown;
+    upsertDeploymentVersion: {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
         };
-        content: {
-          "application/json": {
-            /** @example true */
-            success?: boolean;
-          };
+        requestBody: {
+            content: {
+                "application/json": {
+                    tag: string;
+                    deploymentId: string;
+                    /** Format: date-time */
+                    createdAt?: string;
+                    name?: string;
+                    config?: {
+                        [key: string]: unknown;
+                    };
+                    jobAgentConfig?: {
+                        [key: string]: unknown;
+                    };
+                    /** @enum {string} */
+                    status?: "ready" | "building" | "failed";
+                    message?: string;
+                    metadata?: {
+                        [key: string]: string;
+                    };
+                };
+            };
         };
-      };
-      /** @description Unauthorized */
-      401: {
-        headers: {
-          [name: string]: unknown;
+        responses: {
+            /** @description OK */
+            200: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["DeploymentVersion"];
+                };
+            };
+            /** @description Deployment version already exists */
+            409: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": {
+                        error?: string;
+                        id?: string;
+                    };
+                };
+            };
         };
-        content?: never;
-      };
-      /** @description Permission denied */
-      403: {
-        headers: {
-          [name: string]: unknown;
-        };
-        content?: never;
-      };
-      /** @description Resource not found */
-      404: {
-        headers: {
-          [name: string]: unknown;
-        };
-        content: {
-          "application/json": {
-            /** @example Resource not found */
-            error?: string;
-          };
-        };
-      };
-      /** @description Internal server error */
-      500: {
-        headers: {
-          [name: string]: unknown;
-        };
-        content?: never;
-      };
     };
-  };
-  listResources: {
-    parameters: {
-      query?: never;
-      header?: never;
-      path: {
-        /** @description The ID of the workspace */
-        workspaceId: string;
-      };
-      cookie?: never;
+    deleteDeploymentVersionChannel: {
+        parameters: {
+            query?: never;
+            header?: never;
+            path: {
+                deploymentId: string;
+                name: string;
+            };
+            cookie?: never;
+        };
+        requestBody?: never;
+        responses: {
+            /** @description Deployment version channel deleted */
+            200: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": {
+                        message: string;
+                    };
+                };
+            };
+            /** @description Permission denied */
+            403: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": {
+                        error: string;
+                    };
+                };
+            };
+            /** @description Deployment version channel not found */
+            404: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": {
+                        error: string;
+                    };
+                };
+            };
+            /** @description Failed to delete deployment version channel */
+            500: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": {
+                        error: string;
+                    };
+                };
+            };
+        };
     };
-    requestBody?: never;
-    responses: {
-      /** @description All resources */
-      200: {
-        headers: {
-          [name: string]: unknown;
+    getDeployment: {
+        parameters: {
+            query?: never;
+            header?: never;
+            path: {
+                deploymentId: string;
+            };
+            cookie?: never;
         };
-        content: {
-          "application/json": {
-            resources?: components["schemas"]["Resource"][];
-          };
+        requestBody?: never;
+        responses: {
+            /** @description Deployment found */
+            200: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["Deployment"];
+                };
+            };
+            /** @description Deployment not found */
+            404: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": {
+                        error: string;
+                    };
+                };
+            };
         };
-      };
     };
-  };
-  listSystems: {
-    parameters: {
-      query?: never;
-      header?: never;
-      path: {
-        /** @description The ID of the workspace */
-        workspaceId: string;
-      };
-      cookie?: never;
+    deleteDeployment: {
+        parameters: {
+            query?: never;
+            header?: never;
+            path: {
+                deploymentId: string;
+            };
+            cookie?: never;
+        };
+        requestBody?: never;
+        responses: {
+            /** @description Deployment deleted */
+            200: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["Deployment"];
+                };
+            };
+            /** @description Deployment not found */
+            404: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": {
+                        error: string;
+                    };
+                };
+            };
+            /** @description Failed to delete deployment */
+            500: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": {
+                        error: string;
+                    };
+                };
+            };
+        };
     };
-    requestBody?: never;
-    responses: {
-      /** @description All systems */
-      200: {
-        headers: {
-          [name: string]: unknown;
+    updateDeployment: {
+        parameters: {
+            query?: never;
+            header?: never;
+            path: {
+                deploymentId: string;
+            };
+            cookie?: never;
         };
-        content: {
-          "application/json": {
-            data?: components["schemas"]["System"][];
-          };
+        requestBody: {
+            content: {
+                "application/json": components["schemas"]["UpdateDeployment"];
+            };
         };
-      };
+        responses: {
+            /** @description Deployment updated */
+            200: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["Deployment"];
+                };
+            };
+            /** @description Deployment not found */
+            404: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": {
+                        error: string;
+                    };
+                };
+            };
+            /** @description Failed to update deployment */
+            500: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": {
+                        error: string;
+                    };
+                };
+            };
+        };
     };
-  };
-  getWorkspaceBySlug: {
-    parameters: {
-      query?: never;
-      header?: never;
-      path: {
-        workspaceSlug: string;
-      };
-      cookie?: never;
+    deleteReleaseChannel: {
+        parameters: {
+            query?: never;
+            header?: never;
+            path: {
+                deploymentId: string;
+                name: string;
+            };
+            cookie?: never;
+        };
+        requestBody?: never;
+        responses: {
+            /** @description Release channel deleted */
+            200: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": {
+                        message: string;
+                    };
+                };
+            };
+            /** @description Permission denied */
+            403: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": {
+                        error: string;
+                    };
+                };
+            };
+            /** @description Release channel not found */
+            404: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": {
+                        error: string;
+                    };
+                };
+            };
+            /** @description Failed to delete release channel */
+            500: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": {
+                        error: string;
+                    };
+                };
+            };
+        };
     };
-    requestBody?: never;
-    responses: {
-      /** @description Workspace found */
-      200: {
-        headers: {
-          [name: string]: unknown;
+    getResourcesForDeployment: {
+        parameters: {
+            query?: never;
+            header?: never;
+            path: {
+                /** @description UUID of the deployment */
+                deploymentId: string;
+            };
+            cookie?: never;
         };
-        content: {
-          "application/json": components["schemas"]["Workspace"];
+        requestBody?: never;
+        responses: {
+            /** @description OK */
+            200: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": {
+                        resources?: {
+                            id?: string;
+                            name?: string;
+                            identifier?: string;
+                            kind?: string;
+                            version?: string;
+                        }[];
+                        count?: number;
+                    };
+                };
+            };
+            /** @description Internal Server Error */
+            500: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": {
+                        error?: string;
+                    };
+                };
+            };
         };
-      };
-      /** @description Workspace not found */
-      404: {
-        headers: {
-          [name: string]: unknown;
-        };
-        content: {
-          "application/json": {
-            error?: string;
-          };
-        };
-      };
-      /** @description Internal server error */
-      500: {
-        headers: {
-          [name: string]: unknown;
-        };
-        content: {
-          "application/json": {
-            error?: string;
-          };
-        };
-      };
     };
-  };
+    createDeployment: {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        requestBody?: {
+            content: {
+                "application/json": {
+                    /**
+                     * Format: uuid
+                     * @description The ID of the system to create the deployment for
+                     * @example 123e4567-e89b-12d3-a456-426614174000
+                     */
+                    systemId: string;
+                    /**
+                     * @description The name of the deployment
+                     * @example My Deployment
+                     */
+                    name: string;
+                    /**
+                     * @description The slug of the deployment
+                     * @example my-deployment
+                     */
+                    slug: string;
+                    /**
+                     * @description The description of the deployment
+                     * @example This is a deployment for my system
+                     */
+                    description?: string;
+                    /**
+                     * Format: uuid
+                     * @description The ID of the job agent to use for the deployment
+                     * @example 123e4567-e89b-12d3-a456-426614174000
+                     */
+                    jobAgentId?: string;
+                    /**
+                     * @description The configuration for the job agent
+                     * @example {
+                     *       "key": "value"
+                     *     }
+                     */
+                    jobAgentConfig?: Record<string, never>;
+                    /**
+                     * @description The number of times to retry the deployment
+                     * @example 3
+                     */
+                    retryCount?: number;
+                    /**
+                     * @description The timeout for the deployment
+                     * @example 60
+                     */
+                    timeout?: number;
+                    /**
+                     * @description The resource selector for the deployment
+                     * @example {
+                     *       "key": "value"
+                     *     }
+                     */
+                    resourceSelector?: Record<string, never>;
+                };
+            };
+        };
+        responses: {
+            /** @description Deployment created */
+            201: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["Deployment"];
+                };
+            };
+            /** @description Deployment already exists */
+            409: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": {
+                        error: string;
+                        /** Format: uuid */
+                        id: string;
+                    };
+                };
+            };
+            /** @description Failed to create deployment */
+            500: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": {
+                        error: string;
+                    };
+                };
+            };
+        };
+    };
+    getEnvironment: {
+        parameters: {
+            query?: never;
+            header?: never;
+            path: {
+                /** @description UUID of the environment */
+                environmentId: string;
+            };
+            cookie?: never;
+        };
+        requestBody?: never;
+        responses: {
+            /** @description Successful response */
+            200: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["Environment"];
+                };
+            };
+            /** @description Environment not found */
+            404: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": {
+                        /** @example Environment not found */
+                        error: string;
+                    };
+                };
+            };
+        };
+    };
+    deleteEnvironment: {
+        parameters: {
+            query?: never;
+            header?: never;
+            path: {
+                /** @description UUID of the environment */
+                environmentId: string;
+            };
+            cookie?: never;
+        };
+        requestBody?: never;
+        responses: {
+            /** @description Environment deleted successfully */
+            200: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content?: never;
+            };
+        };
+    };
+    getResourcesForEnvironment: {
+        parameters: {
+            query?: never;
+            header?: never;
+            path: {
+                /** @description UUID of the environment */
+                environmentId: string;
+            };
+            cookie?: never;
+        };
+        requestBody?: never;
+        responses: {
+            /** @description OK */
+            200: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": {
+                        resources?: {
+                            id?: string;
+                            name?: string;
+                            identifier?: string;
+                            kind?: string;
+                            version?: string;
+                        }[];
+                        count?: number;
+                    };
+                };
+            };
+            /** @description Internal Server Error */
+            500: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": {
+                        error?: string;
+                    };
+                };
+            };
+        };
+    };
+    createEnvironment: {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        requestBody: {
+            content: {
+                "application/json": {
+                    /**
+                     * @description The directory path of the environment
+                     * @default
+                     * @example my/env/path
+                     */
+                    directory?: string;
+                    systemId: string;
+                    name: string;
+                    description?: string;
+                    resourceSelector?: {
+                        [key: string]: unknown;
+                    };
+                    policyId?: string;
+                    releaseChannels?: string[];
+                    deploymentVersionChannels?: string[];
+                    metadata?: {
+                        [key: string]: string;
+                    };
+                };
+            };
+        };
+        responses: {
+            /** @description Environment created successfully */
+            200: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["Environment"];
+                };
+            };
+            /** @description Environment already exists */
+            409: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": {
+                        error?: string;
+                        id?: string;
+                    };
+                };
+            };
+            /** @description Failed to create environment */
+            500: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": {
+                        error: string;
+                    };
+                };
+            };
+        };
+    };
+    getAgentRunningJobs: {
+        parameters: {
+            query?: never;
+            header?: never;
+            path: {
+                /** @description The execution ID */
+                agentId: string;
+            };
+            cookie?: never;
+        };
+        requestBody?: never;
+        responses: {
+            /** @description OK */
+            200: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["Job"][];
+                };
+            };
+        };
+    };
+    acknowledgeAgentJob: {
+        parameters: {
+            query?: never;
+            header?: never;
+            path: {
+                /** @description The ID of the job agent */
+                agentId: string;
+            };
+            cookie?: never;
+        };
+        requestBody?: never;
+        responses: {
+            /** @description Successfully acknowledged job */
+            200: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": {
+                        job?: components["schemas"]["Job"];
+                    };
+                };
+            };
+            /** @description Unauthorized */
+            401: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": {
+                        error?: string;
+                    };
+                };
+            };
+            /** @description Workspace not found */
+            404: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": {
+                        error?: string;
+                    };
+                };
+            };
+        };
+    };
+    getNextJobs: {
+        parameters: {
+            query?: never;
+            header?: never;
+            path: {
+                /** @description The agent ID */
+                agentId: string;
+            };
+            cookie?: never;
+        };
+        requestBody?: never;
+        responses: {
+            /** @description OK */
+            200: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": {
+                        jobs?: components["schemas"]["Job"][];
+                    };
+                };
+            };
+        };
+    };
+    upsertJobAgent: {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        requestBody: {
+            content: {
+                "application/json": {
+                    workspaceId: string;
+                    name: string;
+                    type: string;
+                };
+            };
+        };
+        responses: {
+            /** @description Successfully retrieved or created the agent */
+            200: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": {
+                        id: string;
+                        name: string;
+                        workspaceId: string;
+                    };
+                };
+            };
+            /** @description Internal server error */
+            500: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content?: never;
+            };
+        };
+    };
+    acknowledgeJob: {
+        parameters: {
+            query?: never;
+            header?: never;
+            path: {
+                /** @description The job ID */
+                jobId: string;
+            };
+            cookie?: never;
+        };
+        requestBody?: never;
+        responses: {
+            /** @description OK */
+            200: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": {
+                        sucess: boolean;
+                    };
+                };
+            };
+            /** @description Unauthorized */
+            401: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": {
+                        error: string;
+                    };
+                };
+            };
+        };
+    };
+    getJob: {
+        parameters: {
+            query?: never;
+            header?: never;
+            path: {
+                /** @description The job ID */
+                jobId: string;
+            };
+            cookie?: never;
+        };
+        requestBody?: never;
+        responses: {
+            /** @description OK */
+            200: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["JobWithTrigger"];
+                };
+            };
+            /** @description Not Found */
+            404: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": {
+                        /** @example Job not found. */
+                        error?: string;
+                    };
+                };
+            };
+        };
+    };
+    updateJob: {
+        parameters: {
+            query?: never;
+            header?: never;
+            path: {
+                /** @description The execution ID */
+                jobId: string;
+            };
+            cookie?: never;
+        };
+        requestBody: {
+            content: {
+                "application/json": {
+                    status?: components["schemas"]["JobStatus"];
+                    message?: string | null;
+                    externalId?: string | null;
+                };
+            };
+        };
+        responses: {
+            /** @description OK */
+            200: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": {
+                        id: string;
+                    };
+                };
+            };
+        };
+    };
+    deletePolicy: {
+        parameters: {
+            query?: never;
+            header?: never;
+            path: {
+                policyId: string;
+            };
+            cookie?: never;
+        };
+        requestBody?: never;
+        responses: {
+            /** @description OK */
+            200: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": {
+                        count?: number;
+                    };
+                };
+            };
+            /** @description Internal Server Error */
+            500: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content?: never;
+            };
+        };
+    };
+    getReleaseTargetsForPolicy: {
+        parameters: {
+            query?: never;
+            header?: never;
+            path: {
+                /** @description UUID of the policy */
+                policyId: string;
+            };
+            cookie?: never;
+        };
+        requestBody?: never;
+        responses: {
+            /** @description OK */
+            200: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": {
+                        releaseTargets?: {
+                            id?: string;
+                            name?: string;
+                            description?: string;
+                            policyTarget?: {
+                                id?: string;
+                                name?: string;
+                                policyId?: string;
+                                description?: string;
+                            };
+                            resource?: {
+                                id?: string;
+                                name?: string;
+                                identifier?: string;
+                                kind?: string;
+                                version?: string;
+                            };
+                            environment?: {
+                                id?: string;
+                                name?: string;
+                            };
+                        }[];
+                        count?: number;
+                    };
+                };
+            };
+            /** @description Internal Server Error */
+            500: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": {
+                        error?: string;
+                    };
+                };
+            };
+        };
+    };
+    upsertPolicy: {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        requestBody: {
+            content: {
+                "application/json": {
+                    name: string;
+                    description?: string;
+                    priority?: number;
+                    enabled?: boolean;
+                    workspaceId: string;
+                    targets: components["schemas"]["PolicyTarget"][];
+                    denyWindows?: {
+                        timeZone: string;
+                        rrule?: {
+                            [key: string]: unknown;
+                        };
+                        /** Format: date-time */
+                        dtend?: string;
+                    }[];
+                    deploymentVersionSelector?: components["schemas"]["DeploymentVersionSelector"];
+                    versionAnyApprovals?: {
+                        requiredApprovalsCount?: number;
+                    }[];
+                    versionUserApprovals?: components["schemas"]["VersionUserApproval"][];
+                    versionRoleApprovals?: {
+                        roleId: string;
+                        requiredApprovalsCount?: number;
+                    }[];
+                };
+            };
+        };
+        responses: {
+            /** @description OK */
+            200: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["Policy1"];
+                };
+            };
+            /** @description Internal Server Error */
+            500: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": {
+                        error?: string;
+                    };
+                };
+            };
+        };
+    };
+    createJobToResourceRelationship: {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        requestBody: {
+            content: {
+                "application/json": {
+                    /**
+                     * Format: uuid
+                     * @description Unique identifier of the job
+                     * @example 123e4567-e89b-12d3-a456-426614174000
+                     */
+                    jobId: string;
+                    /**
+                     * @description Unique identifier of the resource
+                     * @example resource-123
+                     */
+                    resourceIdentifier: string;
+                };
+            };
+        };
+        responses: {
+            /** @description Relationship created successfully */
+            200: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": {
+                        /** @example Relationship created successfully */
+                        message?: string;
+                    };
+                };
+            };
+            /** @description Invalid request body */
+            400: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": {
+                        /** @example Invalid jobId format */
+                        error?: string;
+                    };
+                };
+            };
+            /** @description Job or resource not found */
+            404: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": {
+                        /** @example Job with specified ID not found */
+                        error?: string;
+                    };
+                };
+            };
+            /** @description Relationship already exists */
+            409: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": {
+                        /** @example Relationship between job and resource already exists */
+                        error?: string;
+                    };
+                };
+            };
+            /** @description Internal server error */
+            500: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": {
+                        /** @example Internal server error occurred */
+                        error?: string;
+                    };
+                };
+            };
+        };
+    };
+    createResourceToResourceRelationship: {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        requestBody: {
+            content: {
+                "application/json": {
+                    /**
+                     * Format: uuid
+                     * @description The workspace ID
+                     * @example 123e4567-e89b-12d3-a456-426614174000
+                     */
+                    workspaceId: string;
+                    /**
+                     * @description The identifier of the resource to connect
+                     * @example my-resource
+                     */
+                    fromIdentifier: string;
+                    /**
+                     * @description The identifier of the resource to connect to
+                     * @example my-resource
+                     */
+                    toIdentifier: string;
+                    /**
+                     * @description The type of relationship
+                     * @example depends_on
+                     */
+                    type: string;
+                };
+            };
+        };
+        responses: {
+            /** @description Relationship created */
+            200: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": {
+                        /** @example Relationship created successfully */
+                        message?: string;
+                    };
+                };
+            };
+            /** @description Invalid request body */
+            400: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": {
+                        error?: string;
+                    };
+                };
+            };
+            /** @description Resource not found */
+            404: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": {
+                        error?: string;
+                    };
+                };
+            };
+            /** @description Relationship already exists */
+            409: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": {
+                        error?: string;
+                    };
+                };
+            };
+            /** @description Internal server error */
+            500: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": {
+                        error?: string;
+                    };
+                };
+            };
+        };
+    };
+    createReleaseChannel: {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        requestBody: {
+            content: {
+                "application/json": {
+                    deploymentId: string;
+                    name: string;
+                    description?: string | null;
+                    releaseSelector: {
+                        [key: string]: unknown;
+                    };
+                };
+            };
+        };
+        responses: {
+            /** @description Release channel created successfully */
+            200: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": {
+                        id: string;
+                        deploymentId: string;
+                        name: string;
+                        description?: string | null;
+                        /** Format: date-time */
+                        createdAt: string;
+                        releaseSelector?: {
+                            [key: string]: unknown;
+                        };
+                    };
+                };
+            };
+            /** @description Unauthorized */
+            401: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": {
+                        error: string;
+                    };
+                };
+            };
+            /** @description Forbidden */
+            403: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": {
+                        error: string;
+                    };
+                };
+            };
+            /** @description Release channel already exists */
+            409: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": {
+                        error: string;
+                        id: string;
+                    };
+                };
+            };
+            /** @description Failed to create release channel */
+            500: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": {
+                        error: string;
+                    };
+                };
+            };
+        };
+    };
+    updateRelease: {
+        parameters: {
+            query?: never;
+            header?: never;
+            path: {
+                /** @description The release ID */
+                releaseId: string;
+            };
+            cookie?: never;
+        };
+        requestBody: {
+            content: {
+                "application/json": {
+                    version?: string;
+                    deploymentId?: string;
+                    /** Format: date-time */
+                    createdAt?: string;
+                    name?: string;
+                    config?: {
+                        [key: string]: unknown;
+                    };
+                    jobAgentConfig?: {
+                        [key: string]: unknown;
+                    };
+                    /** @enum {string} */
+                    status?: "ready" | "building" | "failed";
+                    message?: string;
+                    metadata?: {
+                        [key: string]: string;
+                    };
+                };
+            };
+        };
+        responses: {
+            /** @description OK */
+            200: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["Release"];
+                };
+            };
+        };
+    };
+    upsertRelease: {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        requestBody: {
+            content: {
+                "application/json": {
+                    version: string;
+                    deploymentId: string;
+                    /** Format: date-time */
+                    createdAt?: string;
+                    name?: string;
+                    config?: {
+                        [key: string]: unknown;
+                    };
+                    jobAgentConfig?: {
+                        [key: string]: unknown;
+                    };
+                    /** @enum {string} */
+                    status?: "ready" | "building" | "failed";
+                    message?: string;
+                    metadata?: {
+                        [key: string]: string;
+                    };
+                };
+            };
+        };
+        responses: {
+            /** @description OK */
+            200: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["Release"];
+                };
+            };
+            /** @description Release already exists */
+            409: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": {
+                        error?: string;
+                        id?: string;
+                    };
+                };
+            };
+        };
+    };
+    setResourceProvidersResources: {
+        parameters: {
+            query?: never;
+            header?: never;
+            path: {
+                /** @description UUID of the scanner */
+                providerId: string;
+            };
+            cookie?: never;
+        };
+        requestBody: {
+            content: {
+                "application/json": {
+                    resources: {
+                        identifier: string;
+                        name: string;
+                        version: string;
+                        kind: string;
+                        config: {
+                            [key: string]: unknown;
+                        };
+                        metadata: {
+                            [key: string]: string;
+                        };
+                    }[];
+                };
+            };
+        };
+        responses: {
+            /** @description Successfully updated the deployment resources */
+            200: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content?: never;
+            };
+            /** @description Invalid request */
+            400: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content?: never;
+            };
+            /** @description Deployment resources not found */
+            404: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content?: never;
+            };
+            /** @description Internal server error */
+            500: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content?: never;
+            };
+        };
+    };
+    createResourceSchema: {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        requestBody: {
+            content: {
+                "application/json": {
+                    /**
+                     * Format: uuid
+                     * @description The ID of the workspace
+                     */
+                    workspaceId: string;
+                    /** @description Version of the schema */
+                    version: string;
+                    /** @description Kind of resource this schema is for */
+                    kind: string;
+                    /** @description The JSON schema definition */
+                    jsonSchema: Record<string, never>;
+                };
+            };
+        };
+        responses: {
+            /** @description Resource schema created successfully */
+            201: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": {
+                        /** Format: uuid */
+                        id?: string;
+                        /** Format: uuid */
+                        workspaceId?: string;
+                        version?: string;
+                        kind?: string;
+                        jsonSchema?: Record<string, never>;
+                    };
+                };
+            };
+            /** @description Invalid request body */
+            400: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": {
+                        error?: string;
+                    };
+                };
+            };
+            /** @description Schema already exists for this version and kind */
+            409: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": {
+                        error?: string;
+                        /** Format: uuid */
+                        id?: string;
+                    };
+                };
+            };
+        };
+    };
+    deleteResourceSchema: {
+        parameters: {
+            query?: never;
+            header?: never;
+            path: {
+                /** @description UUID of the schema to delete */
+                schemaId: string;
+            };
+            cookie?: never;
+        };
+        requestBody?: never;
+        responses: {
+            /** @description Schema deleted successfully */
+            200: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": {
+                        /** Format: uuid */
+                        id?: string;
+                    };
+                };
+            };
+            /** @description Schema not found */
+            404: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": {
+                        /** @example Schema not found */
+                        error?: string;
+                    };
+                };
+            };
+        };
+    };
+    getResource: {
+        parameters: {
+            query?: never;
+            header?: never;
+            path: {
+                /** @description The resource ID */
+                resourceId: string;
+            };
+            cookie?: never;
+        };
+        requestBody?: never;
+        responses: {
+            /** @description OK */
+            200: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": {
+                        id: string;
+                        name: string;
+                        workspaceId: string;
+                        kind: string;
+                        identifier: string;
+                        version: string;
+                        config: {
+                            [key: string]: unknown;
+                        };
+                        /** Format: date-time */
+                        lockedAt?: string | null;
+                        /** Format: date-time */
+                        updatedAt: string;
+                        provider?: {
+                            id?: string;
+                            name?: string;
+                        } | null;
+                        metadata: {
+                            [key: string]: string;
+                        };
+                        variable: {
+                            [key: string]: string;
+                        };
+                    };
+                };
+            };
+            /** @description Unauthorized */
+            401: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content?: never;
+            };
+            /** @description Permission denied */
+            403: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content?: never;
+            };
+            /** @description Resource not found */
+            404: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": {
+                        /** @example Resource not found */
+                        error: string;
+                    };
+                };
+            };
+        };
+    };
+    deleteResource: {
+        parameters: {
+            query?: never;
+            header?: never;
+            path: {
+                /** @description The resource ID */
+                resourceId: string;
+            };
+            cookie?: never;
+        };
+        requestBody?: never;
+        responses: {
+            /** @description Resource deleted successfully */
+            200: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": {
+                        success: boolean;
+                    };
+                };
+            };
+            /** @description Unauthorized */
+            401: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content?: never;
+            };
+            /** @description Permission denied */
+            403: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content?: never;
+            };
+            /** @description Resource not found */
+            404: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": {
+                        error: string;
+                    };
+                };
+            };
+        };
+    };
+    updateResource: {
+        parameters: {
+            query?: never;
+            header?: never;
+            path: {
+                resourceId: string;
+            };
+            cookie?: never;
+        };
+        requestBody: {
+            content: {
+                "application/json": {
+                    name?: string;
+                    version?: string;
+                    kind?: string;
+                    identifier?: string;
+                    workspaceId?: string;
+                    metadata?: {
+                        [key: string]: string;
+                    };
+                    variables?: components["schemas"]["Variable"][];
+                };
+            };
+        };
+        responses: {
+            /** @description Resource updated successfully */
+            200: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": {
+                        id: string;
+                        name: string;
+                        workspaceId: string;
+                        kind: string;
+                        identifier: string;
+                        version: string;
+                        config: {
+                            [key: string]: unknown;
+                        };
+                        metadata: {
+                            [key: string]: string;
+                        };
+                    };
+                };
+            };
+            /** @description Unauthorized */
+            401: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content?: never;
+            };
+            /** @description Permission denied */
+            403: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content?: never;
+            };
+            /** @description Resource not found */
+            404: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": {
+                        error: string;
+                    };
+                };
+            };
+        };
+    };
+    upsertResource: {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        requestBody: {
+            content: {
+                "application/json": {
+                    /** Format: uuid */
+                    workspaceId: string;
+                    name: string;
+                    kind: string;
+                    identifier: string;
+                    version: string;
+                    config: Record<string, never>;
+                    metadata?: {
+                        [key: string]: string;
+                    };
+                    variables?: components["schemas"]["Variable"][];
+                };
+            };
+        };
+        responses: {
+            /** @description The created or updated resource */
+            200: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["Resource"];
+                };
+            };
+        };
+    };
+    deleteEnvironmentByName: {
+        parameters: {
+            query?: never;
+            header?: never;
+            path: {
+                /** @description UUID of the system */
+                systemId: string;
+                /** @description Name of the environment */
+                name: string;
+            };
+            cookie?: never;
+        };
+        requestBody?: never;
+        responses: {
+            /** @description Environment deleted successfully */
+            200: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content?: never;
+            };
+        };
+    };
+    getSystem: {
+        parameters: {
+            query?: never;
+            header?: never;
+            path: {
+                /** @description UUID of the system */
+                systemId: string;
+            };
+            cookie?: never;
+        };
+        requestBody?: never;
+        responses: {
+            /** @description System retrieved successfully */
+            200: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["System"] & {
+                        environments?: components["schemas"]["Environment"][];
+                        deployments?: components["schemas"]["Deployment"][];
+                    };
+                };
+            };
+        };
+    };
+    deleteSystem: {
+        parameters: {
+            query?: never;
+            header?: never;
+            path: {
+                systemId: string;
+            };
+            cookie?: never;
+        };
+        requestBody?: never;
+        responses: {
+            /** @description System deleted successfully */
+            200: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": {
+                        /** @example System deleted */
+                        message?: string;
+                    };
+                };
+            };
+            /** @description System not found */
+            404: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": {
+                        /** @example System not found */
+                        error?: string;
+                    };
+                };
+            };
+            /** @description Internal server error */
+            500: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": {
+                        /** @example Internal server error */
+                        error?: string;
+                    };
+                };
+            };
+        };
+    };
+    updateSystem: {
+        parameters: {
+            query?: never;
+            header?: never;
+            path: {
+                /** @description UUID of the system */
+                systemId: string;
+            };
+            cookie?: never;
+        };
+        requestBody: {
+            content: {
+                "application/json": {
+                    /** @description Name of the system */
+                    name?: string;
+                    /** @description Slug of the system */
+                    slug?: string;
+                    /** @description Description of the system */
+                    description?: string;
+                    /**
+                     * Format: uuid
+                     * @description UUID of the workspace
+                     */
+                    workspaceId?: string;
+                };
+            };
+        };
+        responses: {
+            /** @description System updated successfully */
+            200: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["System"];
+                };
+            };
+            /** @description System not found */
+            404: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": {
+                        /** @example System not found */
+                        error?: string;
+                    };
+                };
+            };
+            /** @description Internal server error */
+            500: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": {
+                        /** @example Internal server error */
+                        error?: string;
+                    };
+                };
+            };
+        };
+    };
+    createSystem: {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        requestBody?: {
+            content: {
+                "application/json": {
+                    /**
+                     * Format: uuid
+                     * @description The workspace ID of the system
+                     */
+                    workspaceId: string;
+                    /** @description The name of the system */
+                    name: string;
+                    /** @description The slug of the system */
+                    slug: string;
+                    /** @description The description of the system */
+                    description?: string;
+                };
+            };
+        };
+        responses: {
+            /** @description System created successfully */
+            201: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["System"];
+                };
+            };
+            /** @description Bad request */
+            400: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": {
+                        error?: {
+                            /** @enum {string} */
+                            code: "invalid_type" | "invalid_literal" | "custom";
+                            message: string;
+                            path: (string | number)[];
+                        }[];
+                    };
+                };
+            };
+            /** @description Internal server error */
+            500: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": {
+                        /** @example Internal Server Error */
+                        error?: string;
+                    };
+                };
+            };
+        };
+    };
+    listDeployments: {
+        parameters: {
+            query?: never;
+            header?: never;
+            path: {
+                /** @description The ID of the workspace */
+                workspaceId: string;
+            };
+            cookie?: never;
+        };
+        requestBody?: never;
+        responses: {
+            /** @description All deployments */
+            200: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": {
+                        data?: components["schemas"]["Deployment"][];
+                    };
+                };
+            };
+        };
+    };
+    listEnvironments: {
+        parameters: {
+            query?: never;
+            header?: never;
+            path: {
+                /** @description The ID of the workspace */
+                workspaceId: string;
+            };
+            cookie?: never;
+        };
+        requestBody?: never;
+        responses: {
+            /** @description All environments */
+            200: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": {
+                        data?: components["schemas"]["Environment"][];
+                    };
+                };
+            };
+        };
+    };
+    getWorkspace: {
+        parameters: {
+            query?: never;
+            header?: never;
+            path: {
+                workspaceId: string;
+            };
+            cookie?: never;
+        };
+        requestBody?: never;
+        responses: {
+            /** @description Workspace found */
+            200: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["Workspace"];
+                };
+            };
+            /** @description Workspace not found */
+            404: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": {
+                        error?: string;
+                    };
+                };
+            };
+            /** @description Internal server error */
+            500: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": {
+                        error?: string;
+                    };
+                };
+            };
+        };
+    };
+    deletePolicyByName: {
+        parameters: {
+            query?: never;
+            header?: never;
+            path: {
+                /** @description ID of the workspace */
+                workspaceId: string;
+                /** @description Name of the policy */
+                name: string;
+            };
+            cookie?: never;
+        };
+        requestBody?: never;
+        responses: {
+            /** @description Successfully deleted the policy */
+            200: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": {
+                        /** @example true */
+                        success?: boolean;
+                    };
+                };
+            };
+            /** @description Unauthorized */
+            401: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content?: never;
+            };
+            /** @description Permission denied */
+            403: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content?: never;
+            };
+            /** @description Policy not found */
+            404: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": {
+                        /** @example Policy not found */
+                        error?: string;
+                    };
+                };
+            };
+            /** @description Internal server error */
+            500: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content?: never;
+            };
+        };
+    };
+    upsertResourceProvider: {
+        parameters: {
+            query?: never;
+            header?: never;
+            path: {
+                /** @description Name of the workspace */
+                workspaceId: string;
+                /** @description Name of the resource provider */
+                name: string;
+            };
+            cookie?: never;
+        };
+        requestBody?: never;
+        responses: {
+            /** @description Successfully retrieved or created the resource provider */
+            200: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": {
+                        id: string;
+                        name: string;
+                        workspaceId: string;
+                    };
+                };
+            };
+            /** @description Unauthorized */
+            401: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content?: never;
+            };
+            /** @description Permission denied */
+            403: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content?: never;
+            };
+            /** @description Workspace not found */
+            404: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content?: never;
+            };
+            /** @description Internal server error */
+            500: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content?: never;
+            };
+        };
+    };
+    getResourceByIdentifier: {
+        parameters: {
+            query?: never;
+            header?: never;
+            path: {
+                /** @description ID of the workspace */
+                workspaceId: string;
+                /** @description Identifier of the resource */
+                identifier: string;
+            };
+            cookie?: never;
+        };
+        requestBody?: never;
+        responses: {
+            /** @description Successfully retrieved the resource */
+            200: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": {
+                        id: string;
+                        identifier: string;
+                        workspaceId: string;
+                        providerId: string;
+                        provider?: {
+                            id?: string;
+                            name?: string;
+                            workspaceId?: string;
+                        };
+                        variables?: {
+                            id?: string;
+                            key?: string;
+                            value?: string;
+                        }[];
+                        metadata?: {
+                            [key: string]: string;
+                        };
+                    };
+                };
+            };
+            /** @description Unauthorized */
+            401: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content?: never;
+            };
+            /** @description Permission denied */
+            403: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content?: never;
+            };
+            /** @description Resource not found */
+            404: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": {
+                        /** @example Resource not found */
+                        error?: string;
+                    };
+                };
+            };
+            /** @description Internal server error */
+            500: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content?: never;
+            };
+        };
+    };
+    deleteResourceByIdentifier: {
+        parameters: {
+            query?: never;
+            header?: never;
+            path: {
+                /** @description ID of the workspace */
+                workspaceId: string;
+                /** @description Identifier of the resource */
+                identifier: string;
+            };
+            cookie?: never;
+        };
+        requestBody?: never;
+        responses: {
+            /** @description Successfully deleted the resource */
+            200: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": {
+                        /** @example true */
+                        success?: boolean;
+                    };
+                };
+            };
+            /** @description Unauthorized */
+            401: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content?: never;
+            };
+            /** @description Permission denied */
+            403: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content?: never;
+            };
+            /** @description Resource not found */
+            404: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": {
+                        /** @example Resource not found */
+                        error?: string;
+                    };
+                };
+            };
+            /** @description Internal server error */
+            500: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content?: never;
+            };
+        };
+    };
+    listResources: {
+        parameters: {
+            query?: never;
+            header?: never;
+            path: {
+                /** @description The ID of the workspace */
+                workspaceId: string;
+            };
+            cookie?: never;
+        };
+        requestBody?: never;
+        responses: {
+            /** @description All resources */
+            200: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": {
+                        resources?: components["schemas"]["Resource"][];
+                    };
+                };
+            };
+        };
+    };
+    listSystems: {
+        parameters: {
+            query?: never;
+            header?: never;
+            path: {
+                /** @description The ID of the workspace */
+                workspaceId: string;
+            };
+            cookie?: never;
+        };
+        requestBody?: never;
+        responses: {
+            /** @description All systems */
+            200: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": {
+                        data?: components["schemas"]["System"][];
+                    };
+                };
+            };
+        };
+    };
+    getWorkspaceBySlug: {
+        parameters: {
+            query?: never;
+            header?: never;
+            path: {
+                workspaceSlug: string;
+            };
+            cookie?: never;
+        };
+        requestBody?: never;
+        responses: {
+            /** @description Workspace found */
+            200: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["Workspace"];
+                };
+            };
+            /** @description Workspace not found */
+            404: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": {
+                        error?: string;
+                    };
+                };
+            };
+            /** @description Internal server error */
+            500: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": {
+                        error?: string;
+                    };
+                };
+            };
+        };
+    };
 }
 type WithRequired<T, K extends keyof T> = T & {
-  [P in K]-?: T[P];
+    [P in K]-?: T[P];
 };

--- a/e2e/api/schema.ts
+++ b/e2e/api/schema.ts
@@ -4,3680 +4,3690 @@
  */
 
 export interface paths {
-    "/api/v1/cloud-locations/{provider}": {
-        parameters: {
-            query?: never;
-            header?: never;
-            path?: never;
-            cookie?: never;
-        };
-        /**
-         * Get all regions for a specific cloud provider
-         * @description Returns geographic data for all regions of a specific cloud provider
-         */
-        get: operations["getCloudProviderRegions"];
-        put?: never;
-        post?: never;
-        delete?: never;
-        options?: never;
-        head?: never;
-        patch?: never;
-        trace?: never;
+  "/api/v1/cloud-locations/{provider}": {
+    parameters: {
+      query?: never;
+      header?: never;
+      path?: never;
+      cookie?: never;
     };
-    "/v1/deployment-version-channels": {
-        parameters: {
-            query?: never;
-            header?: never;
-            path?: never;
-            cookie?: never;
-        };
-        get?: never;
-        put?: never;
-        /** Create a deployment version channel */
-        post: operations["createDeploymentVersionChannel"];
-        delete?: never;
-        options?: never;
-        head?: never;
-        patch?: never;
-        trace?: never;
+    /**
+     * Get all regions for a specific cloud provider
+     * @description Returns geographic data for all regions of a specific cloud provider
+     */
+    get: operations["getCloudProviderRegions"];
+    put?: never;
+    post?: never;
+    delete?: never;
+    options?: never;
+    head?: never;
+    patch?: never;
+    trace?: never;
+  };
+  "/v1/deployment-version-channels": {
+    parameters: {
+      query?: never;
+      header?: never;
+      path?: never;
+      cookie?: never;
     };
-    "/v1/deployment-versions/{deploymentVersionId}": {
-        parameters: {
-            query?: never;
-            header?: never;
-            path?: never;
-            cookie?: never;
-        };
-        get?: never;
-        put?: never;
-        post?: never;
-        delete?: never;
-        options?: never;
-        head?: never;
-        /** Updates a deployment version */
-        patch: operations["updateDeploymentVersion"];
-        trace?: never;
+    get?: never;
+    put?: never;
+    /** Create a deployment version channel */
+    post: operations["createDeploymentVersionChannel"];
+    delete?: never;
+    options?: never;
+    head?: never;
+    patch?: never;
+    trace?: never;
+  };
+  "/v1/deployment-versions/{deploymentVersionId}": {
+    parameters: {
+      query?: never;
+      header?: never;
+      path?: never;
+      cookie?: never;
     };
-    "/v1/deployment-versions": {
-        parameters: {
-            query?: never;
-            header?: never;
-            path?: never;
-            cookie?: never;
-        };
-        get?: never;
-        put?: never;
-        /** Upserts a deployment version */
-        post: operations["upsertDeploymentVersion"];
-        delete?: never;
-        options?: never;
-        head?: never;
-        patch?: never;
-        trace?: never;
+    get?: never;
+    put?: never;
+    post?: never;
+    delete?: never;
+    options?: never;
+    head?: never;
+    /** Updates a deployment version */
+    patch: operations["updateDeploymentVersion"];
+    trace?: never;
+  };
+  "/v1/deployment-versions": {
+    parameters: {
+      query?: never;
+      header?: never;
+      path?: never;
+      cookie?: never;
     };
-    "/v1/deployments/{deploymentId}/deployment-version-channels/name/{name}": {
-        parameters: {
-            query?: never;
-            header?: never;
-            path?: never;
-            cookie?: never;
-        };
-        get?: never;
-        put?: never;
-        post?: never;
-        /** Delete a deployment version channel */
-        delete: operations["deleteDeploymentVersionChannel"];
-        options?: never;
-        head?: never;
-        patch?: never;
-        trace?: never;
+    get?: never;
+    put?: never;
+    /** Upserts a deployment version */
+    post: operations["upsertDeploymentVersion"];
+    delete?: never;
+    options?: never;
+    head?: never;
+    patch?: never;
+    trace?: never;
+  };
+  "/v1/deployments/{deploymentId}/deployment-version-channels/name/{name}": {
+    parameters: {
+      query?: never;
+      header?: never;
+      path?: never;
+      cookie?: never;
     };
-    "/v1/deployments/{deploymentId}": {
-        parameters: {
-            query?: never;
-            header?: never;
-            path?: never;
-            cookie?: never;
-        };
-        /** Get a deployment */
-        get: operations["getDeployment"];
-        put?: never;
-        post?: never;
-        /** Delete a deployment */
-        delete: operations["deleteDeployment"];
-        options?: never;
-        head?: never;
-        /** Update a deployment */
-        patch: operations["updateDeployment"];
-        trace?: never;
+    get?: never;
+    put?: never;
+    post?: never;
+    /** Delete a deployment version channel */
+    delete: operations["deleteDeploymentVersionChannel"];
+    options?: never;
+    head?: never;
+    patch?: never;
+    trace?: never;
+  };
+  "/v1/deployments/{deploymentId}": {
+    parameters: {
+      query?: never;
+      header?: never;
+      path?: never;
+      cookie?: never;
     };
-    "/v1/deployments/{deploymentId}/release-channels/name/{name}": {
-        parameters: {
-            query?: never;
-            header?: never;
-            path?: never;
-            cookie?: never;
-        };
-        get?: never;
-        put?: never;
-        post?: never;
-        /** Delete a release channel */
-        delete: operations["deleteReleaseChannel"];
-        options?: never;
-        head?: never;
-        patch?: never;
-        trace?: never;
+    /** Get a deployment */
+    get: operations["getDeployment"];
+    put?: never;
+    post?: never;
+    /** Delete a deployment */
+    delete: operations["deleteDeployment"];
+    options?: never;
+    head?: never;
+    /** Update a deployment */
+    patch: operations["updateDeployment"];
+    trace?: never;
+  };
+  "/v1/deployments/{deploymentId}/release-channels/name/{name}": {
+    parameters: {
+      query?: never;
+      header?: never;
+      path?: never;
+      cookie?: never;
     };
-    "/v1/deployments/{deploymentId}/resources": {
-        parameters: {
-            query?: never;
-            header?: never;
-            path?: never;
-            cookie?: never;
-        };
-        /** Get resources for a deployment */
-        get: operations["getResourcesForDeployment"];
-        put?: never;
-        post?: never;
-        delete?: never;
-        options?: never;
-        head?: never;
-        patch?: never;
-        trace?: never;
+    get?: never;
+    put?: never;
+    post?: never;
+    /** Delete a release channel */
+    delete: operations["deleteReleaseChannel"];
+    options?: never;
+    head?: never;
+    patch?: never;
+    trace?: never;
+  };
+  "/v1/deployments/{deploymentId}/resources": {
+    parameters: {
+      query?: never;
+      header?: never;
+      path?: never;
+      cookie?: never;
     };
-    "/v1/deployments": {
-        parameters: {
-            query?: never;
-            header?: never;
-            path?: never;
-            cookie?: never;
-        };
-        get?: never;
-        put?: never;
-        /** Create a deployment */
-        post: operations["createDeployment"];
-        delete?: never;
-        options?: never;
-        head?: never;
-        patch?: never;
-        trace?: never;
+    /** Get resources for a deployment */
+    get: operations["getResourcesForDeployment"];
+    put?: never;
+    post?: never;
+    delete?: never;
+    options?: never;
+    head?: never;
+    patch?: never;
+    trace?: never;
+  };
+  "/v1/deployments": {
+    parameters: {
+      query?: never;
+      header?: never;
+      path?: never;
+      cookie?: never;
     };
-    "/v1/environments/{environmentId}": {
-        parameters: {
-            query?: never;
-            header?: never;
-            path?: never;
-            cookie?: never;
-        };
-        /** Get an environment */
-        get: operations["getEnvironment"];
-        put?: never;
-        post?: never;
-        /** Delete an environment */
-        delete: operations["deleteEnvironment"];
-        options?: never;
-        head?: never;
-        patch?: never;
-        trace?: never;
+    get?: never;
+    put?: never;
+    /** Create a deployment */
+    post: operations["createDeployment"];
+    delete?: never;
+    options?: never;
+    head?: never;
+    patch?: never;
+    trace?: never;
+  };
+  "/v1/environments/{environmentId}": {
+    parameters: {
+      query?: never;
+      header?: never;
+      path?: never;
+      cookie?: never;
     };
-    "/v1/environments/{environmentId}/resources": {
-        parameters: {
-            query?: never;
-            header?: never;
-            path?: never;
-            cookie?: never;
-        };
-        /** Get resources for an environment */
-        get: operations["getResourcesForEnvironment"];
-        put?: never;
-        post?: never;
-        delete?: never;
-        options?: never;
-        head?: never;
-        patch?: never;
-        trace?: never;
+    /** Get an environment */
+    get: operations["getEnvironment"];
+    put?: never;
+    post?: never;
+    /** Delete an environment */
+    delete: operations["deleteEnvironment"];
+    options?: never;
+    head?: never;
+    patch?: never;
+    trace?: never;
+  };
+  "/v1/environments/{environmentId}/resources": {
+    parameters: {
+      query?: never;
+      header?: never;
+      path?: never;
+      cookie?: never;
     };
-    "/v1/environments": {
-        parameters: {
-            query?: never;
-            header?: never;
-            path?: never;
-            cookie?: never;
-        };
-        get?: never;
-        put?: never;
-        /** Create an environment */
-        post: operations["createEnvironment"];
-        delete?: never;
-        options?: never;
-        head?: never;
-        patch?: never;
-        trace?: never;
+    /** Get resources for an environment */
+    get: operations["getResourcesForEnvironment"];
+    put?: never;
+    post?: never;
+    delete?: never;
+    options?: never;
+    head?: never;
+    patch?: never;
+    trace?: never;
+  };
+  "/v1/environments": {
+    parameters: {
+      query?: never;
+      header?: never;
+      path?: never;
+      cookie?: never;
     };
-    "/v1/job-agents/{agentId}/jobs/running": {
-        parameters: {
-            query?: never;
-            header?: never;
-            path?: never;
-            cookie?: never;
-        };
-        /** Get a agents running jobs */
-        get: operations["getAgentRunningJobs"];
-        put?: never;
-        post?: never;
-        delete?: never;
-        options?: never;
-        head?: never;
-        patch?: never;
-        trace?: never;
+    get?: never;
+    put?: never;
+    /** Create an environment */
+    post: operations["createEnvironment"];
+    delete?: never;
+    options?: never;
+    head?: never;
+    patch?: never;
+    trace?: never;
+  };
+  "/v1/job-agents/{agentId}/jobs/running": {
+    parameters: {
+      query?: never;
+      header?: never;
+      path?: never;
+      cookie?: never;
     };
-    "/v1/job-agents/{agentId}/queue/acknowledge": {
-        parameters: {
-            query?: never;
-            header?: never;
-            path?: never;
-            cookie?: never;
-        };
-        get?: never;
-        put?: never;
-        /**
-         * Acknowledge a job for an agent
-         * @description Marks a job as acknowledged by the agent
-         */
-        post: operations["acknowledgeAgentJob"];
-        delete?: never;
-        options?: never;
-        head?: never;
-        patch?: never;
-        trace?: never;
+    /** Get a agents running jobs */
+    get: operations["getAgentRunningJobs"];
+    put?: never;
+    post?: never;
+    delete?: never;
+    options?: never;
+    head?: never;
+    patch?: never;
+    trace?: never;
+  };
+  "/v1/job-agents/{agentId}/queue/acknowledge": {
+    parameters: {
+      query?: never;
+      header?: never;
+      path?: never;
+      cookie?: never;
     };
-    "/v1/job-agents/{agentId}/queue/next": {
-        parameters: {
-            query?: never;
-            header?: never;
-            path?: never;
-            cookie?: never;
-        };
-        /** Get the next jobs */
-        get: operations["getNextJobs"];
-        put?: never;
-        post?: never;
-        delete?: never;
-        options?: never;
-        head?: never;
-        patch?: never;
-        trace?: never;
+    get?: never;
+    put?: never;
+    /**
+     * Acknowledge a job for an agent
+     * @description Marks a job as acknowledged by the agent
+     */
+    post: operations["acknowledgeAgentJob"];
+    delete?: never;
+    options?: never;
+    head?: never;
+    patch?: never;
+    trace?: never;
+  };
+  "/v1/job-agents/{agentId}/queue/next": {
+    parameters: {
+      query?: never;
+      header?: never;
+      path?: never;
+      cookie?: never;
     };
-    "/v1/job-agents/name": {
-        parameters: {
-            query?: never;
-            header?: never;
-            path?: never;
-            cookie?: never;
-        };
-        get?: never;
-        put?: never;
-        post?: never;
-        delete?: never;
-        options?: never;
-        head?: never;
-        /** Upserts the agent */
-        patch: operations["upsertJobAgent"];
-        trace?: never;
+    /** Get the next jobs */
+    get: operations["getNextJobs"];
+    put?: never;
+    post?: never;
+    delete?: never;
+    options?: never;
+    head?: never;
+    patch?: never;
+    trace?: never;
+  };
+  "/v1/job-agents/name": {
+    parameters: {
+      query?: never;
+      header?: never;
+      path?: never;
+      cookie?: never;
     };
-    "/v1/jobs/{jobId}/acknowledge": {
-        parameters: {
-            query?: never;
-            header?: never;
-            path?: never;
-            cookie?: never;
-        };
-        get?: never;
-        put?: never;
-        /** Acknowledge a job */
-        post: operations["acknowledgeJob"];
-        delete?: never;
-        options?: never;
-        head?: never;
-        patch?: never;
-        trace?: never;
+    get?: never;
+    put?: never;
+    post?: never;
+    delete?: never;
+    options?: never;
+    head?: never;
+    /** Upserts the agent */
+    patch: operations["upsertJobAgent"];
+    trace?: never;
+  };
+  "/v1/jobs/{jobId}/acknowledge": {
+    parameters: {
+      query?: never;
+      header?: never;
+      path?: never;
+      cookie?: never;
     };
-    "/v1/jobs/{jobId}": {
-        parameters: {
-            query?: never;
-            header?: never;
-            path?: never;
-            cookie?: never;
-        };
-        /** Get a Job */
-        get: operations["getJob"];
-        put?: never;
-        post?: never;
-        delete?: never;
-        options?: never;
-        head?: never;
-        /** Update a job */
-        patch: operations["updateJob"];
-        trace?: never;
+    get?: never;
+    put?: never;
+    /** Acknowledge a job */
+    post: operations["acknowledgeJob"];
+    delete?: never;
+    options?: never;
+    head?: never;
+    patch?: never;
+    trace?: never;
+  };
+  "/v1/jobs/{jobId}": {
+    parameters: {
+      query?: never;
+      header?: never;
+      path?: never;
+      cookie?: never;
     };
-    "/v1/policies/{policyId}": {
-        parameters: {
-            query?: never;
-            header?: never;
-            path?: never;
-            cookie?: never;
-        };
-        get?: never;
-        put?: never;
-        post?: never;
-        /** Delete a policy */
-        delete: operations["deletePolicy"];
-        options?: never;
-        head?: never;
-        patch?: never;
-        trace?: never;
+    /** Get a Job */
+    get: operations["getJob"];
+    put?: never;
+    post?: never;
+    delete?: never;
+    options?: never;
+    head?: never;
+    /** Update a job */
+    patch: operations["updateJob"];
+    trace?: never;
+  };
+  "/v1/policies/{policyId}": {
+    parameters: {
+      query?: never;
+      header?: never;
+      path?: never;
+      cookie?: never;
     };
-    "/v1/policies/{policyId}/release-targets": {
-        parameters: {
-            query?: never;
-            header?: never;
-            path?: never;
-            cookie?: never;
-        };
-        /** Get release targets for a policy */
-        get: operations["getReleaseTargetsForPolicy"];
-        put?: never;
-        post?: never;
-        delete?: never;
-        options?: never;
-        head?: never;
-        patch?: never;
-        trace?: never;
+    get?: never;
+    put?: never;
+    post?: never;
+    /** Delete a policy */
+    delete: operations["deletePolicy"];
+    options?: never;
+    head?: never;
+    patch?: never;
+    trace?: never;
+  };
+  "/v1/policies/{policyId}/release-targets": {
+    parameters: {
+      query?: never;
+      header?: never;
+      path?: never;
+      cookie?: never;
     };
-    "/v1/policies": {
-        parameters: {
-            query?: never;
-            header?: never;
-            path?: never;
-            cookie?: never;
-        };
-        get?: never;
-        put?: never;
-        /** Upsert a policy */
-        post: operations["upsertPolicy"];
-        delete?: never;
-        options?: never;
-        head?: never;
-        patch?: never;
-        trace?: never;
+    /** Get release targets for a policy */
+    get: operations["getReleaseTargetsForPolicy"];
+    put?: never;
+    post?: never;
+    delete?: never;
+    options?: never;
+    head?: never;
+    patch?: never;
+    trace?: never;
+  };
+  "/v1/policies": {
+    parameters: {
+      query?: never;
+      header?: never;
+      path?: never;
+      cookie?: never;
     };
-    "/v1/relationship/job-to-resource": {
-        parameters: {
-            query?: never;
-            header?: never;
-            path?: never;
-            cookie?: never;
-        };
-        get?: never;
-        put?: never;
-        /** Create a relationship between a job and a resource */
-        post: operations["createJobToResourceRelationship"];
-        delete?: never;
-        options?: never;
-        head?: never;
-        patch?: never;
-        trace?: never;
+    get?: never;
+    put?: never;
+    /** Upsert a policy */
+    post: operations["upsertPolicy"];
+    delete?: never;
+    options?: never;
+    head?: never;
+    patch?: never;
+    trace?: never;
+  };
+  "/v1/relationship/job-to-resource": {
+    parameters: {
+      query?: never;
+      header?: never;
+      path?: never;
+      cookie?: never;
     };
-    "/v1/relationship/resource-to-resource": {
-        parameters: {
-            query?: never;
-            header?: never;
-            path?: never;
-            cookie?: never;
-        };
-        get?: never;
-        put?: never;
-        /** Create a relationship between two resources */
-        post: operations["createResourceToResourceRelationship"];
-        delete?: never;
-        options?: never;
-        head?: never;
-        patch?: never;
-        trace?: never;
+    get?: never;
+    put?: never;
+    /** Create a relationship between a job and a resource */
+    post: operations["createJobToResourceRelationship"];
+    delete?: never;
+    options?: never;
+    head?: never;
+    patch?: never;
+    trace?: never;
+  };
+  "/v1/relationship/resource-to-resource": {
+    parameters: {
+      query?: never;
+      header?: never;
+      path?: never;
+      cookie?: never;
     };
-    "/v1/release-channels": {
-        parameters: {
-            query?: never;
-            header?: never;
-            path?: never;
-            cookie?: never;
-        };
-        get?: never;
-        put?: never;
-        /** Create a release channel */
-        post: operations["createReleaseChannel"];
-        delete?: never;
-        options?: never;
-        head?: never;
-        patch?: never;
-        trace?: never;
+    get?: never;
+    put?: never;
+    /** Create a relationship between two resources */
+    post: operations["createResourceToResourceRelationship"];
+    delete?: never;
+    options?: never;
+    head?: never;
+    patch?: never;
+    trace?: never;
+  };
+  "/v1/release-channels": {
+    parameters: {
+      query?: never;
+      header?: never;
+      path?: never;
+      cookie?: never;
     };
-    "/v1/releases/{releaseId}": {
-        parameters: {
-            query?: never;
-            header?: never;
-            path?: never;
-            cookie?: never;
-        };
-        get?: never;
-        put?: never;
-        post?: never;
-        delete?: never;
-        options?: never;
-        head?: never;
-        /** Updates a release */
-        patch: operations["updateRelease"];
-        trace?: never;
+    get?: never;
+    put?: never;
+    /** Create a release channel */
+    post: operations["createReleaseChannel"];
+    delete?: never;
+    options?: never;
+    head?: never;
+    patch?: never;
+    trace?: never;
+  };
+  "/v1/releases/{releaseId}": {
+    parameters: {
+      query?: never;
+      header?: never;
+      path?: never;
+      cookie?: never;
     };
-    "/v1/releases": {
-        parameters: {
-            query?: never;
-            header?: never;
-            path?: never;
-            cookie?: never;
-        };
-        get?: never;
-        put?: never;
-        /** Upserts a release */
-        post: operations["upsertRelease"];
-        delete?: never;
-        options?: never;
-        head?: never;
-        patch?: never;
-        trace?: never;
+    get?: never;
+    put?: never;
+    post?: never;
+    delete?: never;
+    options?: never;
+    head?: never;
+    /** Updates a release */
+    patch: operations["updateRelease"];
+    trace?: never;
+  };
+  "/v1/releases": {
+    parameters: {
+      query?: never;
+      header?: never;
+      path?: never;
+      cookie?: never;
     };
-    "/v1/resource-providers/{providerId}/set": {
-        parameters: {
-            query?: never;
-            header?: never;
-            path?: never;
-            cookie?: never;
-        };
-        get?: never;
-        put?: never;
-        post?: never;
-        delete?: never;
-        options?: never;
-        head?: never;
-        /** Sets the resource for a provider. */
-        patch: operations["setResourceProvidersResources"];
-        trace?: never;
+    get?: never;
+    put?: never;
+    /** Upserts a release */
+    post: operations["upsertRelease"];
+    delete?: never;
+    options?: never;
+    head?: never;
+    patch?: never;
+    trace?: never;
+  };
+  "/v1/resource-providers/{providerId}/set": {
+    parameters: {
+      query?: never;
+      header?: never;
+      path?: never;
+      cookie?: never;
     };
-    "/v1/resource-schemas": {
-        parameters: {
-            query?: never;
-            header?: never;
-            path?: never;
-            cookie?: never;
-        };
-        get?: never;
-        put?: never;
-        /** Create a resource schema */
-        post: operations["createResourceSchema"];
-        delete?: never;
-        options?: never;
-        head?: never;
-        patch?: never;
-        trace?: never;
+    get?: never;
+    put?: never;
+    post?: never;
+    delete?: never;
+    options?: never;
+    head?: never;
+    /** Sets the resource for a provider. */
+    patch: operations["setResourceProvidersResources"];
+    trace?: never;
+  };
+  "/v1/resource-schemas": {
+    parameters: {
+      query?: never;
+      header?: never;
+      path?: never;
+      cookie?: never;
     };
-    "/v1/resource-schemas/{schemaId}": {
-        parameters: {
-            query?: never;
-            header?: never;
-            path?: never;
-            cookie?: never;
-        };
-        get?: never;
-        put?: never;
-        post?: never;
-        /** Delete a resource schema */
-        delete: operations["deleteResourceSchema"];
-        options?: never;
-        head?: never;
-        patch?: never;
-        trace?: never;
+    get?: never;
+    put?: never;
+    /** Create a resource schema */
+    post: operations["createResourceSchema"];
+    delete?: never;
+    options?: never;
+    head?: never;
+    patch?: never;
+    trace?: never;
+  };
+  "/v1/resource-schemas/{schemaId}": {
+    parameters: {
+      query?: never;
+      header?: never;
+      path?: never;
+      cookie?: never;
     };
-    "/v1/resources/{resourceId}": {
-        parameters: {
-            query?: never;
-            header?: never;
-            path?: never;
-            cookie?: never;
-        };
-        /** Get a resource */
-        get: operations["getResource"];
-        put?: never;
-        post?: never;
-        /** Delete a resource */
-        delete: operations["deleteResource"];
-        options?: never;
-        head?: never;
-        /** Update a resource */
-        patch: operations["updateResource"];
-        trace?: never;
+    get?: never;
+    put?: never;
+    post?: never;
+    /** Delete a resource schema */
+    delete: operations["deleteResourceSchema"];
+    options?: never;
+    head?: never;
+    patch?: never;
+    trace?: never;
+  };
+  "/v1/resources/{resourceId}": {
+    parameters: {
+      query?: never;
+      header?: never;
+      path?: never;
+      cookie?: never;
     };
-    "/v1/resources": {
-        parameters: {
-            query?: never;
-            header?: never;
-            path?: never;
-            cookie?: never;
-        };
-        get?: never;
-        put?: never;
-        /** Create or update a resource */
-        post: operations["upsertResource"];
-        delete?: never;
-        options?: never;
-        head?: never;
-        patch?: never;
-        trace?: never;
+    /** Get a resource */
+    get: operations["getResource"];
+    put?: never;
+    post?: never;
+    /** Delete a resource */
+    delete: operations["deleteResource"];
+    options?: never;
+    head?: never;
+    /** Update a resource */
+    patch: operations["updateResource"];
+    trace?: never;
+  };
+  "/v1/resources": {
+    parameters: {
+      query?: never;
+      header?: never;
+      path?: never;
+      cookie?: never;
     };
-    "/v1/systems/{systemId}/environments/{name}": {
-        parameters: {
-            query?: never;
-            header?: never;
-            path?: never;
-            cookie?: never;
-        };
-        get?: never;
-        put?: never;
-        post?: never;
-        /** Delete an environment */
-        delete: operations["deleteEnvironmentByName"];
-        options?: never;
-        head?: never;
-        patch?: never;
-        trace?: never;
+    get?: never;
+    put?: never;
+    /** Create or update a resource */
+    post: operations["upsertResource"];
+    delete?: never;
+    options?: never;
+    head?: never;
+    patch?: never;
+    trace?: never;
+  };
+  "/v1/systems/{systemId}/environments/{name}": {
+    parameters: {
+      query?: never;
+      header?: never;
+      path?: never;
+      cookie?: never;
     };
-    "/v1/systems/{systemId}": {
-        parameters: {
-            query?: never;
-            header?: never;
-            path?: never;
-            cookie?: never;
-        };
-        /** Get a system */
-        get: operations["getSystem"];
-        put?: never;
-        post?: never;
-        /** Delete a system */
-        delete: operations["deleteSystem"];
-        options?: never;
-        head?: never;
-        /** Update a system */
-        patch: operations["updateSystem"];
-        trace?: never;
+    get?: never;
+    put?: never;
+    post?: never;
+    /** Delete an environment */
+    delete: operations["deleteEnvironmentByName"];
+    options?: never;
+    head?: never;
+    patch?: never;
+    trace?: never;
+  };
+  "/v1/systems/{systemId}": {
+    parameters: {
+      query?: never;
+      header?: never;
+      path?: never;
+      cookie?: never;
     };
-    "/v1/systems": {
-        parameters: {
-            query?: never;
-            header?: never;
-            path?: never;
-            cookie?: never;
-        };
-        get?: never;
-        put?: never;
-        /** Create a system */
-        post: operations["createSystem"];
-        delete?: never;
-        options?: never;
-        head?: never;
-        patch?: never;
-        trace?: never;
+    /** Get a system */
+    get: operations["getSystem"];
+    put?: never;
+    post?: never;
+    /** Delete a system */
+    delete: operations["deleteSystem"];
+    options?: never;
+    head?: never;
+    /** Update a system */
+    patch: operations["updateSystem"];
+    trace?: never;
+  };
+  "/v1/systems": {
+    parameters: {
+      query?: never;
+      header?: never;
+      path?: never;
+      cookie?: never;
     };
-    "/v1/workspaces/{workspaceId}/deployments": {
-        parameters: {
-            query?: never;
-            header?: never;
-            path: {
-                /** @description The ID of the workspace */
-                workspaceId: string;
-            };
-            cookie?: never;
-        };
-        /** List all deployments */
-        get: operations["listDeployments"];
-        put?: never;
-        post?: never;
-        delete?: never;
-        options?: never;
-        head?: never;
-        patch?: never;
-        trace?: never;
+    get?: never;
+    put?: never;
+    /** Create a system */
+    post: operations["createSystem"];
+    delete?: never;
+    options?: never;
+    head?: never;
+    patch?: never;
+    trace?: never;
+  };
+  "/v1/workspaces/{workspaceId}/deployments": {
+    parameters: {
+      query?: never;
+      header?: never;
+      path: {
+        /** @description The ID of the workspace */
+        workspaceId: string;
+      };
+      cookie?: never;
     };
-    "/v1/workspaces/{workspaceId}/environments": {
-        parameters: {
-            query?: never;
-            header?: never;
-            path: {
-                /** @description The ID of the workspace */
-                workspaceId: string;
-            };
-            cookie?: never;
-        };
-        /** List all environments */
-        get: operations["listEnvironments"];
-        put?: never;
-        post?: never;
-        delete?: never;
-        options?: never;
-        head?: never;
-        patch?: never;
-        trace?: never;
+    /** List all deployments */
+    get: operations["listDeployments"];
+    put?: never;
+    post?: never;
+    delete?: never;
+    options?: never;
+    head?: never;
+    patch?: never;
+    trace?: never;
+  };
+  "/v1/workspaces/{workspaceId}/environments": {
+    parameters: {
+      query?: never;
+      header?: never;
+      path: {
+        /** @description The ID of the workspace */
+        workspaceId: string;
+      };
+      cookie?: never;
     };
-    "/v1/workspaces/{workspaceId}": {
-        parameters: {
-            query?: never;
-            header?: never;
-            path?: never;
-            cookie?: never;
-        };
-        /** Get a workspace */
-        get: operations["getWorkspace"];
-        put?: never;
-        post?: never;
-        delete?: never;
-        options?: never;
-        head?: never;
-        patch?: never;
-        trace?: never;
+    /** List all environments */
+    get: operations["listEnvironments"];
+    put?: never;
+    post?: never;
+    delete?: never;
+    options?: never;
+    head?: never;
+    patch?: never;
+    trace?: never;
+  };
+  "/v1/workspaces/{workspaceId}": {
+    parameters: {
+      query?: never;
+      header?: never;
+      path?: never;
+      cookie?: never;
     };
-    "/v1/workspaces/{workspaceId}/policies/{name}": {
-        parameters: {
-            query?: never;
-            header?: never;
-            path?: never;
-            cookie?: never;
-        };
-        get?: never;
-        put?: never;
-        post?: never;
-        /** Delete a policy by name */
-        delete: operations["deletePolicyByName"];
-        options?: never;
-        head?: never;
-        patch?: never;
-        trace?: never;
+    /** Get a workspace */
+    get: operations["getWorkspace"];
+    put?: never;
+    post?: never;
+    delete?: never;
+    options?: never;
+    head?: never;
+    patch?: never;
+    trace?: never;
+  };
+  "/v1/workspaces/{workspaceId}/policies/{name}": {
+    parameters: {
+      query?: never;
+      header?: never;
+      path?: never;
+      cookie?: never;
     };
-    "/v1/workspaces/{workspaceId}/resource-providers/name/{name}": {
-        parameters: {
-            query?: never;
-            header?: never;
-            path?: never;
-            cookie?: never;
-        };
-        /** Upserts a resource provider. */
-        get: operations["upsertResourceProvider"];
-        put?: never;
-        post?: never;
-        delete?: never;
-        options?: never;
-        head?: never;
-        patch?: never;
-        trace?: never;
+    get?: never;
+    put?: never;
+    post?: never;
+    /** Delete a policy by name */
+    delete: operations["deletePolicyByName"];
+    options?: never;
+    head?: never;
+    patch?: never;
+    trace?: never;
+  };
+  "/v1/workspaces/{workspaceId}/resource-providers/name/{name}": {
+    parameters: {
+      query?: never;
+      header?: never;
+      path?: never;
+      cookie?: never;
     };
-    "/v1/workspaces/{workspaceId}/resources/identifier/{identifier}": {
-        parameters: {
-            query?: never;
-            header?: never;
-            path?: never;
-            cookie?: never;
-        };
-        /** Get a resource by identifier */
-        get: operations["getResourceByIdentifier"];
-        put?: never;
-        post?: never;
-        /** Delete a resource by identifier */
-        delete: operations["deleteResourceByIdentifier"];
-        options?: never;
-        head?: never;
-        patch?: never;
-        trace?: never;
+    /** Upserts a resource provider. */
+    get: operations["upsertResourceProvider"];
+    put?: never;
+    post?: never;
+    delete?: never;
+    options?: never;
+    head?: never;
+    patch?: never;
+    trace?: never;
+  };
+  "/v1/workspaces/{workspaceId}/resources/identifier/{identifier}": {
+    parameters: {
+      query?: never;
+      header?: never;
+      path?: never;
+      cookie?: never;
     };
-    "/v1/workspaces/{workspaceId}/resources": {
-        parameters: {
-            query?: never;
-            header?: never;
-            path: {
-                /** @description The ID of the workspace */
-                workspaceId: string;
-            };
-            cookie?: never;
-        };
-        /** List all resources */
-        get: operations["listResources"];
-        put?: never;
-        post?: never;
-        delete?: never;
-        options?: never;
-        head?: never;
-        patch?: never;
-        trace?: never;
+    /** Get a resource by identifier */
+    get: operations["getResourceByIdentifier"];
+    put?: never;
+    post?: never;
+    /** Delete a resource by identifier */
+    delete: operations["deleteResourceByIdentifier"];
+    options?: never;
+    head?: never;
+    patch?: never;
+    trace?: never;
+  };
+  "/v1/workspaces/{workspaceId}/resources": {
+    parameters: {
+      query?: never;
+      header?: never;
+      path: {
+        /** @description The ID of the workspace */
+        workspaceId: string;
+      };
+      cookie?: never;
     };
-    "/v1/workspaces/{workspaceId}/systems": {
-        parameters: {
-            query?: never;
-            header?: never;
-            path: {
-                /** @description The ID of the workspace */
-                workspaceId: string;
-            };
-            cookie?: never;
-        };
-        /** List all systems */
-        get: operations["listSystems"];
-        put?: never;
-        post?: never;
-        delete?: never;
-        options?: never;
-        head?: never;
-        patch?: never;
-        trace?: never;
+    /** List all resources */
+    get: operations["listResources"];
+    put?: never;
+    post?: never;
+    delete?: never;
+    options?: never;
+    head?: never;
+    patch?: never;
+    trace?: never;
+  };
+  "/v1/workspaces/{workspaceId}/systems": {
+    parameters: {
+      query?: never;
+      header?: never;
+      path: {
+        /** @description The ID of the workspace */
+        workspaceId: string;
+      };
+      cookie?: never;
     };
-    "/v1/workspaces/slug/{workspaceSlug}": {
-        parameters: {
-            query?: never;
-            header?: never;
-            path?: never;
-            cookie?: never;
-        };
-        /** Get a workspace by slug */
-        get: operations["getWorkspaceBySlug"];
-        put?: never;
-        post?: never;
-        delete?: never;
-        options?: never;
-        head?: never;
-        patch?: never;
-        trace?: never;
+    /** List all systems */
+    get: operations["listSystems"];
+    put?: never;
+    post?: never;
+    delete?: never;
+    options?: never;
+    head?: never;
+    patch?: never;
+    trace?: never;
+  };
+  "/v1/workspaces/slug/{workspaceSlug}": {
+    parameters: {
+      query?: never;
+      header?: never;
+      path?: never;
+      cookie?: never;
     };
+    /** Get a workspace by slug */
+    get: operations["getWorkspaceBySlug"];
+    put?: never;
+    post?: never;
+    delete?: never;
+    options?: never;
+    head?: never;
+    patch?: never;
+    trace?: never;
+  };
 }
 export type webhooks = Record<string, never>;
 export interface components {
-    schemas: {
-        CloudRegionGeoData: {
-            /**
-             * @description Timezone of the region in UTC format
-             * @example UTC+1
-             */
-            timezone: string;
-            /**
-             * Format: float
-             * @description Latitude coordinate for the region
-             * @example 50.1109
-             */
-            latitude: number;
-            /**
-             * Format: float
-             * @description Longitude coordinate for the region
-             * @example 8.6821
-             */
-            longitude: number;
-        };
-        JobWithTrigger: components["schemas"]["Job"] & {
-            release?: components["schemas"]["Release"];
-            deploymentVersion?: components["schemas"]["DeploymentVersion"];
-            deployment?: components["schemas"]["Deployment"];
-            runbook?: components["schemas"]["Runbook"];
-            resource?: components["schemas"]["Resource"];
-            environment?: components["schemas"]["Environment"];
-            variables: Record<string, never>;
-            approval?: {
-                id: string;
-                /** @enum {string} */
-                status: "pending" | "approved" | "rejected";
-                /** @description Null when status is pending, contains approver details when approved or rejected */
-                approver?: {
-                    id: string;
-                    name: string;
-                } | null;
-            } | null;
-        };
-        Workspace: {
-            /**
-             * Format: uuid
-             * @description The workspace ID
-             */
-            id: string;
-            /** @description The name of the workspace */
-            name: string;
-            /** @description The slug of the workspace */
-            slug: string;
-            /**
-             * @description The email of the Google service account attached to the workspace
-             * @example ctrlplane@ctrlplane-workspace.iam.gserviceaccount.com
-             */
-            googleServiceAccountEmail?: string | null;
-            /**
-             * @description The ARN of the AWS role attached to the workspace
-             * @example arn:aws:iam::123456789012:role/ctrlplane-workspace-role
-             */
-            awsRoleArn?: string | null;
-        };
-        System: {
-            /**
-             * Format: uuid
-             * @description The system ID
-             */
-            id: string;
-            /**
-             * Format: uuid
-             * @description The workspace ID of the system
-             */
-            workspaceId: string;
-            /** @description The name of the system */
-            name: string;
-            /** @description The slug of the system */
-            slug: string;
-            /** @description The description of the system */
-            description?: string;
-        };
-        Deployment: {
-            /** Format: uuid */
-            id: string;
-            name: string;
-            slug: string;
-            description: string;
-            /** Format: uuid */
-            systemId: string;
-            /** Format: uuid */
-            jobAgentId?: string | null;
-            jobAgentConfig: {
-                [key: string]: unknown;
-            };
-            retryCount?: number;
-            timeout?: number | null;
-        };
-        /** @description Schema for updating a deployment (all fields optional) */
-        UpdateDeployment: {
-            [key: string]: unknown;
-        } & (WithRequired<components["schemas"]["Deployment"], "id"> & {
-            [key: string]: unknown;
-        });
-        Release: {
-            /** Format: uuid */
-            id: string;
-            name: string;
-            version: string;
-            config: {
-                [key: string]: unknown;
-            };
-            jobAgentConfig: {
-                [key: string]: unknown;
-            };
-            /** Format: uuid */
-            deploymentId: string;
-            /** Format: date-time */
-            createdAt: string;
-            metadata?: {
-                [key: string]: unknown;
-            };
-        };
-        DeploymentVersion: {
-            /** Format: uuid */
-            id: string;
-            name: string;
-            tag: string;
-            config: {
-                [key: string]: unknown;
-            };
-            jobAgentConfig: {
-                [key: string]: unknown;
-            };
-            /** Format: uuid */
-            deploymentId: string;
-            /** Format: date-time */
-            createdAt: string;
-            metadata?: {
-                [key: string]: unknown;
-            };
-        };
-        Policy: {
-            /**
-             * Format: uuid
-             * @description The policy ID
-             */
-            id: string;
-            /**
-             * Format: uuid
-             * @description The system ID
-             */
-            systemId: string;
-            /** @description The name of the policy */
-            name: string;
-            /** @description The description of the policy */
-            description?: string | null;
-            /**
-             * @description The approval requirement of the policy
-             * @enum {string}
-             */
-            approvalRequirement: "manual" | "automatic";
-            /**
-             * @description If a policy depends on an environment, whether or not the policy requires all, some, or optional successful releases in the environment
-             * @enum {string}
-             */
-            successType: "some" | "all" | "optional";
-            /** @description If a policy depends on an environment, the minimum number of successful releases in the environment */
-            successMinimum: number;
-            /** @description The maximum number of concurrent releases in the environment */
-            concurrencyLimit?: number | null;
-            /** @description The duration of the rollout in milliseconds */
-            rolloutDuration: number;
-            /** @description The minimum interval between releases in milliseconds */
-            minimumReleaseInterval: number;
-            /**
-             * @description If a new release is created, whether it will wait for the current release to finish before starting, or cancel the current release
-             * @enum {string}
-             */
-            releaseSequencing: "wait" | "cancel";
-        };
-        Environment: {
-            /** Format: uuid */
-            id: string;
-            /** Format: uuid */
-            systemId: string;
-            name: string;
-            description?: string;
-            /** Format: uuid */
-            policyId?: string | null;
-            resourceSelector?: {
-                [key: string]: unknown;
-            } | null;
-            /**
-             * @description The directory path of the environment
-             * @default
-             * @example my/env/path
-             */
-            directory: string;
-            /** Format: date-time */
-            createdAt: string;
-            metadata?: {
-                [key: string]: string;
-            };
-            policy?: components["schemas"]["Policy"];
-        };
-        Runbook: {
-            /** Format: uuid */
-            id: string;
-            name: string;
-            /** Format: uuid */
-            systemId: string;
-            /** Format: uuid */
-            jobAgentId: string;
-        };
-        Resource: {
-            /** Format: uuid */
-            id: string;
-            name: string;
-            version: string;
-            kind: string;
-            identifier: string;
-            config: {
-                [key: string]: unknown;
-            };
-            metadata: {
-                [key: string]: unknown;
-            };
-            /** Format: date-time */
-            createdAt: string;
-            /** Format: date-time */
-            updatedAt: string;
-            /** Format: uuid */
-            workspaceId: string;
-        };
-        /** @enum {string} */
-        JobStatus: "successful" | "cancelled" | "skipped" | "in_progress" | "action_required" | "pending" | "failure" | "invalid_job_agent" | "invalid_integration" | "external_run_not_found";
-        Job: {
-            /** Format: uuid */
-            id: string;
-            status: components["schemas"]["JobStatus"];
-            /** @description External job identifier (e.g. GitHub workflow run ID) */
-            externalId?: string | null;
-            /** Format: date-time */
-            createdAt: string;
-            /** Format: date-time */
-            updatedAt: string;
-            /** Format: date-time */
-            startedAt?: string | null;
-            /** Format: date-time */
-            completedAt?: string | null;
-            /** Format: uuid */
-            jobAgentId?: string;
-            /** @description Configuration for the Job Agent */
-            jobAgentConfig: {
-                [key: string]: unknown;
-            };
-            message?: string;
-            reason?: string;
-        };
-        Variable: {
-            key: string;
-            value: string | number | boolean;
-            sensitive?: boolean;
-        };
-        PolicyTarget: {
-            deploymentSelector?: {
-                [key: string]: unknown;
-            } | null;
-            environmentSelector?: {
-                [key: string]: unknown;
-            } | null;
-            resourceSelector?: {
-                [key: string]: unknown;
-            } | null;
-        };
-        DenyWindow: {
-            timeZone: string;
-            rrule: {
-                [key: string]: unknown;
-            };
-            /** Format: date-time */
-            dtend?: string;
-        };
-        DeploymentVersionSelector: {
-            name: string;
-            deploymentVersionSelector: {
-                [key: string]: unknown;
-            };
-            description?: string;
-        };
-        VersionAnyApproval: {
-            requiredApprovalsCount: number;
-        };
-        VersionUserApproval: {
-            userId: string;
-        };
-        VersionRoleApproval: {
-            roleId: string;
-            requiredApprovalsCount: number;
-        };
-        Policy1: {
-            /** Format: uuid */
-            id: string;
-            name: string;
-            description?: string;
-            priority: number;
-            /** Format: date-time */
-            createdAt: string;
-            enabled: boolean;
-            /** Format: uuid */
-            workspaceId: string;
-            targets: components["schemas"]["PolicyTarget"][];
-            denyWindows: components["schemas"]["DenyWindow"][];
-            deploymentVersionSelector?: components["schemas"]["DeploymentVersionSelector"];
-            versionAnyApprovals?: components["schemas"]["VersionAnyApproval"][];
-            versionUserApprovals: components["schemas"]["VersionUserApproval"][];
-            versionRoleApprovals: components["schemas"]["VersionRoleApproval"][];
-        };
+  schemas: {
+    CloudRegionGeoData: {
+      /**
+       * @description Timezone of the region in UTC format
+       * @example UTC+1
+       */
+      timezone: string;
+      /**
+       * Format: float
+       * @description Latitude coordinate for the region
+       * @example 50.1109
+       */
+      latitude: number;
+      /**
+       * Format: float
+       * @description Longitude coordinate for the region
+       * @example 8.6821
+       */
+      longitude: number;
     };
-    responses: never;
-    parameters: never;
-    requestBodies: never;
-    headers: never;
-    pathItems: never;
+    JobWithTrigger: components["schemas"]["Job"] & {
+      release?: components["schemas"]["Release"];
+      deploymentVersion?: components["schemas"]["DeploymentVersion"];
+      deployment?: components["schemas"]["Deployment"];
+      runbook?: components["schemas"]["Runbook"];
+      resource?: components["schemas"]["Resource"];
+      environment?: components["schemas"]["Environment"];
+      variables: Record<string, never>;
+      approval?: {
+        id: string;
+        /** @enum {string} */
+        status: "pending" | "approved" | "rejected";
+        /** @description Null when status is pending, contains approver details when approved or rejected */
+        approver?: {
+          id: string;
+          name: string;
+        } | null;
+      } | null;
+    };
+    Workspace: {
+      /**
+       * Format: uuid
+       * @description The workspace ID
+       */
+      id: string;
+      /** @description The name of the workspace */
+      name: string;
+      /** @description The slug of the workspace */
+      slug: string;
+      /**
+       * @description The email of the Google service account attached to the workspace
+       * @example ctrlplane@ctrlplane-workspace.iam.gserviceaccount.com
+       */
+      googleServiceAccountEmail?: string | null;
+      /**
+       * @description The ARN of the AWS role attached to the workspace
+       * @example arn:aws:iam::123456789012:role/ctrlplane-workspace-role
+       */
+      awsRoleArn?: string | null;
+    };
+    System: {
+      /**
+       * Format: uuid
+       * @description The system ID
+       */
+      id: string;
+      /**
+       * Format: uuid
+       * @description The workspace ID of the system
+       */
+      workspaceId: string;
+      /** @description The name of the system */
+      name: string;
+      /** @description The slug of the system */
+      slug: string;
+      /** @description The description of the system */
+      description?: string;
+    };
+    Deployment: {
+      /** Format: uuid */
+      id: string;
+      name: string;
+      slug: string;
+      description: string;
+      /** Format: uuid */
+      systemId: string;
+      /** Format: uuid */
+      jobAgentId?: string | null;
+      jobAgentConfig: {
+        [key: string]: unknown;
+      };
+      retryCount?: number;
+      timeout?: number | null;
+    };
+    /** @description Schema for updating a deployment (all fields optional) */
+    UpdateDeployment: {
+      [key: string]: unknown;
+    } & (WithRequired<components["schemas"]["Deployment"], "id"> & {
+      [key: string]: unknown;
+    });
+    Release: {
+      /** Format: uuid */
+      id: string;
+      name: string;
+      version: string;
+      config: {
+        [key: string]: unknown;
+      };
+      jobAgentConfig: {
+        [key: string]: unknown;
+      };
+      /** Format: uuid */
+      deploymentId: string;
+      /** Format: date-time */
+      createdAt: string;
+      metadata?: {
+        [key: string]: unknown;
+      };
+    };
+    DeploymentVersion: {
+      /** Format: uuid */
+      id: string;
+      name: string;
+      tag: string;
+      config: {
+        [key: string]: unknown;
+      };
+      jobAgentConfig: {
+        [key: string]: unknown;
+      };
+      /** Format: uuid */
+      deploymentId: string;
+      /** Format: date-time */
+      createdAt: string;
+      metadata?: {
+        [key: string]: unknown;
+      };
+    };
+    Policy: {
+      /**
+       * Format: uuid
+       * @description The policy ID
+       */
+      id: string;
+      /**
+       * Format: uuid
+       * @description The system ID
+       */
+      systemId: string;
+      /** @description The name of the policy */
+      name: string;
+      /** @description The description of the policy */
+      description?: string | null;
+      /**
+       * @description The approval requirement of the policy
+       * @enum {string}
+       */
+      approvalRequirement: "manual" | "automatic";
+      /**
+       * @description If a policy depends on an environment, whether or not the policy requires all, some, or optional successful releases in the environment
+       * @enum {string}
+       */
+      successType: "some" | "all" | "optional";
+      /** @description If a policy depends on an environment, the minimum number of successful releases in the environment */
+      successMinimum: number;
+      /** @description The maximum number of concurrent releases in the environment */
+      concurrencyLimit?: number | null;
+      /** @description The duration of the rollout in milliseconds */
+      rolloutDuration: number;
+      /** @description The minimum interval between releases in milliseconds */
+      minimumReleaseInterval: number;
+      /**
+       * @description If a new release is created, whether it will wait for the current release to finish before starting, or cancel the current release
+       * @enum {string}
+       */
+      releaseSequencing: "wait" | "cancel";
+    };
+    Environment: {
+      /** Format: uuid */
+      id: string;
+      /** Format: uuid */
+      systemId: string;
+      name: string;
+      description?: string;
+      /** Format: uuid */
+      policyId?: string | null;
+      resourceSelector?: {
+        [key: string]: unknown;
+      } | null;
+      /**
+       * @description The directory path of the environment
+       * @default
+       * @example my/env/path
+       */
+      directory: string;
+      /** Format: date-time */
+      createdAt: string;
+      metadata?: {
+        [key: string]: string;
+      };
+      policy?: components["schemas"]["Policy"];
+    };
+    Runbook: {
+      /** Format: uuid */
+      id: string;
+      name: string;
+      /** Format: uuid */
+      systemId: string;
+      /** Format: uuid */
+      jobAgentId: string;
+    };
+    Resource: {
+      /** Format: uuid */
+      id: string;
+      name: string;
+      version: string;
+      kind: string;
+      identifier: string;
+      config: {
+        [key: string]: unknown;
+      };
+      metadata: {
+        [key: string]: unknown;
+      };
+      /** Format: date-time */
+      createdAt: string;
+      /** Format: date-time */
+      updatedAt: string;
+      /** Format: uuid */
+      workspaceId: string;
+    };
+    /** @enum {string} */
+    JobStatus:
+      | "successful"
+      | "cancelled"
+      | "skipped"
+      | "in_progress"
+      | "action_required"
+      | "pending"
+      | "failure"
+      | "invalid_job_agent"
+      | "invalid_integration"
+      | "external_run_not_found";
+    Job: {
+      /** Format: uuid */
+      id: string;
+      status: components["schemas"]["JobStatus"];
+      /** @description External job identifier (e.g. GitHub workflow run ID) */
+      externalId?: string | null;
+      /** Format: date-time */
+      createdAt: string;
+      /** Format: date-time */
+      updatedAt: string;
+      /** Format: date-time */
+      startedAt?: string | null;
+      /** Format: date-time */
+      completedAt?: string | null;
+      /** Format: uuid */
+      jobAgentId?: string;
+      /** @description Configuration for the Job Agent */
+      jobAgentConfig: {
+        [key: string]: unknown;
+      };
+      message?: string;
+      reason?: string;
+    };
+    Variable: {
+      key: string;
+      value: string | number | boolean;
+      sensitive?: boolean;
+    };
+    PolicyTarget: {
+      deploymentSelector?: {
+        [key: string]: unknown;
+      } | null;
+      environmentSelector?: {
+        [key: string]: unknown;
+      } | null;
+      resourceSelector?: {
+        [key: string]: unknown;
+      } | null;
+    };
+    DenyWindow: {
+      timeZone: string;
+      rrule: {
+        [key: string]: unknown;
+      };
+      /** Format: date-time */
+      dtend?: string;
+    };
+    DeploymentVersionSelector: {
+      name: string;
+      deploymentVersionSelector: {
+        [key: string]: unknown;
+      };
+      description?: string;
+    };
+    VersionAnyApproval: {
+      requiredApprovalsCount: number;
+    };
+    VersionUserApproval: {
+      userId: string;
+    };
+    VersionRoleApproval: {
+      roleId: string;
+      requiredApprovalsCount: number;
+    };
+    Policy1: {
+      /** Format: uuid */
+      id: string;
+      name: string;
+      description?: string;
+      priority: number;
+      /** Format: date-time */
+      createdAt: string;
+      enabled: boolean;
+      /** Format: uuid */
+      workspaceId: string;
+      targets: components["schemas"]["PolicyTarget"][];
+      denyWindows: components["schemas"]["DenyWindow"][];
+      deploymentVersionSelector?: components["schemas"]["DeploymentVersionSelector"];
+      versionAnyApprovals?: components["schemas"]["VersionAnyApproval"][];
+      versionUserApprovals: components["schemas"]["VersionUserApproval"][];
+      versionRoleApprovals: components["schemas"]["VersionRoleApproval"][];
+    };
+  };
+  responses: never;
+  parameters: never;
+  requestBodies: never;
+  headers: never;
+  pathItems: never;
 }
 export type $defs = Record<string, never>;
 export interface operations {
-    getCloudProviderRegions: {
-        parameters: {
-            query?: never;
-            header?: never;
-            path: {
-                /** @description Cloud provider (aws, gcp, azure) */
-                provider: "aws" | "gcp" | "azure";
-            };
-            cookie?: never;
-        };
-        requestBody?: never;
-        responses: {
-            /** @description Successfully returned geographic data for cloud provider regions */
-            200: {
-                headers: {
-                    [name: string]: unknown;
-                };
-                content: {
-                    "application/json": {
-                        [key: string]: components["schemas"]["CloudRegionGeoData"];
-                    };
-                };
-            };
-            /** @description Cloud provider not found */
-            404: {
-                headers: {
-                    [name: string]: unknown;
-                };
-                content: {
-                    "application/json": {
-                        /** @example Cloud provider 'unknown' not found */
-                        error?: string;
-                    };
-                };
-            };
-        };
+  getCloudProviderRegions: {
+    parameters: {
+      query?: never;
+      header?: never;
+      path: {
+        /** @description Cloud provider (aws, gcp, azure) */
+        provider: "aws" | "gcp" | "azure";
+      };
+      cookie?: never;
     };
-    createDeploymentVersionChannel: {
-        parameters: {
-            query?: never;
-            header?: never;
-            path?: never;
-            cookie?: never;
+    requestBody?: never;
+    responses: {
+      /** @description Successfully returned geographic data for cloud provider regions */
+      200: {
+        headers: {
+          [name: string]: unknown;
         };
-        requestBody: {
-            content: {
-                "application/json": {
-                    deploymentId: string;
-                    name: string;
-                    description?: string | null;
-                    versionSelector: {
-                        [key: string]: unknown;
-                    };
-                };
-            };
+        content: {
+          "application/json": {
+            [key: string]: components["schemas"]["CloudRegionGeoData"];
+          };
         };
-        responses: {
-            /** @description Deployment version channel created successfully */
-            200: {
-                headers: {
-                    [name: string]: unknown;
-                };
-                content: {
-                    "application/json": {
-                        id: string;
-                        deploymentId: string;
-                        name: string;
-                        description?: string | null;
-                        /** Format: date-time */
-                        createdAt: string;
-                        versionSelector?: {
-                            [key: string]: unknown;
-                        };
-                    };
-                };
-            };
-            /** @description Unauthorized */
-            401: {
-                headers: {
-                    [name: string]: unknown;
-                };
-                content: {
-                    "application/json": {
-                        error: string;
-                    };
-                };
-            };
-            /** @description Forbidden */
-            403: {
-                headers: {
-                    [name: string]: unknown;
-                };
-                content: {
-                    "application/json": {
-                        error: string;
-                    };
-                };
-            };
-            /** @description Deployment version channel already exists */
-            409: {
-                headers: {
-                    [name: string]: unknown;
-                };
-                content: {
-                    "application/json": {
-                        error: string;
-                        id: string;
-                    };
-                };
-            };
-            /** @description Failed to create deployment version channel */
-            500: {
-                headers: {
-                    [name: string]: unknown;
-                };
-                content: {
-                    "application/json": {
-                        error: string;
-                    };
-                };
-            };
+      };
+      /** @description Cloud provider not found */
+      404: {
+        headers: {
+          [name: string]: unknown;
         };
+        content: {
+          "application/json": {
+            /** @example Cloud provider 'unknown' not found */
+            error?: string;
+          };
+        };
+      };
     };
-    updateDeploymentVersion: {
-        parameters: {
-            query?: never;
-            header?: never;
-            path: {
-                /** @description The deployment version ID */
-                deploymentVersionId: string;
-            };
-            cookie?: never;
-        };
-        requestBody: {
-            content: {
-                "application/json": {
-                    tag?: string;
-                    deploymentId?: string;
-                    /** Format: date-time */
-                    createdAt?: string;
-                    name?: string;
-                    config?: {
-                        [key: string]: unknown;
-                    };
-                    jobAgentConfig?: {
-                        [key: string]: unknown;
-                    };
-                    /** @enum {string} */
-                    status?: "ready" | "building" | "failed";
-                    message?: string;
-                    metadata?: {
-                        [key: string]: string;
-                    };
-                };
-            };
-        };
-        responses: {
-            /** @description OK */
-            200: {
-                headers: {
-                    [name: string]: unknown;
-                };
-                content: {
-                    "application/json": components["schemas"]["DeploymentVersion"];
-                };
-            };
-        };
+  };
+  createDeploymentVersionChannel: {
+    parameters: {
+      query?: never;
+      header?: never;
+      path?: never;
+      cookie?: never;
     };
-    upsertDeploymentVersion: {
-        parameters: {
-            query?: never;
-            header?: never;
-            path?: never;
-            cookie?: never;
+    requestBody: {
+      content: {
+        "application/json": {
+          deploymentId: string;
+          name: string;
+          description?: string | null;
+          versionSelector: {
+            [key: string]: unknown;
+          };
         };
-        requestBody: {
-            content: {
-                "application/json": {
-                    tag: string;
-                    deploymentId: string;
-                    /** Format: date-time */
-                    createdAt?: string;
-                    name?: string;
-                    config?: {
-                        [key: string]: unknown;
-                    };
-                    jobAgentConfig?: {
-                        [key: string]: unknown;
-                    };
-                    /** @enum {string} */
-                    status?: "ready" | "building" | "failed";
-                    message?: string;
-                    metadata?: {
-                        [key: string]: string;
-                    };
-                };
-            };
-        };
-        responses: {
-            /** @description OK */
-            200: {
-                headers: {
-                    [name: string]: unknown;
-                };
-                content: {
-                    "application/json": components["schemas"]["DeploymentVersion"];
-                };
-            };
-            /** @description Deployment version already exists */
-            409: {
-                headers: {
-                    [name: string]: unknown;
-                };
-                content: {
-                    "application/json": {
-                        error?: string;
-                        id?: string;
-                    };
-                };
-            };
-        };
+      };
     };
-    deleteDeploymentVersionChannel: {
-        parameters: {
-            query?: never;
-            header?: never;
-            path: {
-                deploymentId: string;
-                name: string;
-            };
-            cookie?: never;
+    responses: {
+      /** @description Deployment version channel created successfully */
+      200: {
+        headers: {
+          [name: string]: unknown;
         };
-        requestBody?: never;
-        responses: {
-            /** @description Deployment version channel deleted */
-            200: {
-                headers: {
-                    [name: string]: unknown;
-                };
-                content: {
-                    "application/json": {
-                        message: string;
-                    };
-                };
+        content: {
+          "application/json": {
+            id: string;
+            deploymentId: string;
+            name: string;
+            description?: string | null;
+            /** Format: date-time */
+            createdAt: string;
+            versionSelector?: {
+              [key: string]: unknown;
             };
-            /** @description Permission denied */
-            403: {
-                headers: {
-                    [name: string]: unknown;
-                };
-                content: {
-                    "application/json": {
-                        error: string;
-                    };
-                };
-            };
-            /** @description Deployment version channel not found */
-            404: {
-                headers: {
-                    [name: string]: unknown;
-                };
-                content: {
-                    "application/json": {
-                        error: string;
-                    };
-                };
-            };
-            /** @description Failed to delete deployment version channel */
-            500: {
-                headers: {
-                    [name: string]: unknown;
-                };
-                content: {
-                    "application/json": {
-                        error: string;
-                    };
-                };
-            };
+          };
         };
+      };
+      /** @description Unauthorized */
+      401: {
+        headers: {
+          [name: string]: unknown;
+        };
+        content: {
+          "application/json": {
+            error: string;
+          };
+        };
+      };
+      /** @description Forbidden */
+      403: {
+        headers: {
+          [name: string]: unknown;
+        };
+        content: {
+          "application/json": {
+            error: string;
+          };
+        };
+      };
+      /** @description Deployment version channel already exists */
+      409: {
+        headers: {
+          [name: string]: unknown;
+        };
+        content: {
+          "application/json": {
+            error: string;
+            id: string;
+          };
+        };
+      };
+      /** @description Failed to create deployment version channel */
+      500: {
+        headers: {
+          [name: string]: unknown;
+        };
+        content: {
+          "application/json": {
+            error: string;
+          };
+        };
+      };
     };
-    getDeployment: {
-        parameters: {
-            query?: never;
-            header?: never;
-            path: {
-                deploymentId: string;
-            };
-            cookie?: never;
-        };
-        requestBody?: never;
-        responses: {
-            /** @description Deployment found */
-            200: {
-                headers: {
-                    [name: string]: unknown;
-                };
-                content: {
-                    "application/json": components["schemas"]["Deployment"];
-                };
-            };
-            /** @description Deployment not found */
-            404: {
-                headers: {
-                    [name: string]: unknown;
-                };
-                content: {
-                    "application/json": {
-                        error: string;
-                    };
-                };
-            };
-        };
+  };
+  updateDeploymentVersion: {
+    parameters: {
+      query?: never;
+      header?: never;
+      path: {
+        /** @description The deployment version ID */
+        deploymentVersionId: string;
+      };
+      cookie?: never;
     };
-    deleteDeployment: {
-        parameters: {
-            query?: never;
-            header?: never;
-            path: {
-                deploymentId: string;
-            };
-            cookie?: never;
+    requestBody: {
+      content: {
+        "application/json": {
+          tag?: string;
+          deploymentId?: string;
+          /** Format: date-time */
+          createdAt?: string;
+          name?: string;
+          config?: {
+            [key: string]: unknown;
+          };
+          jobAgentConfig?: {
+            [key: string]: unknown;
+          };
+          /** @enum {string} */
+          status?: "ready" | "building" | "failed";
+          message?: string;
+          metadata?: {
+            [key: string]: string;
+          };
         };
-        requestBody?: never;
-        responses: {
-            /** @description Deployment deleted */
-            200: {
-                headers: {
-                    [name: string]: unknown;
-                };
-                content: {
-                    "application/json": components["schemas"]["Deployment"];
-                };
-            };
-            /** @description Deployment not found */
-            404: {
-                headers: {
-                    [name: string]: unknown;
-                };
-                content: {
-                    "application/json": {
-                        error: string;
-                    };
-                };
-            };
-            /** @description Failed to delete deployment */
-            500: {
-                headers: {
-                    [name: string]: unknown;
-                };
-                content: {
-                    "application/json": {
-                        error: string;
-                    };
-                };
-            };
-        };
+      };
     };
-    updateDeployment: {
-        parameters: {
-            query?: never;
-            header?: never;
-            path: {
-                deploymentId: string;
-            };
-            cookie?: never;
+    responses: {
+      /** @description OK */
+      200: {
+        headers: {
+          [name: string]: unknown;
         };
-        requestBody: {
-            content: {
-                "application/json": components["schemas"]["UpdateDeployment"];
-            };
+        content: {
+          "application/json": components["schemas"]["DeploymentVersion"];
         };
-        responses: {
-            /** @description Deployment updated */
-            200: {
-                headers: {
-                    [name: string]: unknown;
-                };
-                content: {
-                    "application/json": components["schemas"]["Deployment"];
-                };
-            };
-            /** @description Deployment not found */
-            404: {
-                headers: {
-                    [name: string]: unknown;
-                };
-                content: {
-                    "application/json": {
-                        error: string;
-                    };
-                };
-            };
-            /** @description Failed to update deployment */
-            500: {
-                headers: {
-                    [name: string]: unknown;
-                };
-                content: {
-                    "application/json": {
-                        error: string;
-                    };
-                };
-            };
-        };
+      };
     };
-    deleteReleaseChannel: {
-        parameters: {
-            query?: never;
-            header?: never;
-            path: {
-                deploymentId: string;
-                name: string;
-            };
-            cookie?: never;
-        };
-        requestBody?: never;
-        responses: {
-            /** @description Release channel deleted */
-            200: {
-                headers: {
-                    [name: string]: unknown;
-                };
-                content: {
-                    "application/json": {
-                        message: string;
-                    };
-                };
-            };
-            /** @description Permission denied */
-            403: {
-                headers: {
-                    [name: string]: unknown;
-                };
-                content: {
-                    "application/json": {
-                        error: string;
-                    };
-                };
-            };
-            /** @description Release channel not found */
-            404: {
-                headers: {
-                    [name: string]: unknown;
-                };
-                content: {
-                    "application/json": {
-                        error: string;
-                    };
-                };
-            };
-            /** @description Failed to delete release channel */
-            500: {
-                headers: {
-                    [name: string]: unknown;
-                };
-                content: {
-                    "application/json": {
-                        error: string;
-                    };
-                };
-            };
-        };
+  };
+  upsertDeploymentVersion: {
+    parameters: {
+      query?: never;
+      header?: never;
+      path?: never;
+      cookie?: never;
     };
-    getResourcesForDeployment: {
-        parameters: {
-            query?: never;
-            header?: never;
-            path: {
-                /** @description UUID of the deployment */
-                deploymentId: string;
-            };
-            cookie?: never;
+    requestBody: {
+      content: {
+        "application/json": {
+          tag: string;
+          deploymentId: string;
+          /** Format: date-time */
+          createdAt?: string;
+          name?: string;
+          config?: {
+            [key: string]: unknown;
+          };
+          jobAgentConfig?: {
+            [key: string]: unknown;
+          };
+          /** @enum {string} */
+          status?: "ready" | "building" | "failed";
+          message?: string;
+          metadata?: {
+            [key: string]: string;
+          };
         };
-        requestBody?: never;
-        responses: {
-            /** @description OK */
-            200: {
-                headers: {
-                    [name: string]: unknown;
-                };
-                content: {
-                    "application/json": {
-                        resources?: {
-                            id?: string;
-                            name?: string;
-                            identifier?: string;
-                            kind?: string;
-                            version?: string;
-                        }[];
-                        count?: number;
-                    };
-                };
-            };
-            /** @description Internal Server Error */
-            500: {
-                headers: {
-                    [name: string]: unknown;
-                };
-                content: {
-                    "application/json": {
-                        error?: string;
-                    };
-                };
-            };
-        };
+      };
     };
-    createDeployment: {
-        parameters: {
-            query?: never;
-            header?: never;
-            path?: never;
-            cookie?: never;
+    responses: {
+      /** @description OK */
+      200: {
+        headers: {
+          [name: string]: unknown;
         };
-        requestBody?: {
-            content: {
-                "application/json": {
-                    /**
-                     * Format: uuid
-                     * @description The ID of the system to create the deployment for
-                     * @example 123e4567-e89b-12d3-a456-426614174000
-                     */
-                    systemId: string;
-                    /**
-                     * @description The name of the deployment
-                     * @example My Deployment
-                     */
-                    name: string;
-                    /**
-                     * @description The slug of the deployment
-                     * @example my-deployment
-                     */
-                    slug: string;
-                    /**
-                     * @description The description of the deployment
-                     * @example This is a deployment for my system
-                     */
-                    description?: string;
-                    /**
-                     * Format: uuid
-                     * @description The ID of the job agent to use for the deployment
-                     * @example 123e4567-e89b-12d3-a456-426614174000
-                     */
-                    jobAgentId?: string;
-                    /**
-                     * @description The configuration for the job agent
-                     * @example {
-                     *       "key": "value"
-                     *     }
-                     */
-                    jobAgentConfig?: Record<string, never>;
-                    /**
-                     * @description The number of times to retry the deployment
-                     * @example 3
-                     */
-                    retryCount?: number;
-                    /**
-                     * @description The timeout for the deployment
-                     * @example 60
-                     */
-                    timeout?: number;
-                    /**
-                     * @description The resource selector for the deployment
-                     * @example {
-                     *       "key": "value"
-                     *     }
-                     */
-                    resourceSelector?: Record<string, never>;
-                };
-            };
+        content: {
+          "application/json": components["schemas"]["DeploymentVersion"];
         };
-        responses: {
-            /** @description Deployment created */
-            201: {
-                headers: {
-                    [name: string]: unknown;
-                };
-                content: {
-                    "application/json": components["schemas"]["Deployment"];
-                };
-            };
-            /** @description Deployment already exists */
-            409: {
-                headers: {
-                    [name: string]: unknown;
-                };
-                content: {
-                    "application/json": {
-                        error: string;
-                        /** Format: uuid */
-                        id: string;
-                    };
-                };
-            };
-            /** @description Failed to create deployment */
-            500: {
-                headers: {
-                    [name: string]: unknown;
-                };
-                content: {
-                    "application/json": {
-                        error: string;
-                    };
-                };
-            };
+      };
+      /** @description Deployment version already exists */
+      409: {
+        headers: {
+          [name: string]: unknown;
         };
+        content: {
+          "application/json": {
+            error?: string;
+            id?: string;
+          };
+        };
+      };
     };
-    getEnvironment: {
-        parameters: {
-            query?: never;
-            header?: never;
-            path: {
-                /** @description UUID of the environment */
-                environmentId: string;
-            };
-            cookie?: never;
-        };
-        requestBody?: never;
-        responses: {
-            /** @description Successful response */
-            200: {
-                headers: {
-                    [name: string]: unknown;
-                };
-                content: {
-                    "application/json": components["schemas"]["Environment"];
-                };
-            };
-            /** @description Environment not found */
-            404: {
-                headers: {
-                    [name: string]: unknown;
-                };
-                content: {
-                    "application/json": {
-                        /** @example Environment not found */
-                        error: string;
-                    };
-                };
-            };
-        };
+  };
+  deleteDeploymentVersionChannel: {
+    parameters: {
+      query?: never;
+      header?: never;
+      path: {
+        deploymentId: string;
+        name: string;
+      };
+      cookie?: never;
     };
-    deleteEnvironment: {
-        parameters: {
-            query?: never;
-            header?: never;
-            path: {
-                /** @description UUID of the environment */
-                environmentId: string;
-            };
-            cookie?: never;
+    requestBody?: never;
+    responses: {
+      /** @description Deployment version channel deleted */
+      200: {
+        headers: {
+          [name: string]: unknown;
         };
-        requestBody?: never;
-        responses: {
-            /** @description Environment deleted successfully */
-            200: {
-                headers: {
-                    [name: string]: unknown;
-                };
-                content?: never;
-            };
+        content: {
+          "application/json": {
+            message: string;
+          };
         };
+      };
+      /** @description Permission denied */
+      403: {
+        headers: {
+          [name: string]: unknown;
+        };
+        content: {
+          "application/json": {
+            error: string;
+          };
+        };
+      };
+      /** @description Deployment version channel not found */
+      404: {
+        headers: {
+          [name: string]: unknown;
+        };
+        content: {
+          "application/json": {
+            error: string;
+          };
+        };
+      };
+      /** @description Failed to delete deployment version channel */
+      500: {
+        headers: {
+          [name: string]: unknown;
+        };
+        content: {
+          "application/json": {
+            error: string;
+          };
+        };
+      };
     };
-    getResourcesForEnvironment: {
-        parameters: {
-            query?: never;
-            header?: never;
-            path: {
-                /** @description UUID of the environment */
-                environmentId: string;
-            };
-            cookie?: never;
-        };
-        requestBody?: never;
-        responses: {
-            /** @description OK */
-            200: {
-                headers: {
-                    [name: string]: unknown;
-                };
-                content: {
-                    "application/json": {
-                        resources?: {
-                            id?: string;
-                            name?: string;
-                            identifier?: string;
-                            kind?: string;
-                            version?: string;
-                        }[];
-                        count?: number;
-                    };
-                };
-            };
-            /** @description Internal Server Error */
-            500: {
-                headers: {
-                    [name: string]: unknown;
-                };
-                content: {
-                    "application/json": {
-                        error?: string;
-                    };
-                };
-            };
-        };
+  };
+  getDeployment: {
+    parameters: {
+      query?: never;
+      header?: never;
+      path: {
+        deploymentId: string;
+      };
+      cookie?: never;
     };
-    createEnvironment: {
-        parameters: {
-            query?: never;
-            header?: never;
-            path?: never;
-            cookie?: never;
+    requestBody?: never;
+    responses: {
+      /** @description Deployment found */
+      200: {
+        headers: {
+          [name: string]: unknown;
         };
-        requestBody: {
-            content: {
-                "application/json": {
-                    /**
-                     * @description The directory path of the environment
-                     * @default
-                     * @example my/env/path
-                     */
-                    directory?: string;
-                    systemId: string;
-                    name: string;
-                    description?: string;
-                    resourceSelector?: {
-                        [key: string]: unknown;
-                    };
-                    policyId?: string;
-                    releaseChannels?: string[];
-                    deploymentVersionChannels?: string[];
-                    metadata?: {
-                        [key: string]: string;
-                    };
-                };
-            };
+        content: {
+          "application/json": components["schemas"]["Deployment"];
         };
-        responses: {
-            /** @description Environment created successfully */
-            200: {
-                headers: {
-                    [name: string]: unknown;
-                };
-                content: {
-                    "application/json": components["schemas"]["Environment"];
-                };
-            };
-            /** @description Environment already exists */
-            409: {
-                headers: {
-                    [name: string]: unknown;
-                };
-                content: {
-                    "application/json": {
-                        error?: string;
-                        id?: string;
-                    };
-                };
-            };
-            /** @description Failed to create environment */
-            500: {
-                headers: {
-                    [name: string]: unknown;
-                };
-                content: {
-                    "application/json": {
-                        error: string;
-                    };
-                };
-            };
+      };
+      /** @description Deployment not found */
+      404: {
+        headers: {
+          [name: string]: unknown;
         };
+        content: {
+          "application/json": {
+            error: string;
+          };
+        };
+      };
     };
-    getAgentRunningJobs: {
-        parameters: {
-            query?: never;
-            header?: never;
-            path: {
-                /** @description The execution ID */
-                agentId: string;
-            };
-            cookie?: never;
-        };
-        requestBody?: never;
-        responses: {
-            /** @description OK */
-            200: {
-                headers: {
-                    [name: string]: unknown;
-                };
-                content: {
-                    "application/json": components["schemas"]["Job"][];
-                };
-            };
-        };
+  };
+  deleteDeployment: {
+    parameters: {
+      query?: never;
+      header?: never;
+      path: {
+        deploymentId: string;
+      };
+      cookie?: never;
     };
-    acknowledgeAgentJob: {
-        parameters: {
-            query?: never;
-            header?: never;
-            path: {
-                /** @description The ID of the job agent */
-                agentId: string;
-            };
-            cookie?: never;
+    requestBody?: never;
+    responses: {
+      /** @description Deployment deleted */
+      200: {
+        headers: {
+          [name: string]: unknown;
         };
-        requestBody?: never;
-        responses: {
-            /** @description Successfully acknowledged job */
-            200: {
-                headers: {
-                    [name: string]: unknown;
-                };
-                content: {
-                    "application/json": {
-                        job?: components["schemas"]["Job"];
-                    };
-                };
-            };
-            /** @description Unauthorized */
-            401: {
-                headers: {
-                    [name: string]: unknown;
-                };
-                content: {
-                    "application/json": {
-                        error?: string;
-                    };
-                };
-            };
-            /** @description Workspace not found */
-            404: {
-                headers: {
-                    [name: string]: unknown;
-                };
-                content: {
-                    "application/json": {
-                        error?: string;
-                    };
-                };
-            };
+        content: {
+          "application/json": components["schemas"]["Deployment"];
         };
+      };
+      /** @description Deployment not found */
+      404: {
+        headers: {
+          [name: string]: unknown;
+        };
+        content: {
+          "application/json": {
+            error: string;
+          };
+        };
+      };
+      /** @description Failed to delete deployment */
+      500: {
+        headers: {
+          [name: string]: unknown;
+        };
+        content: {
+          "application/json": {
+            error: string;
+          };
+        };
+      };
     };
-    getNextJobs: {
-        parameters: {
-            query?: never;
-            header?: never;
-            path: {
-                /** @description The agent ID */
-                agentId: string;
-            };
-            cookie?: never;
-        };
-        requestBody?: never;
-        responses: {
-            /** @description OK */
-            200: {
-                headers: {
-                    [name: string]: unknown;
-                };
-                content: {
-                    "application/json": {
-                        jobs?: components["schemas"]["Job"][];
-                    };
-                };
-            };
-        };
+  };
+  updateDeployment: {
+    parameters: {
+      query?: never;
+      header?: never;
+      path: {
+        deploymentId: string;
+      };
+      cookie?: never;
     };
-    upsertJobAgent: {
-        parameters: {
-            query?: never;
-            header?: never;
-            path?: never;
-            cookie?: never;
-        };
-        requestBody: {
-            content: {
-                "application/json": {
-                    workspaceId: string;
-                    name: string;
-                    type: string;
-                };
-            };
-        };
-        responses: {
-            /** @description Successfully retrieved or created the agent */
-            200: {
-                headers: {
-                    [name: string]: unknown;
-                };
-                content: {
-                    "application/json": {
-                        id: string;
-                        name: string;
-                        workspaceId: string;
-                    };
-                };
-            };
-            /** @description Internal server error */
-            500: {
-                headers: {
-                    [name: string]: unknown;
-                };
-                content?: never;
-            };
-        };
+    requestBody: {
+      content: {
+        "application/json": components["schemas"]["UpdateDeployment"];
+      };
     };
-    acknowledgeJob: {
-        parameters: {
-            query?: never;
-            header?: never;
-            path: {
-                /** @description The job ID */
-                jobId: string;
-            };
-            cookie?: never;
+    responses: {
+      /** @description Deployment updated */
+      200: {
+        headers: {
+          [name: string]: unknown;
         };
-        requestBody?: never;
-        responses: {
-            /** @description OK */
-            200: {
-                headers: {
-                    [name: string]: unknown;
-                };
-                content: {
-                    "application/json": {
-                        sucess: boolean;
-                    };
-                };
-            };
-            /** @description Unauthorized */
-            401: {
-                headers: {
-                    [name: string]: unknown;
-                };
-                content: {
-                    "application/json": {
-                        error: string;
-                    };
-                };
-            };
+        content: {
+          "application/json": components["schemas"]["Deployment"];
         };
+      };
+      /** @description Deployment not found */
+      404: {
+        headers: {
+          [name: string]: unknown;
+        };
+        content: {
+          "application/json": {
+            error: string;
+          };
+        };
+      };
+      /** @description Failed to update deployment */
+      500: {
+        headers: {
+          [name: string]: unknown;
+        };
+        content: {
+          "application/json": {
+            error: string;
+          };
+        };
+      };
     };
-    getJob: {
-        parameters: {
-            query?: never;
-            header?: never;
-            path: {
-                /** @description The job ID */
-                jobId: string;
-            };
-            cookie?: never;
-        };
-        requestBody?: never;
-        responses: {
-            /** @description OK */
-            200: {
-                headers: {
-                    [name: string]: unknown;
-                };
-                content: {
-                    "application/json": components["schemas"]["JobWithTrigger"];
-                };
-            };
-            /** @description Not Found */
-            404: {
-                headers: {
-                    [name: string]: unknown;
-                };
-                content: {
-                    "application/json": {
-                        /** @example Job not found. */
-                        error?: string;
-                    };
-                };
-            };
-        };
+  };
+  deleteReleaseChannel: {
+    parameters: {
+      query?: never;
+      header?: never;
+      path: {
+        deploymentId: string;
+        name: string;
+      };
+      cookie?: never;
     };
-    updateJob: {
-        parameters: {
-            query?: never;
-            header?: never;
-            path: {
-                /** @description The execution ID */
-                jobId: string;
-            };
-            cookie?: never;
+    requestBody?: never;
+    responses: {
+      /** @description Release channel deleted */
+      200: {
+        headers: {
+          [name: string]: unknown;
         };
-        requestBody: {
-            content: {
-                "application/json": {
-                    status?: components["schemas"]["JobStatus"];
-                    message?: string | null;
-                    externalId?: string | null;
-                };
-            };
+        content: {
+          "application/json": {
+            message: string;
+          };
         };
-        responses: {
-            /** @description OK */
-            200: {
-                headers: {
-                    [name: string]: unknown;
-                };
-                content: {
-                    "application/json": {
-                        id: string;
-                    };
-                };
-            };
+      };
+      /** @description Permission denied */
+      403: {
+        headers: {
+          [name: string]: unknown;
         };
+        content: {
+          "application/json": {
+            error: string;
+          };
+        };
+      };
+      /** @description Release channel not found */
+      404: {
+        headers: {
+          [name: string]: unknown;
+        };
+        content: {
+          "application/json": {
+            error: string;
+          };
+        };
+      };
+      /** @description Failed to delete release channel */
+      500: {
+        headers: {
+          [name: string]: unknown;
+        };
+        content: {
+          "application/json": {
+            error: string;
+          };
+        };
+      };
     };
-    deletePolicy: {
-        parameters: {
-            query?: never;
-            header?: never;
-            path: {
-                policyId: string;
-            };
-            cookie?: never;
-        };
-        requestBody?: never;
-        responses: {
-            /** @description OK */
-            200: {
-                headers: {
-                    [name: string]: unknown;
-                };
-                content: {
-                    "application/json": {
-                        count?: number;
-                    };
-                };
-            };
-            /** @description Internal Server Error */
-            500: {
-                headers: {
-                    [name: string]: unknown;
-                };
-                content?: never;
-            };
-        };
+  };
+  getResourcesForDeployment: {
+    parameters: {
+      query?: never;
+      header?: never;
+      path: {
+        /** @description UUID of the deployment */
+        deploymentId: string;
+      };
+      cookie?: never;
     };
-    getReleaseTargetsForPolicy: {
-        parameters: {
-            query?: never;
-            header?: never;
-            path: {
-                /** @description UUID of the policy */
-                policyId: string;
-            };
-            cookie?: never;
+    requestBody?: never;
+    responses: {
+      /** @description OK */
+      200: {
+        headers: {
+          [name: string]: unknown;
         };
-        requestBody?: never;
-        responses: {
-            /** @description OK */
-            200: {
-                headers: {
-                    [name: string]: unknown;
-                };
-                content: {
-                    "application/json": {
-                        releaseTargets?: {
-                            id?: string;
-                            name?: string;
-                            description?: string;
-                            policyTarget?: {
-                                id?: string;
-                                name?: string;
-                                policyId?: string;
-                                description?: string;
-                            };
-                            resource?: {
-                                id?: string;
-                                name?: string;
-                                identifier?: string;
-                                kind?: string;
-                                version?: string;
-                            };
-                            environment?: {
-                                id?: string;
-                                name?: string;
-                            };
-                        }[];
-                        count?: number;
-                    };
-                };
-            };
-            /** @description Internal Server Error */
-            500: {
-                headers: {
-                    [name: string]: unknown;
-                };
-                content: {
-                    "application/json": {
-                        error?: string;
-                    };
-                };
-            };
+        content: {
+          "application/json": {
+            resources?: {
+              id?: string;
+              name?: string;
+              identifier?: string;
+              kind?: string;
+              version?: string;
+            }[];
+            count?: number;
+          };
         };
+      };
+      /** @description Internal Server Error */
+      500: {
+        headers: {
+          [name: string]: unknown;
+        };
+        content: {
+          "application/json": {
+            error?: string;
+          };
+        };
+      };
     };
-    upsertPolicy: {
-        parameters: {
-            query?: never;
-            header?: never;
-            path?: never;
-            cookie?: never;
-        };
-        requestBody: {
-            content: {
-                "application/json": {
-                    name: string;
-                    description?: string;
-                    priority?: number;
-                    enabled?: boolean;
-                    workspaceId: string;
-                    targets: components["schemas"]["PolicyTarget"][];
-                    denyWindows?: {
-                        timeZone: string;
-                        rrule?: {
-                            [key: string]: unknown;
-                        };
-                        /** Format: date-time */
-                        dtend?: string;
-                    }[];
-                    deploymentVersionSelector?: components["schemas"]["DeploymentVersionSelector"];
-                    versionAnyApprovals?: {
-                        requiredApprovalsCount?: number;
-                    }[];
-                    versionUserApprovals?: components["schemas"]["VersionUserApproval"][];
-                    versionRoleApprovals?: {
-                        roleId: string;
-                        requiredApprovalsCount?: number;
-                    }[];
-                };
-            };
-        };
-        responses: {
-            /** @description OK */
-            200: {
-                headers: {
-                    [name: string]: unknown;
-                };
-                content: {
-                    "application/json": components["schemas"]["Policy1"];
-                };
-            };
-            /** @description Internal Server Error */
-            500: {
-                headers: {
-                    [name: string]: unknown;
-                };
-                content: {
-                    "application/json": {
-                        error?: string;
-                    };
-                };
-            };
-        };
+  };
+  createDeployment: {
+    parameters: {
+      query?: never;
+      header?: never;
+      path?: never;
+      cookie?: never;
     };
-    createJobToResourceRelationship: {
-        parameters: {
-            query?: never;
-            header?: never;
-            path?: never;
-            cookie?: never;
+    requestBody?: {
+      content: {
+        "application/json": {
+          /**
+           * Format: uuid
+           * @description The ID of the system to create the deployment for
+           * @example 123e4567-e89b-12d3-a456-426614174000
+           */
+          systemId: string;
+          /**
+           * @description The name of the deployment
+           * @example My Deployment
+           */
+          name: string;
+          /**
+           * @description The slug of the deployment
+           * @example my-deployment
+           */
+          slug: string;
+          /**
+           * @description The description of the deployment
+           * @example This is a deployment for my system
+           */
+          description?: string;
+          /**
+           * Format: uuid
+           * @description The ID of the job agent to use for the deployment
+           * @example 123e4567-e89b-12d3-a456-426614174000
+           */
+          jobAgentId?: string;
+          /**
+           * @description The configuration for the job agent
+           * @example {
+           *       "key": "value"
+           *     }
+           */
+          jobAgentConfig?: Record<string, never>;
+          /**
+           * @description The number of times to retry the deployment
+           * @example 3
+           */
+          retryCount?: number;
+          /**
+           * @description The timeout for the deployment
+           * @example 60
+           */
+          timeout?: number;
+          /**
+           * @description The resource selector for the deployment
+           * @example {
+           *       "key": "value"
+           *     }
+           */
+          resourceSelector?: Record<string, never>;
         };
-        requestBody: {
-            content: {
-                "application/json": {
-                    /**
-                     * Format: uuid
-                     * @description Unique identifier of the job
-                     * @example 123e4567-e89b-12d3-a456-426614174000
-                     */
-                    jobId: string;
-                    /**
-                     * @description Unique identifier of the resource
-                     * @example resource-123
-                     */
-                    resourceIdentifier: string;
-                };
-            };
-        };
-        responses: {
-            /** @description Relationship created successfully */
-            200: {
-                headers: {
-                    [name: string]: unknown;
-                };
-                content: {
-                    "application/json": {
-                        /** @example Relationship created successfully */
-                        message?: string;
-                    };
-                };
-            };
-            /** @description Invalid request body */
-            400: {
-                headers: {
-                    [name: string]: unknown;
-                };
-                content: {
-                    "application/json": {
-                        /** @example Invalid jobId format */
-                        error?: string;
-                    };
-                };
-            };
-            /** @description Job or resource not found */
-            404: {
-                headers: {
-                    [name: string]: unknown;
-                };
-                content: {
-                    "application/json": {
-                        /** @example Job with specified ID not found */
-                        error?: string;
-                    };
-                };
-            };
-            /** @description Relationship already exists */
-            409: {
-                headers: {
-                    [name: string]: unknown;
-                };
-                content: {
-                    "application/json": {
-                        /** @example Relationship between job and resource already exists */
-                        error?: string;
-                    };
-                };
-            };
-            /** @description Internal server error */
-            500: {
-                headers: {
-                    [name: string]: unknown;
-                };
-                content: {
-                    "application/json": {
-                        /** @example Internal server error occurred */
-                        error?: string;
-                    };
-                };
-            };
-        };
+      };
     };
-    createResourceToResourceRelationship: {
-        parameters: {
-            query?: never;
-            header?: never;
-            path?: never;
-            cookie?: never;
+    responses: {
+      /** @description Deployment created */
+      201: {
+        headers: {
+          [name: string]: unknown;
         };
-        requestBody: {
-            content: {
-                "application/json": {
-                    /**
-                     * Format: uuid
-                     * @description The workspace ID
-                     * @example 123e4567-e89b-12d3-a456-426614174000
-                     */
-                    workspaceId: string;
-                    /**
-                     * @description The identifier of the resource to connect
-                     * @example my-resource
-                     */
-                    fromIdentifier: string;
-                    /**
-                     * @description The identifier of the resource to connect to
-                     * @example my-resource
-                     */
-                    toIdentifier: string;
-                    /**
-                     * @description The type of relationship
-                     * @example depends_on
-                     */
-                    type: string;
-                };
-            };
+        content: {
+          "application/json": components["schemas"]["Deployment"];
         };
-        responses: {
-            /** @description Relationship created */
-            200: {
-                headers: {
-                    [name: string]: unknown;
-                };
-                content: {
-                    "application/json": {
-                        /** @example Relationship created successfully */
-                        message?: string;
-                    };
-                };
-            };
-            /** @description Invalid request body */
-            400: {
-                headers: {
-                    [name: string]: unknown;
-                };
-                content: {
-                    "application/json": {
-                        error?: string;
-                    };
-                };
-            };
-            /** @description Resource not found */
-            404: {
-                headers: {
-                    [name: string]: unknown;
-                };
-                content: {
-                    "application/json": {
-                        error?: string;
-                    };
-                };
-            };
-            /** @description Relationship already exists */
-            409: {
-                headers: {
-                    [name: string]: unknown;
-                };
-                content: {
-                    "application/json": {
-                        error?: string;
-                    };
-                };
-            };
-            /** @description Internal server error */
-            500: {
-                headers: {
-                    [name: string]: unknown;
-                };
-                content: {
-                    "application/json": {
-                        error?: string;
-                    };
-                };
-            };
+      };
+      /** @description Deployment already exists */
+      409: {
+        headers: {
+          [name: string]: unknown;
         };
+        content: {
+          "application/json": {
+            error: string;
+            /** Format: uuid */
+            id: string;
+          };
+        };
+      };
+      /** @description Failed to create deployment */
+      500: {
+        headers: {
+          [name: string]: unknown;
+        };
+        content: {
+          "application/json": {
+            error: string;
+          };
+        };
+      };
     };
-    createReleaseChannel: {
-        parameters: {
-            query?: never;
-            header?: never;
-            path?: never;
-            cookie?: never;
-        };
-        requestBody: {
-            content: {
-                "application/json": {
-                    deploymentId: string;
-                    name: string;
-                    description?: string | null;
-                    releaseSelector: {
-                        [key: string]: unknown;
-                    };
-                };
-            };
-        };
-        responses: {
-            /** @description Release channel created successfully */
-            200: {
-                headers: {
-                    [name: string]: unknown;
-                };
-                content: {
-                    "application/json": {
-                        id: string;
-                        deploymentId: string;
-                        name: string;
-                        description?: string | null;
-                        /** Format: date-time */
-                        createdAt: string;
-                        releaseSelector?: {
-                            [key: string]: unknown;
-                        };
-                    };
-                };
-            };
-            /** @description Unauthorized */
-            401: {
-                headers: {
-                    [name: string]: unknown;
-                };
-                content: {
-                    "application/json": {
-                        error: string;
-                    };
-                };
-            };
-            /** @description Forbidden */
-            403: {
-                headers: {
-                    [name: string]: unknown;
-                };
-                content: {
-                    "application/json": {
-                        error: string;
-                    };
-                };
-            };
-            /** @description Release channel already exists */
-            409: {
-                headers: {
-                    [name: string]: unknown;
-                };
-                content: {
-                    "application/json": {
-                        error: string;
-                        id: string;
-                    };
-                };
-            };
-            /** @description Failed to create release channel */
-            500: {
-                headers: {
-                    [name: string]: unknown;
-                };
-                content: {
-                    "application/json": {
-                        error: string;
-                    };
-                };
-            };
-        };
+  };
+  getEnvironment: {
+    parameters: {
+      query?: never;
+      header?: never;
+      path: {
+        /** @description UUID of the environment */
+        environmentId: string;
+      };
+      cookie?: never;
     };
-    updateRelease: {
-        parameters: {
-            query?: never;
-            header?: never;
-            path: {
-                /** @description The release ID */
-                releaseId: string;
-            };
-            cookie?: never;
+    requestBody?: never;
+    responses: {
+      /** @description Successful response */
+      200: {
+        headers: {
+          [name: string]: unknown;
         };
-        requestBody: {
-            content: {
-                "application/json": {
-                    version?: string;
-                    deploymentId?: string;
-                    /** Format: date-time */
-                    createdAt?: string;
-                    name?: string;
-                    config?: {
-                        [key: string]: unknown;
-                    };
-                    jobAgentConfig?: {
-                        [key: string]: unknown;
-                    };
-                    /** @enum {string} */
-                    status?: "ready" | "building" | "failed";
-                    message?: string;
-                    metadata?: {
-                        [key: string]: string;
-                    };
-                };
-            };
+        content: {
+          "application/json": components["schemas"]["Environment"];
         };
-        responses: {
-            /** @description OK */
-            200: {
-                headers: {
-                    [name: string]: unknown;
-                };
-                content: {
-                    "application/json": components["schemas"]["Release"];
-                };
-            };
+      };
+      /** @description Environment not found */
+      404: {
+        headers: {
+          [name: string]: unknown;
         };
+        content: {
+          "application/json": {
+            /** @example Environment not found */
+            error: string;
+          };
+        };
+      };
     };
-    upsertRelease: {
-        parameters: {
-            query?: never;
-            header?: never;
-            path?: never;
-            cookie?: never;
-        };
-        requestBody: {
-            content: {
-                "application/json": {
-                    version: string;
-                    deploymentId: string;
-                    /** Format: date-time */
-                    createdAt?: string;
-                    name?: string;
-                    config?: {
-                        [key: string]: unknown;
-                    };
-                    jobAgentConfig?: {
-                        [key: string]: unknown;
-                    };
-                    /** @enum {string} */
-                    status?: "ready" | "building" | "failed";
-                    message?: string;
-                    metadata?: {
-                        [key: string]: string;
-                    };
-                };
-            };
-        };
-        responses: {
-            /** @description OK */
-            200: {
-                headers: {
-                    [name: string]: unknown;
-                };
-                content: {
-                    "application/json": components["schemas"]["Release"];
-                };
-            };
-            /** @description Release already exists */
-            409: {
-                headers: {
-                    [name: string]: unknown;
-                };
-                content: {
-                    "application/json": {
-                        error?: string;
-                        id?: string;
-                    };
-                };
-            };
-        };
+  };
+  deleteEnvironment: {
+    parameters: {
+      query?: never;
+      header?: never;
+      path: {
+        /** @description UUID of the environment */
+        environmentId: string;
+      };
+      cookie?: never;
     };
-    setResourceProvidersResources: {
-        parameters: {
-            query?: never;
-            header?: never;
-            path: {
-                /** @description UUID of the scanner */
-                providerId: string;
-            };
-            cookie?: never;
+    requestBody?: never;
+    responses: {
+      /** @description Environment deleted successfully */
+      200: {
+        headers: {
+          [name: string]: unknown;
         };
-        requestBody: {
-            content: {
-                "application/json": {
-                    resources: {
-                        identifier: string;
-                        name: string;
-                        version: string;
-                        kind: string;
-                        config: {
-                            [key: string]: unknown;
-                        };
-                        metadata: {
-                            [key: string]: string;
-                        };
-                    }[];
-                };
-            };
-        };
-        responses: {
-            /** @description Successfully updated the deployment resources */
-            200: {
-                headers: {
-                    [name: string]: unknown;
-                };
-                content?: never;
-            };
-            /** @description Invalid request */
-            400: {
-                headers: {
-                    [name: string]: unknown;
-                };
-                content?: never;
-            };
-            /** @description Deployment resources not found */
-            404: {
-                headers: {
-                    [name: string]: unknown;
-                };
-                content?: never;
-            };
-            /** @description Internal server error */
-            500: {
-                headers: {
-                    [name: string]: unknown;
-                };
-                content?: never;
-            };
-        };
+        content?: never;
+      };
     };
-    createResourceSchema: {
-        parameters: {
-            query?: never;
-            header?: never;
-            path?: never;
-            cookie?: never;
-        };
-        requestBody: {
-            content: {
-                "application/json": {
-                    /**
-                     * Format: uuid
-                     * @description The ID of the workspace
-                     */
-                    workspaceId: string;
-                    /** @description Version of the schema */
-                    version: string;
-                    /** @description Kind of resource this schema is for */
-                    kind: string;
-                    /** @description The JSON schema definition */
-                    jsonSchema: Record<string, never>;
-                };
-            };
-        };
-        responses: {
-            /** @description Resource schema created successfully */
-            201: {
-                headers: {
-                    [name: string]: unknown;
-                };
-                content: {
-                    "application/json": {
-                        /** Format: uuid */
-                        id?: string;
-                        /** Format: uuid */
-                        workspaceId?: string;
-                        version?: string;
-                        kind?: string;
-                        jsonSchema?: Record<string, never>;
-                    };
-                };
-            };
-            /** @description Invalid request body */
-            400: {
-                headers: {
-                    [name: string]: unknown;
-                };
-                content: {
-                    "application/json": {
-                        error?: string;
-                    };
-                };
-            };
-            /** @description Schema already exists for this version and kind */
-            409: {
-                headers: {
-                    [name: string]: unknown;
-                };
-                content: {
-                    "application/json": {
-                        error?: string;
-                        /** Format: uuid */
-                        id?: string;
-                    };
-                };
-            };
-        };
+  };
+  getResourcesForEnvironment: {
+    parameters: {
+      query?: never;
+      header?: never;
+      path: {
+        /** @description UUID of the environment */
+        environmentId: string;
+      };
+      cookie?: never;
     };
-    deleteResourceSchema: {
-        parameters: {
-            query?: never;
-            header?: never;
-            path: {
-                /** @description UUID of the schema to delete */
-                schemaId: string;
-            };
-            cookie?: never;
+    requestBody?: never;
+    responses: {
+      /** @description OK */
+      200: {
+        headers: {
+          [name: string]: unknown;
         };
-        requestBody?: never;
-        responses: {
-            /** @description Schema deleted successfully */
-            200: {
-                headers: {
-                    [name: string]: unknown;
-                };
-                content: {
-                    "application/json": {
-                        /** Format: uuid */
-                        id?: string;
-                    };
-                };
-            };
-            /** @description Schema not found */
-            404: {
-                headers: {
-                    [name: string]: unknown;
-                };
-                content: {
-                    "application/json": {
-                        /** @example Schema not found */
-                        error?: string;
-                    };
-                };
-            };
+        content: {
+          "application/json": {
+            resources?: {
+              id?: string;
+              name?: string;
+              identifier?: string;
+              kind?: string;
+              version?: string;
+            }[];
+            count?: number;
+          };
         };
+      };
+      /** @description Internal Server Error */
+      500: {
+        headers: {
+          [name: string]: unknown;
+        };
+        content: {
+          "application/json": {
+            error?: string;
+          };
+        };
+      };
     };
-    getResource: {
-        parameters: {
-            query?: never;
-            header?: never;
-            path: {
-                /** @description The resource ID */
-                resourceId: string;
-            };
-            cookie?: never;
-        };
-        requestBody?: never;
-        responses: {
-            /** @description OK */
-            200: {
-                headers: {
-                    [name: string]: unknown;
-                };
-                content: {
-                    "application/json": {
-                        id: string;
-                        name: string;
-                        workspaceId: string;
-                        kind: string;
-                        identifier: string;
-                        version: string;
-                        config: {
-                            [key: string]: unknown;
-                        };
-                        /** Format: date-time */
-                        lockedAt?: string | null;
-                        /** Format: date-time */
-                        updatedAt: string;
-                        provider?: {
-                            id?: string;
-                            name?: string;
-                        } | null;
-                        metadata: {
-                            [key: string]: string;
-                        };
-                        variable: {
-                            [key: string]: string;
-                        };
-                    };
-                };
-            };
-            /** @description Unauthorized */
-            401: {
-                headers: {
-                    [name: string]: unknown;
-                };
-                content?: never;
-            };
-            /** @description Permission denied */
-            403: {
-                headers: {
-                    [name: string]: unknown;
-                };
-                content?: never;
-            };
-            /** @description Resource not found */
-            404: {
-                headers: {
-                    [name: string]: unknown;
-                };
-                content: {
-                    "application/json": {
-                        /** @example Resource not found */
-                        error: string;
-                    };
-                };
-            };
-        };
+  };
+  createEnvironment: {
+    parameters: {
+      query?: never;
+      header?: never;
+      path?: never;
+      cookie?: never;
     };
-    deleteResource: {
-        parameters: {
-            query?: never;
-            header?: never;
-            path: {
-                /** @description The resource ID */
-                resourceId: string;
-            };
-            cookie?: never;
+    requestBody: {
+      content: {
+        "application/json": {
+          /**
+           * @description The directory path of the environment
+           * @default
+           * @example my/env/path
+           */
+          directory?: string;
+          systemId: string;
+          name: string;
+          description?: string;
+          resourceSelector?: {
+            [key: string]: unknown;
+          };
+          policyId?: string;
+          releaseChannels?: string[];
+          deploymentVersionChannels?: string[];
+          metadata?: {
+            [key: string]: string;
+          };
         };
-        requestBody?: never;
-        responses: {
-            /** @description Resource deleted successfully */
-            200: {
-                headers: {
-                    [name: string]: unknown;
-                };
-                content: {
-                    "application/json": {
-                        success: boolean;
-                    };
-                };
-            };
-            /** @description Unauthorized */
-            401: {
-                headers: {
-                    [name: string]: unknown;
-                };
-                content?: never;
-            };
-            /** @description Permission denied */
-            403: {
-                headers: {
-                    [name: string]: unknown;
-                };
-                content?: never;
-            };
-            /** @description Resource not found */
-            404: {
-                headers: {
-                    [name: string]: unknown;
-                };
-                content: {
-                    "application/json": {
-                        error: string;
-                    };
-                };
-            };
-        };
+      };
     };
-    updateResource: {
-        parameters: {
-            query?: never;
-            header?: never;
-            path: {
-                resourceId: string;
-            };
-            cookie?: never;
+    responses: {
+      /** @description Environment created successfully */
+      200: {
+        headers: {
+          [name: string]: unknown;
         };
-        requestBody: {
-            content: {
-                "application/json": {
-                    name?: string;
-                    version?: string;
-                    kind?: string;
-                    identifier?: string;
-                    workspaceId?: string;
-                    metadata?: {
-                        [key: string]: string;
-                    };
-                    variables?: components["schemas"]["Variable"][];
-                };
-            };
+        content: {
+          "application/json": components["schemas"]["Environment"];
         };
-        responses: {
-            /** @description Resource updated successfully */
-            200: {
-                headers: {
-                    [name: string]: unknown;
-                };
-                content: {
-                    "application/json": {
-                        id: string;
-                        name: string;
-                        workspaceId: string;
-                        kind: string;
-                        identifier: string;
-                        version: string;
-                        config: {
-                            [key: string]: unknown;
-                        };
-                        metadata: {
-                            [key: string]: string;
-                        };
-                    };
-                };
-            };
-            /** @description Unauthorized */
-            401: {
-                headers: {
-                    [name: string]: unknown;
-                };
-                content?: never;
-            };
-            /** @description Permission denied */
-            403: {
-                headers: {
-                    [name: string]: unknown;
-                };
-                content?: never;
-            };
-            /** @description Resource not found */
-            404: {
-                headers: {
-                    [name: string]: unknown;
-                };
-                content: {
-                    "application/json": {
-                        error: string;
-                    };
-                };
-            };
+      };
+      /** @description Environment already exists */
+      409: {
+        headers: {
+          [name: string]: unknown;
         };
+        content: {
+          "application/json": {
+            error?: string;
+            id?: string;
+          };
+        };
+      };
+      /** @description Failed to create environment */
+      500: {
+        headers: {
+          [name: string]: unknown;
+        };
+        content: {
+          "application/json": {
+            error: string;
+          };
+        };
+      };
     };
-    upsertResource: {
-        parameters: {
-            query?: never;
-            header?: never;
-            path?: never;
-            cookie?: never;
-        };
-        requestBody: {
-            content: {
-                "application/json": {
-                    /** Format: uuid */
-                    workspaceId: string;
-                    name: string;
-                    kind: string;
-                    identifier: string;
-                    version: string;
-                    config: Record<string, never>;
-                    metadata?: {
-                        [key: string]: string;
-                    };
-                    variables?: components["schemas"]["Variable"][];
-                };
-            };
-        };
-        responses: {
-            /** @description The created or updated resource */
-            200: {
-                headers: {
-                    [name: string]: unknown;
-                };
-                content: {
-                    "application/json": components["schemas"]["Resource"];
-                };
-            };
-        };
+  };
+  getAgentRunningJobs: {
+    parameters: {
+      query?: never;
+      header?: never;
+      path: {
+        /** @description The execution ID */
+        agentId: string;
+      };
+      cookie?: never;
     };
-    deleteEnvironmentByName: {
-        parameters: {
-            query?: never;
-            header?: never;
-            path: {
-                /** @description UUID of the system */
-                systemId: string;
-                /** @description Name of the environment */
-                name: string;
-            };
-            cookie?: never;
+    requestBody?: never;
+    responses: {
+      /** @description OK */
+      200: {
+        headers: {
+          [name: string]: unknown;
         };
-        requestBody?: never;
-        responses: {
-            /** @description Environment deleted successfully */
-            200: {
-                headers: {
-                    [name: string]: unknown;
-                };
-                content?: never;
-            };
+        content: {
+          "application/json": components["schemas"]["Job"][];
         };
+      };
     };
-    getSystem: {
-        parameters: {
-            query?: never;
-            header?: never;
-            path: {
-                /** @description UUID of the system */
-                systemId: string;
-            };
-            cookie?: never;
-        };
-        requestBody?: never;
-        responses: {
-            /** @description System retrieved successfully */
-            200: {
-                headers: {
-                    [name: string]: unknown;
-                };
-                content: {
-                    "application/json": components["schemas"]["System"] & {
-                        environments?: components["schemas"]["Environment"][];
-                        deployments?: components["schemas"]["Deployment"][];
-                    };
-                };
-            };
-        };
+  };
+  acknowledgeAgentJob: {
+    parameters: {
+      query?: never;
+      header?: never;
+      path: {
+        /** @description The ID of the job agent */
+        agentId: string;
+      };
+      cookie?: never;
     };
-    deleteSystem: {
-        parameters: {
-            query?: never;
-            header?: never;
-            path: {
-                systemId: string;
-            };
-            cookie?: never;
+    requestBody?: never;
+    responses: {
+      /** @description Successfully acknowledged job */
+      200: {
+        headers: {
+          [name: string]: unknown;
         };
-        requestBody?: never;
-        responses: {
-            /** @description System deleted successfully */
-            200: {
-                headers: {
-                    [name: string]: unknown;
-                };
-                content: {
-                    "application/json": {
-                        /** @example System deleted */
-                        message?: string;
-                    };
-                };
-            };
-            /** @description System not found */
-            404: {
-                headers: {
-                    [name: string]: unknown;
-                };
-                content: {
-                    "application/json": {
-                        /** @example System not found */
-                        error?: string;
-                    };
-                };
-            };
-            /** @description Internal server error */
-            500: {
-                headers: {
-                    [name: string]: unknown;
-                };
-                content: {
-                    "application/json": {
-                        /** @example Internal server error */
-                        error?: string;
-                    };
-                };
-            };
+        content: {
+          "application/json": {
+            job?: components["schemas"]["Job"];
+          };
         };
+      };
+      /** @description Unauthorized */
+      401: {
+        headers: {
+          [name: string]: unknown;
+        };
+        content: {
+          "application/json": {
+            error?: string;
+          };
+        };
+      };
+      /** @description Workspace not found */
+      404: {
+        headers: {
+          [name: string]: unknown;
+        };
+        content: {
+          "application/json": {
+            error?: string;
+          };
+        };
+      };
     };
-    updateSystem: {
-        parameters: {
-            query?: never;
-            header?: never;
-            path: {
-                /** @description UUID of the system */
-                systemId: string;
-            };
-            cookie?: never;
-        };
-        requestBody: {
-            content: {
-                "application/json": {
-                    /** @description Name of the system */
-                    name?: string;
-                    /** @description Slug of the system */
-                    slug?: string;
-                    /** @description Description of the system */
-                    description?: string;
-                    /**
-                     * Format: uuid
-                     * @description UUID of the workspace
-                     */
-                    workspaceId?: string;
-                };
-            };
-        };
-        responses: {
-            /** @description System updated successfully */
-            200: {
-                headers: {
-                    [name: string]: unknown;
-                };
-                content: {
-                    "application/json": components["schemas"]["System"];
-                };
-            };
-            /** @description System not found */
-            404: {
-                headers: {
-                    [name: string]: unknown;
-                };
-                content: {
-                    "application/json": {
-                        /** @example System not found */
-                        error?: string;
-                    };
-                };
-            };
-            /** @description Internal server error */
-            500: {
-                headers: {
-                    [name: string]: unknown;
-                };
-                content: {
-                    "application/json": {
-                        /** @example Internal server error */
-                        error?: string;
-                    };
-                };
-            };
-        };
+  };
+  getNextJobs: {
+    parameters: {
+      query?: never;
+      header?: never;
+      path: {
+        /** @description The agent ID */
+        agentId: string;
+      };
+      cookie?: never;
     };
-    createSystem: {
-        parameters: {
-            query?: never;
-            header?: never;
-            path?: never;
-            cookie?: never;
+    requestBody?: never;
+    responses: {
+      /** @description OK */
+      200: {
+        headers: {
+          [name: string]: unknown;
         };
-        requestBody?: {
-            content: {
-                "application/json": {
-                    /**
-                     * Format: uuid
-                     * @description The workspace ID of the system
-                     */
-                    workspaceId: string;
-                    /** @description The name of the system */
-                    name: string;
-                    /** @description The slug of the system */
-                    slug: string;
-                    /** @description The description of the system */
-                    description?: string;
-                };
-            };
+        content: {
+          "application/json": {
+            jobs?: components["schemas"]["Job"][];
+          };
         };
-        responses: {
-            /** @description System created successfully */
-            201: {
-                headers: {
-                    [name: string]: unknown;
-                };
-                content: {
-                    "application/json": components["schemas"]["System"];
-                };
-            };
-            /** @description Bad request */
-            400: {
-                headers: {
-                    [name: string]: unknown;
-                };
-                content: {
-                    "application/json": {
-                        error?: {
-                            /** @enum {string} */
-                            code: "invalid_type" | "invalid_literal" | "custom";
-                            message: string;
-                            path: (string | number)[];
-                        }[];
-                    };
-                };
-            };
-            /** @description Internal server error */
-            500: {
-                headers: {
-                    [name: string]: unknown;
-                };
-                content: {
-                    "application/json": {
-                        /** @example Internal Server Error */
-                        error?: string;
-                    };
-                };
-            };
-        };
+      };
     };
-    listDeployments: {
-        parameters: {
-            query?: never;
-            header?: never;
-            path: {
-                /** @description The ID of the workspace */
-                workspaceId: string;
-            };
-            cookie?: never;
-        };
-        requestBody?: never;
-        responses: {
-            /** @description All deployments */
-            200: {
-                headers: {
-                    [name: string]: unknown;
-                };
-                content: {
-                    "application/json": {
-                        data?: components["schemas"]["Deployment"][];
-                    };
-                };
-            };
-        };
+  };
+  upsertJobAgent: {
+    parameters: {
+      query?: never;
+      header?: never;
+      path?: never;
+      cookie?: never;
     };
-    listEnvironments: {
-        parameters: {
-            query?: never;
-            header?: never;
-            path: {
-                /** @description The ID of the workspace */
-                workspaceId: string;
-            };
-            cookie?: never;
+    requestBody: {
+      content: {
+        "application/json": {
+          workspaceId: string;
+          name: string;
+          type: string;
         };
-        requestBody?: never;
-        responses: {
-            /** @description All environments */
-            200: {
-                headers: {
-                    [name: string]: unknown;
-                };
-                content: {
-                    "application/json": {
-                        data?: components["schemas"]["Environment"][];
-                    };
-                };
-            };
-        };
+      };
     };
-    getWorkspace: {
-        parameters: {
-            query?: never;
-            header?: never;
-            path: {
-                workspaceId: string;
-            };
-            cookie?: never;
+    responses: {
+      /** @description Successfully retrieved or created the agent */
+      200: {
+        headers: {
+          [name: string]: unknown;
         };
-        requestBody?: never;
-        responses: {
-            /** @description Workspace found */
-            200: {
-                headers: {
-                    [name: string]: unknown;
-                };
-                content: {
-                    "application/json": components["schemas"]["Workspace"];
-                };
-            };
-            /** @description Workspace not found */
-            404: {
-                headers: {
-                    [name: string]: unknown;
-                };
-                content: {
-                    "application/json": {
-                        error?: string;
-                    };
-                };
-            };
-            /** @description Internal server error */
-            500: {
-                headers: {
-                    [name: string]: unknown;
-                };
-                content: {
-                    "application/json": {
-                        error?: string;
-                    };
-                };
-            };
+        content: {
+          "application/json": {
+            id: string;
+            name: string;
+            workspaceId: string;
+          };
         };
+      };
+      /** @description Internal server error */
+      500: {
+        headers: {
+          [name: string]: unknown;
+        };
+        content?: never;
+      };
     };
-    deletePolicyByName: {
-        parameters: {
-            query?: never;
-            header?: never;
-            path: {
-                /** @description ID of the workspace */
-                workspaceId: string;
-                /** @description Name of the policy */
-                name: string;
-            };
-            cookie?: never;
-        };
-        requestBody?: never;
-        responses: {
-            /** @description Successfully deleted the policy */
-            200: {
-                headers: {
-                    [name: string]: unknown;
-                };
-                content: {
-                    "application/json": {
-                        /** @example true */
-                        success?: boolean;
-                    };
-                };
-            };
-            /** @description Unauthorized */
-            401: {
-                headers: {
-                    [name: string]: unknown;
-                };
-                content?: never;
-            };
-            /** @description Permission denied */
-            403: {
-                headers: {
-                    [name: string]: unknown;
-                };
-                content?: never;
-            };
-            /** @description Policy not found */
-            404: {
-                headers: {
-                    [name: string]: unknown;
-                };
-                content: {
-                    "application/json": {
-                        /** @example Policy not found */
-                        error?: string;
-                    };
-                };
-            };
-            /** @description Internal server error */
-            500: {
-                headers: {
-                    [name: string]: unknown;
-                };
-                content?: never;
-            };
-        };
+  };
+  acknowledgeJob: {
+    parameters: {
+      query?: never;
+      header?: never;
+      path: {
+        /** @description The job ID */
+        jobId: string;
+      };
+      cookie?: never;
     };
-    upsertResourceProvider: {
-        parameters: {
-            query?: never;
-            header?: never;
-            path: {
-                /** @description Name of the workspace */
-                workspaceId: string;
-                /** @description Name of the resource provider */
-                name: string;
-            };
-            cookie?: never;
+    requestBody?: never;
+    responses: {
+      /** @description OK */
+      200: {
+        headers: {
+          [name: string]: unknown;
         };
-        requestBody?: never;
-        responses: {
-            /** @description Successfully retrieved or created the resource provider */
-            200: {
-                headers: {
-                    [name: string]: unknown;
-                };
-                content: {
-                    "application/json": {
-                        id: string;
-                        name: string;
-                        workspaceId: string;
-                    };
-                };
-            };
-            /** @description Unauthorized */
-            401: {
-                headers: {
-                    [name: string]: unknown;
-                };
-                content?: never;
-            };
-            /** @description Permission denied */
-            403: {
-                headers: {
-                    [name: string]: unknown;
-                };
-                content?: never;
-            };
-            /** @description Workspace not found */
-            404: {
-                headers: {
-                    [name: string]: unknown;
-                };
-                content?: never;
-            };
-            /** @description Internal server error */
-            500: {
-                headers: {
-                    [name: string]: unknown;
-                };
-                content?: never;
-            };
+        content: {
+          "application/json": {
+            sucess: boolean;
+          };
         };
+      };
+      /** @description Unauthorized */
+      401: {
+        headers: {
+          [name: string]: unknown;
+        };
+        content: {
+          "application/json": {
+            error: string;
+          };
+        };
+      };
     };
-    getResourceByIdentifier: {
-        parameters: {
-            query?: never;
-            header?: never;
-            path: {
-                /** @description ID of the workspace */
-                workspaceId: string;
-                /** @description Identifier of the resource */
-                identifier: string;
-            };
-            cookie?: never;
-        };
-        requestBody?: never;
-        responses: {
-            /** @description Successfully retrieved the resource */
-            200: {
-                headers: {
-                    [name: string]: unknown;
-                };
-                content: {
-                    "application/json": {
-                        id: string;
-                        identifier: string;
-                        workspaceId: string;
-                        providerId: string;
-                        provider?: {
-                            id?: string;
-                            name?: string;
-                            workspaceId?: string;
-                        };
-                        variables?: {
-                            id?: string;
-                            key?: string;
-                            value?: string;
-                        }[];
-                        metadata?: {
-                            [key: string]: string;
-                        };
-                    };
-                };
-            };
-            /** @description Unauthorized */
-            401: {
-                headers: {
-                    [name: string]: unknown;
-                };
-                content?: never;
-            };
-            /** @description Permission denied */
-            403: {
-                headers: {
-                    [name: string]: unknown;
-                };
-                content?: never;
-            };
-            /** @description Resource not found */
-            404: {
-                headers: {
-                    [name: string]: unknown;
-                };
-                content: {
-                    "application/json": {
-                        /** @example Resource not found */
-                        error?: string;
-                    };
-                };
-            };
-            /** @description Internal server error */
-            500: {
-                headers: {
-                    [name: string]: unknown;
-                };
-                content?: never;
-            };
-        };
+  };
+  getJob: {
+    parameters: {
+      query?: never;
+      header?: never;
+      path: {
+        /** @description The job ID */
+        jobId: string;
+      };
+      cookie?: never;
     };
-    deleteResourceByIdentifier: {
-        parameters: {
-            query?: never;
-            header?: never;
-            path: {
-                /** @description ID of the workspace */
-                workspaceId: string;
-                /** @description Identifier of the resource */
-                identifier: string;
-            };
-            cookie?: never;
+    requestBody?: never;
+    responses: {
+      /** @description OK */
+      200: {
+        headers: {
+          [name: string]: unknown;
         };
-        requestBody?: never;
-        responses: {
-            /** @description Successfully deleted the resource */
-            200: {
-                headers: {
-                    [name: string]: unknown;
-                };
-                content: {
-                    "application/json": {
-                        /** @example true */
-                        success?: boolean;
-                    };
-                };
-            };
-            /** @description Unauthorized */
-            401: {
-                headers: {
-                    [name: string]: unknown;
-                };
-                content?: never;
-            };
-            /** @description Permission denied */
-            403: {
-                headers: {
-                    [name: string]: unknown;
-                };
-                content?: never;
-            };
-            /** @description Resource not found */
-            404: {
-                headers: {
-                    [name: string]: unknown;
-                };
-                content: {
-                    "application/json": {
-                        /** @example Resource not found */
-                        error?: string;
-                    };
-                };
-            };
-            /** @description Internal server error */
-            500: {
-                headers: {
-                    [name: string]: unknown;
-                };
-                content?: never;
-            };
+        content: {
+          "application/json": components["schemas"]["JobWithTrigger"];
         };
+      };
+      /** @description Not Found */
+      404: {
+        headers: {
+          [name: string]: unknown;
+        };
+        content: {
+          "application/json": {
+            /** @example Job not found. */
+            error?: string;
+          };
+        };
+      };
     };
-    listResources: {
-        parameters: {
-            query?: never;
-            header?: never;
-            path: {
-                /** @description The ID of the workspace */
-                workspaceId: string;
-            };
-            cookie?: never;
-        };
-        requestBody?: never;
-        responses: {
-            /** @description All resources */
-            200: {
-                headers: {
-                    [name: string]: unknown;
-                };
-                content: {
-                    "application/json": {
-                        resources?: components["schemas"]["Resource"][];
-                    };
-                };
-            };
-        };
+  };
+  updateJob: {
+    parameters: {
+      query?: never;
+      header?: never;
+      path: {
+        /** @description The execution ID */
+        jobId: string;
+      };
+      cookie?: never;
     };
-    listSystems: {
-        parameters: {
-            query?: never;
-            header?: never;
-            path: {
-                /** @description The ID of the workspace */
-                workspaceId: string;
-            };
-            cookie?: never;
+    requestBody: {
+      content: {
+        "application/json": {
+          status?: components["schemas"]["JobStatus"];
+          message?: string | null;
+          externalId?: string | null;
         };
-        requestBody?: never;
-        responses: {
-            /** @description All systems */
-            200: {
-                headers: {
-                    [name: string]: unknown;
-                };
-                content: {
-                    "application/json": {
-                        data?: components["schemas"]["System"][];
-                    };
-                };
-            };
-        };
+      };
     };
-    getWorkspaceBySlug: {
-        parameters: {
-            query?: never;
-            header?: never;
-            path: {
-                workspaceSlug: string;
-            };
-            cookie?: never;
+    responses: {
+      /** @description OK */
+      200: {
+        headers: {
+          [name: string]: unknown;
         };
-        requestBody?: never;
-        responses: {
-            /** @description Workspace found */
-            200: {
-                headers: {
-                    [name: string]: unknown;
-                };
-                content: {
-                    "application/json": components["schemas"]["Workspace"];
-                };
-            };
-            /** @description Workspace not found */
-            404: {
-                headers: {
-                    [name: string]: unknown;
-                };
-                content: {
-                    "application/json": {
-                        error?: string;
-                    };
-                };
-            };
-            /** @description Internal server error */
-            500: {
-                headers: {
-                    [name: string]: unknown;
-                };
-                content: {
-                    "application/json": {
-                        error?: string;
-                    };
-                };
-            };
+        content: {
+          "application/json": {
+            id: string;
+          };
         };
+      };
     };
+  };
+  deletePolicy: {
+    parameters: {
+      query?: never;
+      header?: never;
+      path: {
+        policyId: string;
+      };
+      cookie?: never;
+    };
+    requestBody?: never;
+    responses: {
+      /** @description OK */
+      200: {
+        headers: {
+          [name: string]: unknown;
+        };
+        content: {
+          "application/json": {
+            count?: number;
+          };
+        };
+      };
+      /** @description Internal Server Error */
+      500: {
+        headers: {
+          [name: string]: unknown;
+        };
+        content?: never;
+      };
+    };
+  };
+  getReleaseTargetsForPolicy: {
+    parameters: {
+      query?: never;
+      header?: never;
+      path: {
+        /** @description UUID of the policy */
+        policyId: string;
+      };
+      cookie?: never;
+    };
+    requestBody?: never;
+    responses: {
+      /** @description OK */
+      200: {
+        headers: {
+          [name: string]: unknown;
+        };
+        content: {
+          "application/json": {
+            releaseTargets?: {
+              id?: string;
+              name?: string;
+              description?: string;
+              policyTarget?: {
+                id?: string;
+                name?: string;
+                policyId?: string;
+                description?: string;
+              };
+              resource?: {
+                id?: string;
+                name?: string;
+                identifier?: string;
+                kind?: string;
+                version?: string;
+              };
+              environment?: {
+                id?: string;
+                name?: string;
+              };
+            }[];
+            count?: number;
+          };
+        };
+      };
+      /** @description Internal Server Error */
+      500: {
+        headers: {
+          [name: string]: unknown;
+        };
+        content: {
+          "application/json": {
+            error?: string;
+          };
+        };
+      };
+    };
+  };
+  upsertPolicy: {
+    parameters: {
+      query?: never;
+      header?: never;
+      path?: never;
+      cookie?: never;
+    };
+    requestBody: {
+      content: {
+        "application/json": {
+          name: string;
+          description?: string;
+          priority?: number;
+          enabled?: boolean;
+          workspaceId: string;
+          targets: components["schemas"]["PolicyTarget"][];
+          denyWindows?: {
+            timeZone: string;
+            rrule?: {
+              [key: string]: unknown;
+            };
+            /** Format: date-time */
+            dtend?: string;
+          }[];
+          deploymentVersionSelector?: components["schemas"]["DeploymentVersionSelector"];
+          versionAnyApprovals?: {
+            requiredApprovalsCount?: number;
+          }[];
+          versionUserApprovals?: components["schemas"]["VersionUserApproval"][];
+          versionRoleApprovals?: {
+            roleId: string;
+            requiredApprovalsCount?: number;
+          }[];
+        };
+      };
+    };
+    responses: {
+      /** @description OK */
+      200: {
+        headers: {
+          [name: string]: unknown;
+        };
+        content: {
+          "application/json": components["schemas"]["Policy1"];
+        };
+      };
+      /** @description Internal Server Error */
+      500: {
+        headers: {
+          [name: string]: unknown;
+        };
+        content: {
+          "application/json": {
+            error?: string;
+          };
+        };
+      };
+    };
+  };
+  createJobToResourceRelationship: {
+    parameters: {
+      query?: never;
+      header?: never;
+      path?: never;
+      cookie?: never;
+    };
+    requestBody: {
+      content: {
+        "application/json": {
+          /**
+           * Format: uuid
+           * @description Unique identifier of the job
+           * @example 123e4567-e89b-12d3-a456-426614174000
+           */
+          jobId: string;
+          /**
+           * @description Unique identifier of the resource
+           * @example resource-123
+           */
+          resourceIdentifier: string;
+        };
+      };
+    };
+    responses: {
+      /** @description Relationship created successfully */
+      200: {
+        headers: {
+          [name: string]: unknown;
+        };
+        content: {
+          "application/json": {
+            /** @example Relationship created successfully */
+            message?: string;
+          };
+        };
+      };
+      /** @description Invalid request body */
+      400: {
+        headers: {
+          [name: string]: unknown;
+        };
+        content: {
+          "application/json": {
+            /** @example Invalid jobId format */
+            error?: string;
+          };
+        };
+      };
+      /** @description Job or resource not found */
+      404: {
+        headers: {
+          [name: string]: unknown;
+        };
+        content: {
+          "application/json": {
+            /** @example Job with specified ID not found */
+            error?: string;
+          };
+        };
+      };
+      /** @description Relationship already exists */
+      409: {
+        headers: {
+          [name: string]: unknown;
+        };
+        content: {
+          "application/json": {
+            /** @example Relationship between job and resource already exists */
+            error?: string;
+          };
+        };
+      };
+      /** @description Internal server error */
+      500: {
+        headers: {
+          [name: string]: unknown;
+        };
+        content: {
+          "application/json": {
+            /** @example Internal server error occurred */
+            error?: string;
+          };
+        };
+      };
+    };
+  };
+  createResourceToResourceRelationship: {
+    parameters: {
+      query?: never;
+      header?: never;
+      path?: never;
+      cookie?: never;
+    };
+    requestBody: {
+      content: {
+        "application/json": {
+          /**
+           * Format: uuid
+           * @description The workspace ID
+           * @example 123e4567-e89b-12d3-a456-426614174000
+           */
+          workspaceId: string;
+          /**
+           * @description The identifier of the resource to connect
+           * @example my-resource
+           */
+          fromIdentifier: string;
+          /**
+           * @description The identifier of the resource to connect to
+           * @example my-resource
+           */
+          toIdentifier: string;
+          /**
+           * @description The type of relationship
+           * @example depends_on
+           */
+          type: string;
+        };
+      };
+    };
+    responses: {
+      /** @description Relationship created */
+      200: {
+        headers: {
+          [name: string]: unknown;
+        };
+        content: {
+          "application/json": {
+            /** @example Relationship created successfully */
+            message?: string;
+          };
+        };
+      };
+      /** @description Invalid request body */
+      400: {
+        headers: {
+          [name: string]: unknown;
+        };
+        content: {
+          "application/json": {
+            error?: string;
+          };
+        };
+      };
+      /** @description Resource not found */
+      404: {
+        headers: {
+          [name: string]: unknown;
+        };
+        content: {
+          "application/json": {
+            error?: string;
+          };
+        };
+      };
+      /** @description Relationship already exists */
+      409: {
+        headers: {
+          [name: string]: unknown;
+        };
+        content: {
+          "application/json": {
+            error?: string;
+          };
+        };
+      };
+      /** @description Internal server error */
+      500: {
+        headers: {
+          [name: string]: unknown;
+        };
+        content: {
+          "application/json": {
+            error?: string;
+          };
+        };
+      };
+    };
+  };
+  createReleaseChannel: {
+    parameters: {
+      query?: never;
+      header?: never;
+      path?: never;
+      cookie?: never;
+    };
+    requestBody: {
+      content: {
+        "application/json": {
+          deploymentId: string;
+          name: string;
+          description?: string | null;
+          releaseSelector: {
+            [key: string]: unknown;
+          };
+        };
+      };
+    };
+    responses: {
+      /** @description Release channel created successfully */
+      200: {
+        headers: {
+          [name: string]: unknown;
+        };
+        content: {
+          "application/json": {
+            id: string;
+            deploymentId: string;
+            name: string;
+            description?: string | null;
+            /** Format: date-time */
+            createdAt: string;
+            releaseSelector?: {
+              [key: string]: unknown;
+            };
+          };
+        };
+      };
+      /** @description Unauthorized */
+      401: {
+        headers: {
+          [name: string]: unknown;
+        };
+        content: {
+          "application/json": {
+            error: string;
+          };
+        };
+      };
+      /** @description Forbidden */
+      403: {
+        headers: {
+          [name: string]: unknown;
+        };
+        content: {
+          "application/json": {
+            error: string;
+          };
+        };
+      };
+      /** @description Release channel already exists */
+      409: {
+        headers: {
+          [name: string]: unknown;
+        };
+        content: {
+          "application/json": {
+            error: string;
+            id: string;
+          };
+        };
+      };
+      /** @description Failed to create release channel */
+      500: {
+        headers: {
+          [name: string]: unknown;
+        };
+        content: {
+          "application/json": {
+            error: string;
+          };
+        };
+      };
+    };
+  };
+  updateRelease: {
+    parameters: {
+      query?: never;
+      header?: never;
+      path: {
+        /** @description The release ID */
+        releaseId: string;
+      };
+      cookie?: never;
+    };
+    requestBody: {
+      content: {
+        "application/json": {
+          version?: string;
+          deploymentId?: string;
+          /** Format: date-time */
+          createdAt?: string;
+          name?: string;
+          config?: {
+            [key: string]: unknown;
+          };
+          jobAgentConfig?: {
+            [key: string]: unknown;
+          };
+          /** @enum {string} */
+          status?: "ready" | "building" | "failed";
+          message?: string;
+          metadata?: {
+            [key: string]: string;
+          };
+        };
+      };
+    };
+    responses: {
+      /** @description OK */
+      200: {
+        headers: {
+          [name: string]: unknown;
+        };
+        content: {
+          "application/json": components["schemas"]["Release"];
+        };
+      };
+    };
+  };
+  upsertRelease: {
+    parameters: {
+      query?: never;
+      header?: never;
+      path?: never;
+      cookie?: never;
+    };
+    requestBody: {
+      content: {
+        "application/json": {
+          version: string;
+          deploymentId: string;
+          /** Format: date-time */
+          createdAt?: string;
+          name?: string;
+          config?: {
+            [key: string]: unknown;
+          };
+          jobAgentConfig?: {
+            [key: string]: unknown;
+          };
+          /** @enum {string} */
+          status?: "ready" | "building" | "failed";
+          message?: string;
+          metadata?: {
+            [key: string]: string;
+          };
+        };
+      };
+    };
+    responses: {
+      /** @description OK */
+      200: {
+        headers: {
+          [name: string]: unknown;
+        };
+        content: {
+          "application/json": components["schemas"]["Release"];
+        };
+      };
+      /** @description Release already exists */
+      409: {
+        headers: {
+          [name: string]: unknown;
+        };
+        content: {
+          "application/json": {
+            error?: string;
+            id?: string;
+          };
+        };
+      };
+    };
+  };
+  setResourceProvidersResources: {
+    parameters: {
+      query?: never;
+      header?: never;
+      path: {
+        /** @description UUID of the scanner */
+        providerId: string;
+      };
+      cookie?: never;
+    };
+    requestBody: {
+      content: {
+        "application/json": {
+          resources: {
+            identifier: string;
+            name: string;
+            version: string;
+            kind: string;
+            config: {
+              [key: string]: unknown;
+            };
+            metadata: {
+              [key: string]: string;
+            };
+          }[];
+        };
+      };
+    };
+    responses: {
+      /** @description Successfully updated the deployment resources */
+      200: {
+        headers: {
+          [name: string]: unknown;
+        };
+        content?: never;
+      };
+      /** @description Invalid request */
+      400: {
+        headers: {
+          [name: string]: unknown;
+        };
+        content?: never;
+      };
+      /** @description Deployment resources not found */
+      404: {
+        headers: {
+          [name: string]: unknown;
+        };
+        content?: never;
+      };
+      /** @description Internal server error */
+      500: {
+        headers: {
+          [name: string]: unknown;
+        };
+        content?: never;
+      };
+    };
+  };
+  createResourceSchema: {
+    parameters: {
+      query?: never;
+      header?: never;
+      path?: never;
+      cookie?: never;
+    };
+    requestBody: {
+      content: {
+        "application/json": {
+          /**
+           * Format: uuid
+           * @description The ID of the workspace
+           */
+          workspaceId: string;
+          /** @description Version of the schema */
+          version: string;
+          /** @description Kind of resource this schema is for */
+          kind: string;
+          /** @description The JSON schema definition */
+          jsonSchema: Record<string, never>;
+        };
+      };
+    };
+    responses: {
+      /** @description Resource schema created successfully */
+      201: {
+        headers: {
+          [name: string]: unknown;
+        };
+        content: {
+          "application/json": {
+            /** Format: uuid */
+            id?: string;
+            /** Format: uuid */
+            workspaceId?: string;
+            version?: string;
+            kind?: string;
+            jsonSchema?: Record<string, never>;
+          };
+        };
+      };
+      /** @description Invalid request body */
+      400: {
+        headers: {
+          [name: string]: unknown;
+        };
+        content: {
+          "application/json": {
+            error?: string;
+          };
+        };
+      };
+      /** @description Schema already exists for this version and kind */
+      409: {
+        headers: {
+          [name: string]: unknown;
+        };
+        content: {
+          "application/json": {
+            error?: string;
+            /** Format: uuid */
+            id?: string;
+          };
+        };
+      };
+    };
+  };
+  deleteResourceSchema: {
+    parameters: {
+      query?: never;
+      header?: never;
+      path: {
+        /** @description UUID of the schema to delete */
+        schemaId: string;
+      };
+      cookie?: never;
+    };
+    requestBody?: never;
+    responses: {
+      /** @description Schema deleted successfully */
+      200: {
+        headers: {
+          [name: string]: unknown;
+        };
+        content: {
+          "application/json": {
+            /** Format: uuid */
+            id?: string;
+          };
+        };
+      };
+      /** @description Schema not found */
+      404: {
+        headers: {
+          [name: string]: unknown;
+        };
+        content: {
+          "application/json": {
+            /** @example Schema not found */
+            error?: string;
+          };
+        };
+      };
+    };
+  };
+  getResource: {
+    parameters: {
+      query?: never;
+      header?: never;
+      path: {
+        /** @description The resource ID */
+        resourceId: string;
+      };
+      cookie?: never;
+    };
+    requestBody?: never;
+    responses: {
+      /** @description OK */
+      200: {
+        headers: {
+          [name: string]: unknown;
+        };
+        content: {
+          "application/json": {
+            id: string;
+            name: string;
+            workspaceId: string;
+            kind: string;
+            identifier: string;
+            version: string;
+            config: {
+              [key: string]: unknown;
+            };
+            /** Format: date-time */
+            lockedAt?: string | null;
+            /** Format: date-time */
+            updatedAt: string;
+            provider?: {
+              id?: string;
+              name?: string;
+            } | null;
+            metadata: {
+              [key: string]: string;
+            };
+            variable: {
+              [key: string]: string;
+            };
+          };
+        };
+      };
+      /** @description Unauthorized */
+      401: {
+        headers: {
+          [name: string]: unknown;
+        };
+        content?: never;
+      };
+      /** @description Permission denied */
+      403: {
+        headers: {
+          [name: string]: unknown;
+        };
+        content?: never;
+      };
+      /** @description Resource not found */
+      404: {
+        headers: {
+          [name: string]: unknown;
+        };
+        content: {
+          "application/json": {
+            /** @example Resource not found */
+            error: string;
+          };
+        };
+      };
+    };
+  };
+  deleteResource: {
+    parameters: {
+      query?: never;
+      header?: never;
+      path: {
+        /** @description The resource ID */
+        resourceId: string;
+      };
+      cookie?: never;
+    };
+    requestBody?: never;
+    responses: {
+      /** @description Resource deleted successfully */
+      200: {
+        headers: {
+          [name: string]: unknown;
+        };
+        content: {
+          "application/json": {
+            success: boolean;
+          };
+        };
+      };
+      /** @description Unauthorized */
+      401: {
+        headers: {
+          [name: string]: unknown;
+        };
+        content?: never;
+      };
+      /** @description Permission denied */
+      403: {
+        headers: {
+          [name: string]: unknown;
+        };
+        content?: never;
+      };
+      /** @description Resource not found */
+      404: {
+        headers: {
+          [name: string]: unknown;
+        };
+        content: {
+          "application/json": {
+            error: string;
+          };
+        };
+      };
+    };
+  };
+  updateResource: {
+    parameters: {
+      query?: never;
+      header?: never;
+      path: {
+        resourceId: string;
+      };
+      cookie?: never;
+    };
+    requestBody: {
+      content: {
+        "application/json": {
+          name?: string;
+          version?: string;
+          kind?: string;
+          identifier?: string;
+          workspaceId?: string;
+          metadata?: {
+            [key: string]: string;
+          };
+          variables?: components["schemas"]["Variable"][];
+        };
+      };
+    };
+    responses: {
+      /** @description Resource updated successfully */
+      200: {
+        headers: {
+          [name: string]: unknown;
+        };
+        content: {
+          "application/json": {
+            id: string;
+            name: string;
+            workspaceId: string;
+            kind: string;
+            identifier: string;
+            version: string;
+            config: {
+              [key: string]: unknown;
+            };
+            metadata: {
+              [key: string]: string;
+            };
+          };
+        };
+      };
+      /** @description Unauthorized */
+      401: {
+        headers: {
+          [name: string]: unknown;
+        };
+        content?: never;
+      };
+      /** @description Permission denied */
+      403: {
+        headers: {
+          [name: string]: unknown;
+        };
+        content?: never;
+      };
+      /** @description Resource not found */
+      404: {
+        headers: {
+          [name: string]: unknown;
+        };
+        content: {
+          "application/json": {
+            error: string;
+          };
+        };
+      };
+    };
+  };
+  upsertResource: {
+    parameters: {
+      query?: never;
+      header?: never;
+      path?: never;
+      cookie?: never;
+    };
+    requestBody: {
+      content: {
+        "application/json": {
+          /** Format: uuid */
+          workspaceId: string;
+          name: string;
+          kind: string;
+          identifier: string;
+          version: string;
+          config: Record<string, never>;
+          metadata?: {
+            [key: string]: string;
+          };
+          variables?: components["schemas"]["Variable"][];
+        };
+      };
+    };
+    responses: {
+      /** @description The created or updated resource */
+      200: {
+        headers: {
+          [name: string]: unknown;
+        };
+        content: {
+          "application/json": components["schemas"]["Resource"];
+        };
+      };
+    };
+  };
+  deleteEnvironmentByName: {
+    parameters: {
+      query?: never;
+      header?: never;
+      path: {
+        /** @description UUID of the system */
+        systemId: string;
+        /** @description Name of the environment */
+        name: string;
+      };
+      cookie?: never;
+    };
+    requestBody?: never;
+    responses: {
+      /** @description Environment deleted successfully */
+      200: {
+        headers: {
+          [name: string]: unknown;
+        };
+        content?: never;
+      };
+    };
+  };
+  getSystem: {
+    parameters: {
+      query?: never;
+      header?: never;
+      path: {
+        /** @description UUID of the system */
+        systemId: string;
+      };
+      cookie?: never;
+    };
+    requestBody?: never;
+    responses: {
+      /** @description System retrieved successfully */
+      200: {
+        headers: {
+          [name: string]: unknown;
+        };
+        content: {
+          "application/json": components["schemas"]["System"] & {
+            environments?: components["schemas"]["Environment"][];
+            deployments?: components["schemas"]["Deployment"][];
+          };
+        };
+      };
+    };
+  };
+  deleteSystem: {
+    parameters: {
+      query?: never;
+      header?: never;
+      path: {
+        systemId: string;
+      };
+      cookie?: never;
+    };
+    requestBody?: never;
+    responses: {
+      /** @description System deleted successfully */
+      200: {
+        headers: {
+          [name: string]: unknown;
+        };
+        content: {
+          "application/json": {
+            /** @example System deleted */
+            message?: string;
+          };
+        };
+      };
+      /** @description System not found */
+      404: {
+        headers: {
+          [name: string]: unknown;
+        };
+        content: {
+          "application/json": {
+            /** @example System not found */
+            error?: string;
+          };
+        };
+      };
+      /** @description Internal server error */
+      500: {
+        headers: {
+          [name: string]: unknown;
+        };
+        content: {
+          "application/json": {
+            /** @example Internal server error */
+            error?: string;
+          };
+        };
+      };
+    };
+  };
+  updateSystem: {
+    parameters: {
+      query?: never;
+      header?: never;
+      path: {
+        /** @description UUID of the system */
+        systemId: string;
+      };
+      cookie?: never;
+    };
+    requestBody: {
+      content: {
+        "application/json": {
+          /** @description Name of the system */
+          name?: string;
+          /** @description Slug of the system */
+          slug?: string;
+          /** @description Description of the system */
+          description?: string;
+          /**
+           * Format: uuid
+           * @description UUID of the workspace
+           */
+          workspaceId?: string;
+        };
+      };
+    };
+    responses: {
+      /** @description System updated successfully */
+      200: {
+        headers: {
+          [name: string]: unknown;
+        };
+        content: {
+          "application/json": components["schemas"]["System"];
+        };
+      };
+      /** @description System not found */
+      404: {
+        headers: {
+          [name: string]: unknown;
+        };
+        content: {
+          "application/json": {
+            /** @example System not found */
+            error?: string;
+          };
+        };
+      };
+      /** @description Internal server error */
+      500: {
+        headers: {
+          [name: string]: unknown;
+        };
+        content: {
+          "application/json": {
+            /** @example Internal server error */
+            error?: string;
+          };
+        };
+      };
+    };
+  };
+  createSystem: {
+    parameters: {
+      query?: never;
+      header?: never;
+      path?: never;
+      cookie?: never;
+    };
+    requestBody?: {
+      content: {
+        "application/json": {
+          /**
+           * Format: uuid
+           * @description The workspace ID of the system
+           */
+          workspaceId: string;
+          /** @description The name of the system */
+          name: string;
+          /** @description The slug of the system */
+          slug: string;
+          /** @description The description of the system */
+          description?: string;
+        };
+      };
+    };
+    responses: {
+      /** @description System created successfully */
+      201: {
+        headers: {
+          [name: string]: unknown;
+        };
+        content: {
+          "application/json": components["schemas"]["System"];
+        };
+      };
+      /** @description Bad request */
+      400: {
+        headers: {
+          [name: string]: unknown;
+        };
+        content: {
+          "application/json": {
+            error?: {
+              /** @enum {string} */
+              code: "invalid_type" | "invalid_literal" | "custom";
+              message: string;
+              path: (string | number)[];
+            }[];
+          };
+        };
+      };
+      /** @description Internal server error */
+      500: {
+        headers: {
+          [name: string]: unknown;
+        };
+        content: {
+          "application/json": {
+            /** @example Internal Server Error */
+            error?: string;
+          };
+        };
+      };
+    };
+  };
+  listDeployments: {
+    parameters: {
+      query?: never;
+      header?: never;
+      path: {
+        /** @description The ID of the workspace */
+        workspaceId: string;
+      };
+      cookie?: never;
+    };
+    requestBody?: never;
+    responses: {
+      /** @description All deployments */
+      200: {
+        headers: {
+          [name: string]: unknown;
+        };
+        content: {
+          "application/json": {
+            data?: components["schemas"]["Deployment"][];
+          };
+        };
+      };
+    };
+  };
+  listEnvironments: {
+    parameters: {
+      query?: never;
+      header?: never;
+      path: {
+        /** @description The ID of the workspace */
+        workspaceId: string;
+      };
+      cookie?: never;
+    };
+    requestBody?: never;
+    responses: {
+      /** @description All environments */
+      200: {
+        headers: {
+          [name: string]: unknown;
+        };
+        content: {
+          "application/json": {
+            data?: components["schemas"]["Environment"][];
+          };
+        };
+      };
+    };
+  };
+  getWorkspace: {
+    parameters: {
+      query?: never;
+      header?: never;
+      path: {
+        workspaceId: string;
+      };
+      cookie?: never;
+    };
+    requestBody?: never;
+    responses: {
+      /** @description Workspace found */
+      200: {
+        headers: {
+          [name: string]: unknown;
+        };
+        content: {
+          "application/json": components["schemas"]["Workspace"];
+        };
+      };
+      /** @description Workspace not found */
+      404: {
+        headers: {
+          [name: string]: unknown;
+        };
+        content: {
+          "application/json": {
+            error?: string;
+          };
+        };
+      };
+      /** @description Internal server error */
+      500: {
+        headers: {
+          [name: string]: unknown;
+        };
+        content: {
+          "application/json": {
+            error?: string;
+          };
+        };
+      };
+    };
+  };
+  deletePolicyByName: {
+    parameters: {
+      query?: never;
+      header?: never;
+      path: {
+        /** @description ID of the workspace */
+        workspaceId: string;
+        /** @description Name of the policy */
+        name: string;
+      };
+      cookie?: never;
+    };
+    requestBody?: never;
+    responses: {
+      /** @description Successfully deleted the policy */
+      200: {
+        headers: {
+          [name: string]: unknown;
+        };
+        content: {
+          "application/json": {
+            /** @example true */
+            success?: boolean;
+          };
+        };
+      };
+      /** @description Unauthorized */
+      401: {
+        headers: {
+          [name: string]: unknown;
+        };
+        content?: never;
+      };
+      /** @description Permission denied */
+      403: {
+        headers: {
+          [name: string]: unknown;
+        };
+        content?: never;
+      };
+      /** @description Policy not found */
+      404: {
+        headers: {
+          [name: string]: unknown;
+        };
+        content: {
+          "application/json": {
+            /** @example Policy not found */
+            error?: string;
+          };
+        };
+      };
+      /** @description Internal server error */
+      500: {
+        headers: {
+          [name: string]: unknown;
+        };
+        content?: never;
+      };
+    };
+  };
+  upsertResourceProvider: {
+    parameters: {
+      query?: never;
+      header?: never;
+      path: {
+        /** @description Name of the workspace */
+        workspaceId: string;
+        /** @description Name of the resource provider */
+        name: string;
+      };
+      cookie?: never;
+    };
+    requestBody?: never;
+    responses: {
+      /** @description Successfully retrieved or created the resource provider */
+      200: {
+        headers: {
+          [name: string]: unknown;
+        };
+        content: {
+          "application/json": {
+            id: string;
+            name: string;
+            workspaceId: string;
+          };
+        };
+      };
+      /** @description Unauthorized */
+      401: {
+        headers: {
+          [name: string]: unknown;
+        };
+        content?: never;
+      };
+      /** @description Permission denied */
+      403: {
+        headers: {
+          [name: string]: unknown;
+        };
+        content?: never;
+      };
+      /** @description Workspace not found */
+      404: {
+        headers: {
+          [name: string]: unknown;
+        };
+        content?: never;
+      };
+      /** @description Internal server error */
+      500: {
+        headers: {
+          [name: string]: unknown;
+        };
+        content?: never;
+      };
+    };
+  };
+  getResourceByIdentifier: {
+    parameters: {
+      query?: never;
+      header?: never;
+      path: {
+        /** @description ID of the workspace */
+        workspaceId: string;
+        /** @description Identifier of the resource */
+        identifier: string;
+      };
+      cookie?: never;
+    };
+    requestBody?: never;
+    responses: {
+      /** @description Successfully retrieved the resource */
+      200: {
+        headers: {
+          [name: string]: unknown;
+        };
+        content: {
+          "application/json": {
+            id: string;
+            identifier: string;
+            workspaceId: string;
+            providerId: string;
+            provider?: {
+              id?: string;
+              name?: string;
+              workspaceId?: string;
+            };
+            variables?: {
+              id?: string;
+              key?: string;
+              value?: string;
+            }[];
+            metadata?: {
+              [key: string]: string;
+            };
+          };
+        };
+      };
+      /** @description Unauthorized */
+      401: {
+        headers: {
+          [name: string]: unknown;
+        };
+        content?: never;
+      };
+      /** @description Permission denied */
+      403: {
+        headers: {
+          [name: string]: unknown;
+        };
+        content?: never;
+      };
+      /** @description Resource not found */
+      404: {
+        headers: {
+          [name: string]: unknown;
+        };
+        content: {
+          "application/json": {
+            /** @example Resource not found */
+            error?: string;
+          };
+        };
+      };
+      /** @description Internal server error */
+      500: {
+        headers: {
+          [name: string]: unknown;
+        };
+        content?: never;
+      };
+    };
+  };
+  deleteResourceByIdentifier: {
+    parameters: {
+      query?: never;
+      header?: never;
+      path: {
+        /** @description ID of the workspace */
+        workspaceId: string;
+        /** @description Identifier of the resource */
+        identifier: string;
+      };
+      cookie?: never;
+    };
+    requestBody?: never;
+    responses: {
+      /** @description Successfully deleted the resource */
+      200: {
+        headers: {
+          [name: string]: unknown;
+        };
+        content: {
+          "application/json": {
+            /** @example true */
+            success?: boolean;
+          };
+        };
+      };
+      /** @description Unauthorized */
+      401: {
+        headers: {
+          [name: string]: unknown;
+        };
+        content?: never;
+      };
+      /** @description Permission denied */
+      403: {
+        headers: {
+          [name: string]: unknown;
+        };
+        content?: never;
+      };
+      /** @description Resource not found */
+      404: {
+        headers: {
+          [name: string]: unknown;
+        };
+        content: {
+          "application/json": {
+            /** @example Resource not found */
+            error?: string;
+          };
+        };
+      };
+      /** @description Internal server error */
+      500: {
+        headers: {
+          [name: string]: unknown;
+        };
+        content?: never;
+      };
+    };
+  };
+  listResources: {
+    parameters: {
+      query?: never;
+      header?: never;
+      path: {
+        /** @description The ID of the workspace */
+        workspaceId: string;
+      };
+      cookie?: never;
+    };
+    requestBody?: never;
+    responses: {
+      /** @description All resources */
+      200: {
+        headers: {
+          [name: string]: unknown;
+        };
+        content: {
+          "application/json": {
+            resources?: components["schemas"]["Resource"][];
+          };
+        };
+      };
+    };
+  };
+  listSystems: {
+    parameters: {
+      query?: never;
+      header?: never;
+      path: {
+        /** @description The ID of the workspace */
+        workspaceId: string;
+      };
+      cookie?: never;
+    };
+    requestBody?: never;
+    responses: {
+      /** @description All systems */
+      200: {
+        headers: {
+          [name: string]: unknown;
+        };
+        content: {
+          "application/json": {
+            data?: components["schemas"]["System"][];
+          };
+        };
+      };
+    };
+  };
+  getWorkspaceBySlug: {
+    parameters: {
+      query?: never;
+      header?: never;
+      path: {
+        workspaceSlug: string;
+      };
+      cookie?: never;
+    };
+    requestBody?: never;
+    responses: {
+      /** @description Workspace found */
+      200: {
+        headers: {
+          [name: string]: unknown;
+        };
+        content: {
+          "application/json": components["schemas"]["Workspace"];
+        };
+      };
+      /** @description Workspace not found */
+      404: {
+        headers: {
+          [name: string]: unknown;
+        };
+        content: {
+          "application/json": {
+            error?: string;
+          };
+        };
+      };
+      /** @description Internal server error */
+      500: {
+        headers: {
+          [name: string]: unknown;
+        };
+        content: {
+          "application/json": {
+            error?: string;
+          };
+        };
+      };
+    };
+  };
 }
 type WithRequired<T, K extends keyof T> = T & {
-    [P in K]-?: T[P];
+  [P in K]-?: T[P];
 };

--- a/e2e/api/yaml-loader.ts
+++ b/e2e/api/yaml-loader.ts
@@ -143,20 +143,20 @@ export async function importEntitiesFromYaml(
   if (data.resources && data.resources.length > 0) {
     console.log(`Creating ${data.resources.length} resources`);
 
-    const resourcesResponse = await api.POST("/v1/resources", {
-      body: {
-        workspaceId,
-        resources: data.resources.map((resource) => ({
+    for (const resource of data.resources) {
+      const resourceResponse = await api.POST("/v1/resources", {
+        body: {
           ...resource,
+          workspaceId,
           config: resource.config as Record<string, never>,
-        })),
-      },
-    });
+        },
+      });
 
-    if (resourcesResponse.response.status !== 200) {
-      throw new Error(
-        `Failed to create resources: ${JSON.stringify(resourcesResponse.error)}`,
-      );
+      if (resourceResponse.response.status !== 200) {
+        throw new Error(
+          `Failed to create resource: ${JSON.stringify(resourceResponse.error)}`,
+        );
+      }
     }
 
     // Store created resources in result

--- a/e2e/tests/api/resources.spec.ts
+++ b/e2e/tests/api/resources.spec.ts
@@ -11,30 +11,25 @@ test.describe("Resource API", () => {
     const resource = await api.POST("/v1/resources", {
       body: {
         workspaceId: workspace.id,
-        resources: [
-          {
-            name: resourceName1,
-            kind: "ResourceAPI",
-            identifier: resourceName1,
-            version: "test-version/v1",
-            config: { "e2e-test": true } as any,
-            metadata: { "e2e-test": "true" },
-          },
-          {
-            name: resourceName2,
-            kind: "ResourceAPI",
-            identifier: resourceName2,
-            version: "test-version/v1",
-            config: { "e2e-test": true } as any,
-            metadata: { "e2e-test": "true" },
-          },
-        ],
+        name: resourceName1,
+        kind: "ResourceAPI",
+        identifier: resourceName1,
+        version: "test-version/v1",
+        config: { "e2e-test": true } as any,
+        metadata: { "e2e-test": "true" },
       },
     });
 
     expect(resource.response.status).toBe(200);
-    expect(resource.data?.count).toBe(2);
+    expect(resource.data?.id).toBeDefined();
     expect(resource.error).toBeUndefined();
+    expect(resource.data?.workspaceId).toBe(workspace.id);
+    expect(resource.data?.name).toBe(resourceName1);
+    expect(resource.data?.kind).toBe("ResourceAPI");
+    expect(resource.data?.identifier).toBe(resourceName1);
+    expect(resource.data?.version).toBe("test-version/v1");
+    expect(resource.data?.config).toEqual({ "e2e-test": true });
+    expect(resource.data?.metadata).toEqual({ "e2e-test": "true" });
   });
 
   test("get a resource by identifier", async ({ api, workspace }) => {
@@ -43,16 +38,12 @@ test.describe("Resource API", () => {
     await api.POST("/v1/resources", {
       body: {
         workspaceId: workspace.id,
-        resources: [
-          {
-            name: resourceName,
-            kind: "ResourceAPI",
-            identifier: resourceName,
-            version: "test-version/v1",
-            config: { "e2e-test": true } as any,
-            metadata: { "e2e-test": "true" },
-          },
-        ],
+        name: resourceName,
+        kind: "ResourceAPI",
+        identifier: resourceName,
+        version: "test-version/v1",
+        config: { "e2e-test": true } as any,
+        metadata: { "e2e-test": "true" },
       },
     });
 
@@ -83,16 +74,12 @@ test.describe("Resource API", () => {
     await api.POST("/v1/resources", {
       body: {
         workspaceId: workspace.id,
-        resources: [
-          {
-            name: resourceName,
-            kind: "ResourceAPI",
-            identifier: resourceName,
-            version: "test-version/v1",
-            config: { "e2e-test": true } as any,
-            metadata: { "e2e-test": "true" },
-          },
-        ],
+        name: resourceName,
+        kind: "ResourceAPI",
+        identifier: resourceName,
+        version: "test-version/v1",
+        config: { "e2e-test": true } as any,
+        metadata: { "e2e-test": "true" },
       },
     });
 
@@ -117,16 +104,12 @@ test.describe("Resource API", () => {
     await api.POST("/v1/resources", {
       body: {
         workspaceId: workspace.id,
-        resources: [
-          {
-            name: resourceName,
-            kind: "ResourceAPI",
-            identifier: resourceName,
-            version: "test-version/v1",
-            config: { "e2e-test": true } as any,
-            metadata: { "e2e-test": "true" },
-          },
-        ],
+        name: resourceName,
+        kind: "ResourceAPI",
+        identifier: resourceName,
+        version: "test-version/v1",
+        config: { "e2e-test": true } as any,
+        metadata: { "e2e-test": "true" },
       },
     });
 
@@ -170,16 +153,12 @@ test.describe("Resource API", () => {
     await api.POST("/v1/resources", {
       body: {
         workspaceId: workspace.id,
-        resources: [
-          {
-            name: resourceName,
-            kind: "ResourceAPI",
-            identifier: resourceName,
-            version: "test-version/v1",
-            config: { "e2e-test": true } as any,
-            metadata: { "e2e-test": "true" },
-          },
-        ],
+        name: resourceName,
+        kind: "ResourceAPI",
+        identifier: resourceName,
+        version: "test-version/v1",
+        config: { "e2e-test": true } as any,
+        metadata: { "e2e-test": "true" },
       },
     });
 
@@ -218,27 +197,28 @@ test.describe("Resource API", () => {
     // Create two resources
     const resource1Name = faker.string.alphanumeric(10);
     const resource2Name = faker.string.alphanumeric(10);
+
     await api.POST("/v1/resources", {
       body: {
         workspaceId: workspace.id,
-        resources: [
-          {
-            name: resource1Name,
-            kind: "ResourceAPI",
-            identifier: resource1Name,
-            version: "test-version/v1",
-            config: { "e2e-test": true } as any,
-            metadata: { "e2e-test": "true" },
-          },
-          {
-            name: resource2Name,
-            kind: "ResourceAPI",
-            identifier: resource2Name,
-            version: "test-version/v1",
-            config: { "e2e-test": true } as any,
-            metadata: { "e2e-test": "true" },
-          },
-        ],
+        name: resource1Name,
+        kind: "ResourceAPI",
+        identifier: resource1Name,
+        version: "test-version/v1",
+        config: { "e2e-test": true } as any,
+        metadata: { "e2e-test": "true" },
+      },
+    });
+
+    await api.POST("/v1/resources", {
+      body: {
+        workspaceId: workspace.id,
+        name: resource2Name,
+        kind: "ResourceAPI",
+        identifier: resource2Name,
+        version: "test-version/v1",
+        config: { "e2e-test": true } as any,
+        metadata: { "e2e-test": "true" },
       },
     });
 

--- a/openapi.v1.json
+++ b/openapi.v1.json
@@ -2985,8 +2985,8 @@
     },
     "/v1/resources": {
       "post": {
-        "summary": "Create or update multiple resources",
-        "operationId": "upsertResources",
+        "summary": "Create or update a resource",
+        "operationId": "upsertResource",
         "requestBody": {
           "required": true,
           "content": {
@@ -2995,53 +2995,42 @@
                 "type": "object",
                 "required": [
                   "workspaceId",
-                  "resources"
+                  "name",
+                  "kind",
+                  "identifier",
+                  "version",
+                  "config"
                 ],
                 "properties": {
                   "workspaceId": {
                     "type": "string",
                     "format": "uuid"
                   },
-                  "resources": {
+                  "name": {
+                    "type": "string"
+                  },
+                  "kind": {
+                    "type": "string"
+                  },
+                  "identifier": {
+                    "type": "string"
+                  },
+                  "version": {
+                    "type": "string"
+                  },
+                  "config": {
+                    "type": "object"
+                  },
+                  "metadata": {
+                    "type": "object",
+                    "additionalProperties": {
+                      "type": "string"
+                    }
+                  },
+                  "variables": {
                     "type": "array",
                     "items": {
-                      "type": "object",
-                      "required": [
-                        "name",
-                        "kind",
-                        "identifier",
-                        "version",
-                        "config"
-                      ],
-                      "properties": {
-                        "name": {
-                          "type": "string"
-                        },
-                        "kind": {
-                          "type": "string"
-                        },
-                        "identifier": {
-                          "type": "string"
-                        },
-                        "version": {
-                          "type": "string"
-                        },
-                        "config": {
-                          "type": "object"
-                        },
-                        "metadata": {
-                          "type": "object",
-                          "additionalProperties": {
-                            "type": "string"
-                          }
-                        },
-                        "variables": {
-                          "type": "array",
-                          "items": {
-                            "$ref": "#/components/schemas/Variable"
-                          }
-                        }
-                      }
+                      "$ref": "#/components/schemas/Variable"
                     }
                   }
                 }
@@ -3051,16 +3040,11 @@
         },
         "responses": {
           "200": {
-            "description": "All of the cats",
+            "description": "The created or updated resource",
             "content": {
               "application/json": {
                 "schema": {
-                  "type": "object",
-                  "properties": {
-                    "count": {
-                      "type": "number"
-                    }
-                  }
+                  "$ref": "#/components/schemas/Resource"
                 }
               }
             }


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added support for including optional metadata and variables when creating or updating a resource via the API.

- **Bug Fixes**
  - Improved error handling for resource creation, ensuring immediate feedback if any resource fails to be created.

- **Refactor**
  - Changed the API to handle creation or update of a single resource per request instead of multiple resources.
  - Updated API documentation, client schema, and tests to reflect the new single-resource request and response format.
  - Simplified job dispatching logic and response handling for resource upsertion.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->