### PR TITLE
fix: make locks less restrictive on compute workers

### DIFF
--- a/apps/event-worker/src/workers/compute-deployment-resource-selector.ts
+++ b/apps/event-worker/src/workers/compute-deployment-resource-selector.ts
@@ -20,8 +20,8 @@ export const computeDeploymentResourceSelectorWorkerEvent = createWorker(
       await db.transaction(async (tx) => {
         await tx.execute(
           sql`
-           SELECT * from ${schema.deployment}
-           WHERE ${schema.deployment.id} = ${id}
+           SELECT * from ${schema.computedDeploymentResource}
+           WHERE ${eq(schema.computedDeploymentResource.deploymentId, deployment.id)}
            FOR UPDATE NOWAIT
           `,
         );

--- a/apps/event-worker/src/workers/compute-environment-resource-selector.ts
+++ b/apps/event-worker/src/workers/compute-environment-resource-selector.ts
@@ -23,10 +23,6 @@ import { Channel, createWorker, getQueue } from "@ctrlplane/events";
 export const computeEnvironmentResourceSelectorWorkerEvent = createWorker(
   Channel.ComputeEnvironmentResourceSelector,
   async (job) => {
-    console.log(
-      "computeEnvironmentResourceSelectorWorkerEvent",
-      JSON.stringify(job.data, null, 2),
-    );
     const { id } = job.data;
 
     const environment = await db.query.environment.findFirst({
@@ -42,8 +38,8 @@ export const computeEnvironmentResourceSelectorWorkerEvent = createWorker(
         // acquire a lock on the environment
         await tx.execute(
           sql`
-           SELECT * from ${schema.environment}
-           WHERE ${schema.environment.id} = ${id}
+           SELECT * from ${schema.computedEnvironmentResource}
+           WHERE ${eq(schema.computedEnvironmentResource.environmentId, environment.id)}
            FOR UPDATE NOWAIT
           `,
         );

--- a/apps/webservice/src/app/api/v1/policies/[policyId]/release-targets/route.ts
+++ b/apps/webservice/src/app/api/v1/policies/[policyId]/release-targets/route.ts
@@ -19,6 +19,19 @@ export const GET = request()
   .handle<unknown, { params: Promise<{ policyId: string }> }>(
     async (ctx, { params }) => {
       const { policyId } = await params;
+      const policy = await ctx.db.query.policy.findFirst({
+        where: eq(schema.policy.id, policyId),
+      });
+
+      if (policy == null) {
+        return NextResponse.json(
+          { error: "Policy not found" },
+          { status: 404 },
+        );
+      }
+
+      console.log("querying release targets for policy: ", policy.name);
+
       const releaseTargetsQuery = ctx.db
         .select()
         .from(schema.releaseTarget)

--- a/e2e/tests/api/policies/matched-release-targets.spec.ts
+++ b/e2e/tests/api/policies/matched-release-targets.spec.ts
@@ -21,6 +21,8 @@ test.describe("Release Targets API", () => {
       workspace.id,
       yamlPath,
     );
+
+    await new Promise((resolve) => setTimeout(resolve, 10_000));
   });
 
   test.afterAll(async ({ api, workspace }) => {
@@ -35,6 +37,7 @@ test.describe("Release Targets API", () => {
     const systemPrefix = importedEntities.system.slug.split("-")[0]!;
 
     const policyName = faker.string.alphanumeric(10);
+    console.log("policyName", policyName);
     const policyResponse = await api.POST("/v1/policies", {
       body: {
         name: policyName,
@@ -57,7 +60,7 @@ test.describe("Release Targets API", () => {
     expect(policyIdResponse).toBeDefined();
     const policyId = policyIdResponse ?? "";
 
-    await new Promise((resolve) => setTimeout(resolve, 25_000));
+    await new Promise((resolve) => setTimeout(resolve, 10_000));
 
     const releaseTargetsResponse = await api.GET(
       "/v1/policies/{policyId}/release-targets",
@@ -68,6 +71,7 @@ test.describe("Release Targets API", () => {
     const releaseTargets = releaseTargetsResponse.data?.releaseTargets;
     const count = releaseTargetsResponse.data?.count;
     expect(releaseTargets).toBeDefined();
+    console.log("releaseTargets", releaseTargets);
 
     expect(count).toBe(4);
 
@@ -97,6 +101,7 @@ test.describe("Release Targets API", () => {
     const { id: workspaceId } = workspace;
     const systemPrefix = importedEntities.system.slug.split("-")[0]!;
     const policyName = faker.string.alphanumeric(10);
+    console.log("policyName", policyName);
     const policyResponse = await api.POST("/v1/policies", {
       body: {
         name: policyName,
@@ -138,7 +143,7 @@ test.describe("Release Targets API", () => {
 
     expect(updatePolicyResponse.response.status).toBe(200);
 
-    await new Promise((resolve) => setTimeout(resolve, 24_000));
+    await new Promise((resolve) => setTimeout(resolve, 10_000));
 
     const releaseTargetsResponse = await api.GET(
       "/v1/policies/{policyId}/release-targets",
@@ -149,6 +154,7 @@ test.describe("Release Targets API", () => {
     const releaseTargets = releaseTargetsResponse.data?.releaseTargets;
     const count = releaseTargetsResponse.data?.count;
     expect(releaseTargets).toBeDefined();
+    console.log("releaseTargets", releaseTargets);
 
     expect(count).toBe(4);
 
@@ -201,6 +207,7 @@ test.describe("Release Targets API", () => {
     expect(deleteResourceResponse.response.status).toBe(200);
 
     const policyName = faker.string.alphanumeric(10);
+    console.log("policyName", policyName);
     const policyResponse = await api.POST("/v1/policies", {
       body: {
         name: policyName,
@@ -234,7 +241,7 @@ test.describe("Release Targets API", () => {
     const releaseTargets = releaseTargetsResponse.data?.releaseTargets;
     const count = releaseTargetsResponse.data?.count;
     expect(releaseTargets).toBeDefined();
-
+    console.log("releaseTargets", releaseTargets);
     expect(count).toBe(0);
 
     const deletePolicyResponse = await api.DELETE("/v1/policies/{policyId}", {
@@ -252,6 +259,7 @@ test.describe("Release Targets API", () => {
     const systemPrefix = importedEntities.system.slug.split("-")[0]!;
 
     const policyName = faker.string.alphanumeric(10);
+    console.log("policyName", policyName);
     const policyResponse = await api.POST("/v1/policies", {
       body: {
         name: policyName,
@@ -274,7 +282,7 @@ test.describe("Release Targets API", () => {
     expect(policyIdResponse).toBeDefined();
     const policyId = policyIdResponse ?? "";
 
-    await new Promise((resolve) => setTimeout(resolve, 25_000));
+    await new Promise((resolve) => setTimeout(resolve, 10_000));
 
     const releaseTargetsResponse = await api.GET(
       "/v1/policies/{policyId}/release-targets",
@@ -285,7 +293,7 @@ test.describe("Release Targets API", () => {
     const releaseTargets = releaseTargetsResponse.data?.releaseTargets;
     const count = releaseTargetsResponse.data?.count;
     expect(releaseTargets).toBeDefined();
-
+    console.log("releaseTargets", releaseTargets);
     expect(count).toBe(4);
 
     const aEnvironmentMatch =
@@ -314,6 +322,7 @@ test.describe("Release Targets API", () => {
     const { id: workspaceId } = workspace;
     const systemPrefix = importedEntities.system.slug.split("-")[0]!;
     const policyName = faker.string.alphanumeric(10);
+    console.log("policyName", policyName);
     const policyResponse = await api.POST("/v1/policies", {
       body: {
         name: policyName,
@@ -355,7 +364,7 @@ test.describe("Release Targets API", () => {
 
     expect(updatePolicyResponse.response.status).toBe(200);
 
-    await new Promise((resolve) => setTimeout(resolve, 24_000));
+    await new Promise((resolve) => setTimeout(resolve, 10_000));
 
     const releaseTargetsResponse = await api.GET(
       "/v1/policies/{policyId}/release-targets",
@@ -423,6 +432,7 @@ test.describe("Release Targets API", () => {
     expect(deleteEnvironmentResponse.response.status).toBe(200);
 
     const policyName = faker.string.alphanumeric(10);
+    console.log("policyName", policyName);
     const policyResponse = await api.POST("/v1/policies", {
       body: {
         name: policyName,
@@ -456,7 +466,7 @@ test.describe("Release Targets API", () => {
     const releaseTargets = releaseTargetsResponse.data?.releaseTargets;
     const count = releaseTargetsResponse.data?.count;
     expect(releaseTargets).toBeDefined();
-
+    console.log("releaseTargets", releaseTargets);
     expect(count).toBe(0);
 
     const deletePolicyResponse = await api.DELETE("/v1/policies/{policyId}", {
@@ -474,6 +484,7 @@ test.describe("Release Targets API", () => {
     const systemPrefix = importedEntities.system.slug.split("-")[0]!;
 
     const policyName = faker.string.alphanumeric(10);
+    console.log("policyName", policyName);
     const policyResponse = await api.POST("/v1/policies", {
       body: {
         name: policyName,
@@ -496,7 +507,7 @@ test.describe("Release Targets API", () => {
     expect(policyIdResponse).toBeDefined();
     const policyId = policyIdResponse ?? "";
 
-    await new Promise((resolve) => setTimeout(resolve, 25_000));
+    await new Promise((resolve) => setTimeout(resolve, 10_000));
 
     const releaseTargetsResponse = await api.GET(
       "/v1/policies/{policyId}/release-targets",
@@ -507,7 +518,7 @@ test.describe("Release Targets API", () => {
     const releaseTargets = releaseTargetsResponse.data?.releaseTargets;
     const count = releaseTargetsResponse.data?.count;
     expect(releaseTargets).toBeDefined();
-
+    console.log("releaseTargets", releaseTargets);
     expect(count).toBe(4);
 
     const aDeploymentMatch =
@@ -536,6 +547,7 @@ test.describe("Release Targets API", () => {
     const { id: workspaceId } = workspace;
     const systemPrefix = importedEntities.system.slug.split("-")[0]!;
     const policyName = faker.string.alphanumeric(10);
+    console.log("policyName", policyName);
     const policyResponse = await api.POST("/v1/policies", {
       body: {
         name: policyName,
@@ -577,7 +589,7 @@ test.describe("Release Targets API", () => {
 
     expect(updatePolicyResponse.response.status).toBe(200);
 
-    await new Promise((resolve) => setTimeout(resolve, 24_000));
+    await new Promise((resolve) => setTimeout(resolve, 10_000));
 
     const releaseTargetsResponse = await api.GET(
       "/v1/policies/{policyId}/release-targets",
@@ -588,7 +600,7 @@ test.describe("Release Targets API", () => {
     const releaseTargets = releaseTargetsResponse.data?.releaseTargets;
     const count = releaseTargetsResponse.data?.count;
     expect(releaseTargets).toBeDefined();
-
+    console.log("releaseTargets", releaseTargets);
     expect(count).toBe(4);
 
     const bDeploymentMatch =
@@ -646,6 +658,7 @@ test.describe("Release Targets API", () => {
     expect(deleteDeploymentResponse.response.status).toBe(200);
 
     const policyName = faker.string.alphanumeric(10);
+    console.log("policyName", policyName);
     const policyResponse = await api.POST("/v1/policies", {
       body: {
         name: policyName,
@@ -679,7 +692,7 @@ test.describe("Release Targets API", () => {
     const releaseTargets = releaseTargetsResponse.data?.releaseTargets;
     const count = releaseTargetsResponse.data?.count;
     expect(releaseTargets).toBeDefined();
-
+    console.log("releaseTargets", releaseTargets);
     expect(count).toBe(0);
 
     const deletePolicyResponse = await api.DELETE("/v1/policies/{policyId}", {
@@ -697,6 +710,7 @@ test.describe("Release Targets API", () => {
     const systemPrefix = importedEntities.system.slug.split("-")[0]!;
 
     const policyName = faker.string.alphanumeric(10);
+    console.log("policyName", policyName);
     const policyResponse = await api.POST("/v1/policies", {
       body: {
         name: policyName,
@@ -724,7 +738,7 @@ test.describe("Release Targets API", () => {
     expect(policyIdResponse).toBeDefined();
     const policyId = policyIdResponse ?? "";
 
-    await new Promise((resolve) => setTimeout(resolve, 25_000));
+    await new Promise((resolve) => setTimeout(resolve, 10_000));
 
     const releaseTargetsResponse = await api.GET(
       "/v1/policies/{policyId}/release-targets",
@@ -735,7 +749,7 @@ test.describe("Release Targets API", () => {
     const releaseTargets = releaseTargetsResponse.data?.releaseTargets;
     const count = releaseTargetsResponse.data?.count;
     expect(releaseTargets).toBeDefined();
-
+    console.log("releaseTargets", releaseTargets);
     expect(count).toBe(2);
 
     const deploymentAEnvironmentAMatch =
@@ -784,6 +798,7 @@ test.describe("Release Targets API", () => {
     const { id: workspaceId } = workspace;
     const systemPrefix = importedEntities.system.slug.split("-")[0]!;
     const policyName = faker.string.alphanumeric(10);
+    console.log("policyName", policyName);
     const policyResponse = await api.POST("/v1/policies", {
       body: {
         name: policyName,
@@ -835,7 +850,7 @@ test.describe("Release Targets API", () => {
 
     expect(updatePolicyResponse.response.status).toBe(200);
 
-    await new Promise((resolve) => setTimeout(resolve, 24_000));
+    await new Promise((resolve) => setTimeout(resolve, 10_000));
 
     const releaseTargetsResponse = await api.GET(
       "/v1/policies/{policyId}/release-targets",
@@ -846,7 +861,7 @@ test.describe("Release Targets API", () => {
     const releaseTargets = releaseTargetsResponse.data?.releaseTargets;
     const count = releaseTargetsResponse.data?.count;
     expect(releaseTargets).toBeDefined();
-
+    console.log("releaseTargets", releaseTargets);
     expect(count).toBe(2);
 
     const deploymentAEnvironmentAMatch =
@@ -896,6 +911,7 @@ test.describe("Release Targets API", () => {
     const systemPrefix = importedEntities.system.slug.split("-")[0]!;
 
     const policyName = faker.string.alphanumeric(10);
+    console.log("policyName", policyName);
     const policyResponse = await api.POST("/v1/policies", {
       body: {
         name: policyName,
@@ -923,7 +939,7 @@ test.describe("Release Targets API", () => {
     expect(policyIdResponse).toBeDefined();
     const policyId = policyIdResponse ?? "";
 
-    await new Promise((resolve) => setTimeout(resolve, 25_000));
+    await new Promise((resolve) => setTimeout(resolve, 10_000));
 
     const releaseTargetsResponse = await api.GET(
       "/v1/policies/{policyId}/release-targets",
@@ -934,7 +950,7 @@ test.describe("Release Targets API", () => {
     const releaseTargets = releaseTargetsResponse.data?.releaseTargets;
     const count = releaseTargetsResponse.data?.count;
     expect(releaseTargets).toBeDefined();
-
+    console.log("releaseTargets", releaseTargets);
     expect(count).toBe(2);
 
     const prodEnvironmentAMatch =
@@ -983,6 +999,7 @@ test.describe("Release Targets API", () => {
     const { id: workspaceId } = workspace;
     const systemPrefix = importedEntities.system.slug.split("-")[0]!;
     const policyName = faker.string.alphanumeric(10);
+    console.log("policyName", policyName);
     const policyResponse = await api.POST("/v1/policies", {
       body: {
         name: policyName,
@@ -1012,6 +1029,7 @@ test.describe("Release Targets API", () => {
 
     await new Promise((resolve) => setTimeout(resolve, 1_000));
 
+    console.log("policyName", policyName);
     const updatePolicyResponse = await api.PATCH("/v1/policies/{policyId}", {
       params: { path: { policyId } },
       body: {
@@ -1034,7 +1052,7 @@ test.describe("Release Targets API", () => {
 
     expect(updatePolicyResponse.response.status).toBe(200);
 
-    await new Promise((resolve) => setTimeout(resolve, 24_000));
+    await new Promise((resolve) => setTimeout(resolve, 10_000));
 
     const releaseTargetsResponse = await api.GET(
       "/v1/policies/{policyId}/release-targets",
@@ -1045,7 +1063,7 @@ test.describe("Release Targets API", () => {
     const releaseTargets = releaseTargetsResponse.data?.releaseTargets;
     const count = releaseTargetsResponse.data?.count;
     expect(releaseTargets).toBeDefined();
-
+    console.log("releaseTargets", releaseTargets);
     expect(count).toBe(2);
 
     const prodEnvironmentAMatch =
@@ -1095,6 +1113,7 @@ test.describe("Release Targets API", () => {
     const systemPrefix = importedEntities.system.slug.split("-")[0]!;
 
     const policyName = faker.string.alphanumeric(10);
+    console.log("policyName", policyName);
     const policyResponse = await api.POST("/v1/policies", {
       body: {
         name: policyName,
@@ -1122,7 +1141,7 @@ test.describe("Release Targets API", () => {
     expect(policyIdResponse).toBeDefined();
     const policyId = policyIdResponse ?? "";
 
-    await new Promise((resolve) => setTimeout(resolve, 25_000));
+    await new Promise((resolve) => setTimeout(resolve, 10_000));
 
     const releaseTargetsResponse = await api.GET(
       "/v1/policies/{policyId}/release-targets",
@@ -1133,7 +1152,7 @@ test.describe("Release Targets API", () => {
     const releaseTargets = releaseTargetsResponse.data?.releaseTargets;
     const count = releaseTargetsResponse.data?.count;
     expect(releaseTargets).toBeDefined();
-
+    console.log("releaseTargets", releaseTargets);
     expect(count).toBe(2);
 
     const prodDeploymentAMatch =
@@ -1182,6 +1201,7 @@ test.describe("Release Targets API", () => {
     const { id: workspaceId } = workspace;
     const systemPrefix = importedEntities.system.slug.split("-")[0]!;
     const policyName = faker.string.alphanumeric(10);
+    console.log("policyName", policyName);
     const policyResponse = await api.POST("/v1/policies", {
       body: {
         name: policyName,
@@ -1233,7 +1253,7 @@ test.describe("Release Targets API", () => {
 
     expect(updatePolicyResponse.response.status).toBe(200);
 
-    await new Promise((resolve) => setTimeout(resolve, 24_000));
+    await new Promise((resolve) => setTimeout(resolve, 10_000));
 
     const releaseTargetsResponse = await api.GET(
       "/v1/policies/{policyId}/release-targets",
@@ -1244,7 +1264,7 @@ test.describe("Release Targets API", () => {
     const releaseTargets = releaseTargetsResponse.data?.releaseTargets;
     const count = releaseTargetsResponse.data?.count;
     expect(releaseTargets).toBeDefined();
-
+    console.log("releaseTargets", releaseTargets);
     expect(count).toBe(2);
 
     const prodDeploymentAMatch =
@@ -1294,6 +1314,7 @@ test.describe("Release Targets API", () => {
     const systemPrefix = importedEntities.system.slug.split("-")[0]!;
 
     const policyName = faker.string.alphanumeric(10);
+    console.log("policyName", policyName);
     const policyResponse = await api.POST("/v1/policies", {
       body: {
         name: policyName,
@@ -1326,7 +1347,7 @@ test.describe("Release Targets API", () => {
     expect(policyIdResponse).toBeDefined();
     const policyId = policyIdResponse ?? "";
 
-    await new Promise((resolve) => setTimeout(resolve, 25_000));
+    await new Promise((resolve) => setTimeout(resolve, 10_000));
 
     const releaseTargetsResponse = await api.GET(
       "/v1/policies/{policyId}/release-targets",
@@ -1337,7 +1358,7 @@ test.describe("Release Targets API", () => {
     const releaseTargets = releaseTargetsResponse.data?.releaseTargets;
     const count = releaseTargetsResponse.data?.count;
     expect(releaseTargets).toBeDefined();
-
+    console.log("releaseTargets", releaseTargets);
     expect(count).toBe(1);
 
     const prodDeploymentAEnvironmentAMatch =
@@ -1426,6 +1447,7 @@ test.describe("Release Targets API", () => {
     const { id: workspaceId } = workspace;
     const systemPrefix = importedEntities.system.slug.split("-")[0]!;
     const policyName = faker.string.alphanumeric(10);
+    console.log("policyName", policyName);
     const policyResponse = await api.POST("/v1/policies", {
       body: {
         name: policyName,
@@ -1487,7 +1509,7 @@ test.describe("Release Targets API", () => {
 
     expect(updatePolicyResponse.response.status).toBe(200);
 
-    await new Promise((resolve) => setTimeout(resolve, 24_000));
+    await new Promise((resolve) => setTimeout(resolve, 10_000));
 
     const releaseTargetsResponse = await api.GET(
       "/v1/policies/{policyId}/release-targets",
@@ -1498,6 +1520,7 @@ test.describe("Release Targets API", () => {
     const releaseTargets = releaseTargetsResponse.data?.releaseTargets;
     const count = releaseTargetsResponse.data?.count;
     expect(releaseTargets).toBeDefined();
+    console.log("releaseTargets", releaseTargets);
 
     expect(count).toBe(1);
 


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
	- Improved error handling when fetching release targets by policy ID, now returning a clear error message if the policy does not exist.
- **Refactor**
	- Updated database locking strategies to target more specific resource records during background processing, enhancing reliability and efficiency.
- **Tests**
	- Reduced wait times in release target API tests for faster feedback.
	- Added additional logging in tests to improve visibility into test execution and results.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->