### PR TITLE
feat: Target Relationship Rules

### DIFF
--- a/apps/webservice/src/app/[workspaceSlug]/(app)/resources/(sidebar)/relationship-rules/components/CreateRelationshipDialog.tsx
+++ b/apps/webservice/src/app/[workspaceSlug]/(app)/resources/(sidebar)/relationship-rules/components/CreateRelationshipDialog.tsx
@@ -30,7 +30,6 @@ import {
 } from "@ctrlplane/ui/form";
 import { Input } from "@ctrlplane/ui/input";
 import { Textarea } from "@ctrlplane/ui/textarea";
-import { Tabs, TabsContent, TabsList, TabsTrigger } from "@ctrlplane/ui/tabs";
 
 import { api } from "~/trpc/react";
 

--- a/apps/webservice/src/app/[workspaceSlug]/(app)/resources/(sidebar)/relationship-rules/components/RelationshipRulesTable.tsx
+++ b/apps/webservice/src/app/[workspaceSlug]/(app)/resources/(sidebar)/relationship-rules/components/RelationshipRulesTable.tsx
@@ -41,6 +41,7 @@ export const RelationshipRulesTable: React.FC<RelationshipRulesTableProps> = ({
               <TableHead>Reference</TableHead>
               <TableHead>Dependency</TableHead>
               <TableHead>Matching Metadata</TableHead>
+              <TableHead>Target Metadata</TableHead>
               <TableHead />
             </TableRow>
           </TableHeader>
@@ -68,7 +69,19 @@ export const RelationshipRulesTable: React.FC<RelationshipRulesTableProps> = ({
                     ))}
                   </div>
                 </TableCell>
-
+                <TableCell>
+                  <div className="flex flex-wrap gap-2">
+                    {rule.metadataEquals?.map((match) => (
+                      <Badge
+                        variant="outline"
+                        className="font-mono"
+                        key={match.key}
+                      >
+                        {match.key}={match.value}
+                      </Badge>
+                    ))}
+                  </div>
+                </TableCell>
                 <TableCell>
                   <div className="flex justify-end">
                     <RelationshipRuleDropdown ruleId={rule.id} />


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Added the ability to specify and manage multiple key-value pairs for target metadata when creating relationship rules.
	- Introduced a new "Additional Target Metadata Matching" section in the creation dialog for adding these key-value pairs.
	- Displayed target metadata key-value pairs in a new "Target Metadata" column within the relationship rules table.

- **UI Improvements**
	- Clarified and renamed the "Metadata Keys" section to "Metadata Matching" with improved labeling for better usability.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->