### PR TITLE
chore: add logs when requeueing due to row lock

### DIFF
--- a/apps/event-worker/src/workers/compute-deployment-resource-selector.ts
+++ b/apps/event-worker/src/workers/compute-deployment-resource-selector.ts
@@ -75,7 +75,6 @@ export const computeDeploymentResourceSelectorWorkerEvent = createWorker(
         await getQueue(Channel.ComputeDeploymentResourceSelector).add(
           job.name,
           job.data,
-          { delay: 500 },
         );
         return;
       }

--- a/apps/event-worker/src/workers/compute-environment-resource-selector.ts
+++ b/apps/event-worker/src/workers/compute-environment-resource-selector.ts
@@ -96,7 +96,6 @@ export const computeEnvironmentResourceSelectorWorkerEvent = createWorker(
         await getQueue(Channel.ComputeEnvironmentResourceSelector).add(
           job.name,
           job.data,
-          { delay: 500 },
         );
         return;
       }

--- a/apps/event-worker/src/workers/compute-policy-target-release-target-selector.ts
+++ b/apps/event-worker/src/workers/compute-policy-target-release-target-selector.ts
@@ -131,7 +131,6 @@ export const computePolicyTargetReleaseTargetSelectorWorkerEvent = createWorker(
         await getQueue(Channel.ComputePolicyTargetReleaseTargetSelector).add(
           job.name,
           job.data,
-          { delay: 500 },
         );
         return;
       }

--- a/apps/event-worker/src/workers/compute-systems-release-targets.ts
+++ b/apps/event-worker/src/workers/compute-systems-release-targets.ts
@@ -205,7 +205,6 @@ export const computeSystemsReleaseTargetsWorker = createWorker(
         await getQueue(Channel.ComputeSystemsReleaseTargets).add(
           job.name,
           job.data,
-          { delay: 500 },
         );
         return;
       }


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - Added informational logging for database row lock errors during job processing, improving visibility into retries.
  - Retrying jobs on row lock errors now includes detailed logs without changing the retry behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->