### PR TITLE
feat: metadata equals ui

### DIFF
--- a/apps/webservice/src/app/[workspaceSlug]/(app)/resources/(sidebar)/relationship-rules/components/CreateRelationshipDialog.tsx
+++ b/apps/webservice/src/app/[workspaceSlug]/(app)/resources/(sidebar)/relationship-rules/components/CreateRelationshipDialog.tsx
@@ -1,10 +1,11 @@
 "use client";
 
 import React, { useState } from "react";
-import { IconPlus } from "@tabler/icons-react";
+import { IconPlus, IconX } from "@tabler/icons-react";
 import { capitalCase } from "change-case";
 import { z } from "zod";
 
+import * as SCHEMA from "@ctrlplane/db/schema";
 import { Button } from "@ctrlplane/ui/button";
 import {
   Dialog,
@@ -26,6 +27,7 @@ import {
   FormItem,
   FormLabel,
   FormMessage,
+  useFieldArray,
   useForm,
 } from "@ctrlplane/ui/form";
 import { Input } from "@ctrlplane/ui/input";
@@ -37,49 +39,17 @@ interface CreateRelationshipDialogProps {
   workspaceId: string;
 }
 
-const dependencyType = [
-  "depends_on",
-  "depends_indirectly_on",
-  "uses_at_runtime",
-  "created_after",
-  "provisioned_in",
-  "inherits_from",
-] as const;
-
-const schema = z.object({
-  reference: z
-    .string()
-    .min(1)
-    .refine(
-      (val) =>
-        /^[a-z0-9]+(?:-[a-z0-9]+)*$/.test(val) || // slug case
-        /^[a-z][a-zA-Z0-9]*$/.test(val) || // camel case
-        /^[a-z][a-z0-9]*(?:_[a-z0-9]+)*$/.test(val), // snake case
-      {
-        message:
-          "Reference must be in slug case (my-reference), camel case (myReference), or snake case (my_reference)",
-      },
-    ),
-
-  name: z.string().min(1),
-  description: z.string().nullable(),
-  dependencyDescription: z.string().nullable(),
-  sourceKind: z.string(),
-  sourceVersion: z.string(),
-  targetKind: z.string().nullable(),
-  targetVersion: z.string().nullable(),
-  dependencyType: z.enum(dependencyType),
-  metadataKeys: z.string().array().min(1),
-});
-
 export const CreateRelationshipDialog: React.FC<
   CreateRelationshipDialogProps
 > = ({ workspaceId }) => {
-  const [currentMetadataKey, setCurrentMetadataKey] = useState("");
+  const [open, setOpen] = useState(false);
 
   const form = useForm({
-    schema,
+    schema: SCHEMA.createResourceRelationshipRule.extend({
+      metadataKeysMatch: z.array(z.object({ key: z.string() })),
+    }),
     defaultValues: {
+      workspaceId,
       reference: "",
       name: "",
       description: null,
@@ -89,19 +59,47 @@ export const CreateRelationshipDialog: React.FC<
       targetKind: null,
       targetVersion: null,
       dependencyType: "depends_on",
-      metadataKeys: [],
+      metadataKeysMatch: [],
+      metadataKeysEquals: [],
     },
   });
 
   const utils = api.useUtils();
-  const createRule = api.resource.relationshipRules.create.useMutation({
-    onSuccess: () => {
-      utils.resource.relationshipRules.list.invalidate();
-    },
+  const createRule = api.resource.relationshipRules.create.useMutation();
+
+  const onSubmit = form.handleSubmit((data) => {
+    const { metadataKeysMatch } = data;
+    const matchKeys = metadataKeysMatch.map((item) => item.key);
+
+    createRule
+      .mutateAsync({ ...data, metadataKeysMatch: matchKeys })
+      .then(() => utils.resource.relationshipRules.list.invalidate())
+      .then(() => setOpen(false));
   });
 
+  const {
+    fields: metadataKeysMatch,
+    append: appendMetadataKeysMatch,
+    remove: removeMetadataKeysMatch,
+  } = useFieldArray({
+    name: "metadataKeysMatch",
+    control: form.control,
+  });
+
+  const {
+    fields: metadataKeysEquals,
+    append: appendMetadataKeysEquals,
+    remove: removeMetadataKeysEquals,
+  } = useFieldArray({
+    name: "metadataKeysEquals",
+    control: form.control,
+  });
+
+  const formError = form.formState.errors;
+  console.log({ formError });
+
   return (
-    <Dialog>
+    <Dialog open={open} onOpenChange={setOpen}>
       <DialogTrigger asChild>
         <Button variant="outline" size="sm" className="flex items-center gap-2">
           <IconPlus className="h-4 w-4" />
@@ -114,16 +112,7 @@ export const CreateRelationshipDialog: React.FC<
         </DialogHeader>
 
         <Form {...form}>
-          <form
-            onSubmit={form.handleSubmit((data) =>
-              createRule.mutateAsync({
-                workspaceId,
-
-                ...data,
-              }),
-            )}
-            className="space-y-4"
-          >
+          <form onSubmit={onSubmit} className="space-y-4">
             <FormField
               control={form.control}
               name="reference"
@@ -144,12 +133,13 @@ export const CreateRelationshipDialog: React.FC<
             <FormField
               control={form.control}
               name="name"
-              render={({ field }) => (
+              render={({ field: { value, onChange } }) => (
                 <FormItem>
                   <FormLabel>Name</FormLabel>
                   <FormControl>
                     <Input
-                      {...field}
+                      value={value ?? ""}
+                      onChange={onChange}
                       placeholder="Enter a human-readable name"
                     />
                   </FormControl>
@@ -254,14 +244,16 @@ export const CreateRelationshipDialog: React.FC<
                         </Button>
                       </DropdownMenuTrigger>
                       <DropdownMenuContent className="w-full min-w-[200px]">
-                        {dependencyType.map((type) => (
-                          <DropdownMenuItem
-                            key={type}
-                            onClick={() => field.onChange(type)}
-                          >
-                            {capitalCase(type)}
-                          </DropdownMenuItem>
-                        ))}
+                        {Object.values(SCHEMA.ResourceDependencyType).map(
+                          (type) => (
+                            <DropdownMenuItem
+                              key={type}
+                              onClick={() => field.onChange(type)}
+                            >
+                              {capitalCase(type)}
+                            </DropdownMenuItem>
+                          ),
+                        )}
                       </DropdownMenuContent>
                     </DropdownMenu>
                   </FormControl>
@@ -319,74 +311,111 @@ export const CreateRelationshipDialog: React.FC<
 
             <div className="space-y-4">
               <h4 className="text-sm font-medium leading-none">
-                Metadata Keys
+                Metadata Match Keys
               </h4>
-              <FormField
-                control={form.control}
-                name="metadataKeys"
-                render={({ field }) => {
-                  const addKey = () => {
-                    const value = currentMetadataKey.trim();
-                    if (value && !field.value.includes(value)) {
-                      field.onChange([...field.value, value]);
-                      setCurrentMetadataKey("");
-                    }
-                  };
-
-                  return (
-                    <FormItem>
-                      <FormControl>
-                        <div className="flex flex-wrap items-start gap-2">
-                          {field.value.map((key, index) => (
-                            <div
-                              key={index}
-                              className="flex items-center gap-1 rounded-md bg-secondary px-2 py-1"
-                            >
-                              <span>{key}</span>
-                              <button
-                                type="button"
-                                onClick={() => {
-                                  const newKeys = [...field.value];
-                                  newKeys.splice(index, 1);
-                                  field.onChange(newKeys);
-                                }}
-                                className="ml-1 text-muted-foreground hover:text-foreground"
-                              >
-                                ×
-                              </button>
-                            </div>
-                          ))}
-                          <div className="flex min-w-[200px] flex-1 items-center gap-2">
+              <div className="flex flex-wrap items-start gap-2">
+                {metadataKeysMatch.map((field, index) => (
+                  <FormField
+                    key={field.id}
+                    control={form.control}
+                    name={`metadataKeysMatch.${index}`}
+                    render={({ field }) => (
+                      <FormItem>
+                        <FormControl>
+                          <div className="flex items-center gap-1 rounded-md border border-neutral-800 px-2 py-1">
                             <Input
-                              className="!mt-0 flex-1"
-                              placeholder="Enter metadata key"
-                              value={currentMetadataKey}
+                              value={field.value.key}
                               onChange={(e) =>
-                                setCurrentMetadataKey(e.target.value)
+                                field.onChange({ key: e.target.value })
                               }
-                              onKeyDown={(e) => {
-                                if (e.key === "Enter") {
-                                  e.preventDefault();
-                                  addKey();
-                                }
-                              }}
+                              placeholder="Enter key..."
+                              className="h-6 w-32 border-0 ring-0 focus-visible:ring-0"
                             />
                             <Button
                               type="button"
-                              variant="secondary"
-                              size="sm"
-                              onClick={addKey}
+                              variant="ghost"
+                              size="icon"
+                              onClick={() => removeMetadataKeysMatch(index)}
+                              className="h-5 w-5"
                             >
-                              Add
+                              <IconX className="h-3 w-3" />
                             </Button>
                           </div>
-                        </div>
-                      </FormControl>
-                      <FormMessage />
-                    </FormItem>
-                  );
-                }}
-              />
+                        </FormControl>
+                      </FormItem>
+                    )}
+                  />
+                ))}
+                <Button
+                  type="button"
+                  variant="secondary"
+                  size="sm"
+                  onClick={() => appendMetadataKeysMatch({ key: "" })}
+                >
+                  Add
+                </Button>
+              </div>
+            </div>
+
+            <div className="space-y-4">
+              <h4 className="text-sm font-medium leading-none">
+                Metadata Equals Keys
+              </h4>
+              <div className="flex flex-wrap items-start gap-2">
+                {metadataKeysEquals.map((field, index) => (
+                  <FormField
+                    key={field.id}
+                    control={form.control}
+                    name={`metadataKeysEquals.${index}`}
+                    render={({ field: { value, onChange } }) => (
+                      <FormItem>
+                        <FormControl>
+                          <div className="flex items-center gap-4 rounded-md border border-neutral-800 px-2 py-1">
+                            <Input
+                              value={value.key}
+                              onChange={(e) =>
+                                onChange({ ...value, key: e.target.value })
+                              }
+                              placeholder="key"
+                              className="h-6 w-40 border-neutral-800 ring-0 focus-visible:ring-0"
+                            />
+                            <span className="text-sm text-neutral-200">
+                              equals
+                            </span>
+                            <Input
+                              value={value.value}
+                              onChange={(e) =>
+                                onChange({ ...value, value: e.target.value })
+                              }
+                              placeholder="value"
+                              className="h-6 w-40 border-neutral-800 ring-0 focus-visible:ring-0"
+                            />
+                            <Button
+                              type="button"
+                              variant="ghost"
+                              size="icon"
+                              onClick={() => removeMetadataKeysEquals(index)}
+                              className="h-5 w-5"
+                            >
+                              <IconX className="h-3 w-3" />
+                            </Button>
+                          </div>
+                        </FormControl>
+                      </FormItem>
+                    )}
+                  />
+                ))}
+                <Button
+                  type="button"
+                  variant="secondary"
+                  size="sm"
+                  onClick={() =>
+                    appendMetadataKeysEquals({ key: "", value: "" })
+                  }
+                >
+                  Add
+                </Button>
+              </div>
             </div>
 
             <Button type="submit">Create</Button>

--- a/apps/webservice/src/app/[workspaceSlug]/(app)/resources/(sidebar)/relationship-rules/components/RelationshipRulesTable.tsx
+++ b/apps/webservice/src/app/[workspaceSlug]/(app)/resources/(sidebar)/relationship-rules/components/RelationshipRulesTable.tsx
@@ -41,6 +41,7 @@ export const RelationshipRulesTable: React.FC<RelationshipRulesTableProps> = ({
               <TableHead>Reference</TableHead>
               <TableHead>Dependency</TableHead>
               <TableHead>Matching Metadata</TableHead>
+              <TableHead>Metadata Equals</TableHead>
               <TableHead />
             </TableRow>
           </TableHeader>
@@ -64,6 +65,19 @@ export const RelationshipRulesTable: React.FC<RelationshipRulesTableProps> = ({
                         key={match.key}
                       >
                         {match.key}
+                      </Badge>
+                    ))}
+                  </div>
+                </TableCell>
+                <TableCell>
+                  <div className="flex flex-wrap gap-2">
+                    {rule.metadataEquals.map((equals) => (
+                      <Badge
+                        variant="outline"
+                        className="font-mono"
+                        key={equals.key}
+                      >
+                        {equals.key}: {equals.value}
                       </Badge>
                     ))}
                   </div>

--- a/packages/db/src/schema/resource-relationship-rule.ts
+++ b/packages/db/src/schema/resource-relationship-rule.ts
@@ -53,6 +53,15 @@ const resourceDependencyType = pgEnum("resource_dependency_type", [
   "inherits_from",
 ]);
 
+export enum ResourceDependencyType {
+  DependsOn = "depends_on",
+  DependsIndirectlyOn = "depends_indirectly_on",
+  UsesAtRuntime = "uses_at_runtime",
+  CreatedAfter = "created_after",
+  ProvisionedIn = "provisioned_in",
+  InheritsFrom = "inherits_from",
+}
+
 export const resourceRelationshipRule = pgTable(
   "resource_relationship_rule",
   {
@@ -164,9 +173,22 @@ export const createResourceRelationshipRule = createInsertSchema(
 )
   .omit({ id: true })
   .extend({
-    metadataKeysMatch: z.array(z.string()).optional(),
+    reference: z
+      .string()
+      .min(1)
+      .refine(
+        (val) =>
+          /^[a-z0-9]+(?:-[a-z0-9]+)*$/.test(val) || // slug case
+          /^[a-z][a-zA-Z0-9]*$/.test(val) || // camel case
+          /^[a-z][a-z0-9]*(?:_[a-z0-9]+)*$/.test(val), // snake case
+        {
+          message:
+            "Reference must be in slug case (my-reference), camel case (myReference), or snake case (my_reference)",
+        },
+      ),
+    metadataKeysMatch: z.array(z.string().min(1)).optional(),
     metadataKeysEquals: z
-      .array(z.object({ key: z.string(), value: z.string() }))
+      .array(z.object({ key: z.string().min(1), value: z.string().min(1) }))
       .optional(),
   });
 

--- a/packages/validators/src/auth/index.ts
+++ b/packages/validators/src/auth/index.ts
@@ -71,6 +71,7 @@ export enum Permission {
   ResourceRelationshipRuleCreate = "resourceRelationshipRule.create",
   ResourceRelationshipRuleUpdate = "resourceRelationshipRule.update",
   ResourceRelationshipRuleDelete = "resourceRelationshipRule.delete",
+  ResourceRelationshipRuleList = "resourceRelationshipRule.list",
 
   DeploymentCreate = "deployment.create",
   DeploymentUpdate = "deployment.update",


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added support for specifying both "Metadata Match Keys" and "Metadata Equals Keys" when creating relationship rules, allowing for more detailed rule definitions.
  - The relationship rules table now displays a new "Metadata Equals" column, showing key-value pairs for each rule.

- **Improvements**
  - Enhanced form validation for relationship rule creation, ensuring non-empty and properly formatted fields.
  - Dependency type options are now unified with backend definitions for consistency.

- **Access Control**
  - Updated permissions to provide more granular control over listing, creating, and deleting relationship rules.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->