### PR TITLE
perf: only dispatch affected release targets to eval queue in compute policy target job

### DIFF
--- a/apps/event-worker/src/workers/compute-policy-target-release-target-selector.ts
+++ b/apps/event-worker/src/workers/compute-policy-target-release-target-selector.ts
@@ -71,7 +71,7 @@ export const computePolicyTargetReleaseTargetSelectorWorkerEvent = createWorker(
     if (policyTarget == null) throw new Error("Policy target not found");
 
     try {
-      const actionableReleaseTargetIds = await db.transaction(async (tx) => {
+      const affectedReleaseTargetIds = await db.transaction(async (tx) => {
         await tx.execute(
           sql`
             SELECT * from ${schema.computedPolicyTargetReleaseTarget}
@@ -121,12 +121,12 @@ export const computePolicyTargetReleaseTargetSelectorWorkerEvent = createWorker(
         );
       });
 
-      const actionableReleaseTargets = await db
+      const affectedReleaseTargets = await db
         .select()
         .from(schema.releaseTarget)
-        .where(inArray(schema.releaseTarget.id, actionableReleaseTargetIds));
+        .where(inArray(schema.releaseTarget.id, affectedReleaseTargetIds));
 
-      await dispatchEvaluateJobs(actionableReleaseTargets);
+      await dispatchEvaluateJobs(affectedReleaseTargets);
     } catch (e: any) {
       const isRowLocked = e.code === "55P03";
       if (isRowLocked) {

--- a/apps/event-worker/src/workers/compute-policy-target-release-target-selector.ts
+++ b/apps/event-worker/src/workers/compute-policy-target-release-target-selector.ts
@@ -96,18 +96,13 @@ export const computePolicyTargetReleaseTargetSelectorWorkerEvent = createWorker(
           policyTarget,
         );
 
+        const prevIds = new Set(previous.map((rt) => rt.releaseTargetId));
+        const nextIds = new Set(releaseTargets.map((rt) => rt.releaseTargetId));
         const unmatched = previous.filter(
-          (previousRt) =>
-            !releaseTargets.some(
-              (rt) => rt.releaseTargetId === previousRt.releaseTargetId,
-            ),
+          ({ releaseTargetId }) => !nextIds.has(releaseTargetId),
         );
-
         const newReleaseTargets = releaseTargets.filter(
-          (rt) =>
-            !previous.some(
-              (previousRt) => previousRt.releaseTargetId === rt.releaseTargetId,
-            ),
+          ({ releaseTargetId }) => !prevIds.has(releaseTargetId),
         );
 
         if (releaseTargets.length > 0)
@@ -120,6 +115,8 @@ export const computePolicyTargetReleaseTargetSelectorWorkerEvent = createWorker(
           (rt) => rt.releaseTargetId,
         );
       });
+
+      if (affectedReleaseTargetIds.length === 0) return;
 
       const affectedReleaseTargets = await db
         .select()

--- a/apps/event-worker/src/workers/compute-policy-target-release-target-selector.ts
+++ b/apps/event-worker/src/workers/compute-policy-target-release-target-selector.ts
@@ -1,6 +1,6 @@
 import type { Tx } from "@ctrlplane/db";
 
-import { and, eq, isNull, selector, sql } from "@ctrlplane/db";
+import { and, eq, inArray, isNull, selector, sql } from "@ctrlplane/db";
 import { db } from "@ctrlplane/db/client";
 import * as schema from "@ctrlplane/db/schema";
 import { Channel, createWorker } from "@ctrlplane/events";
@@ -66,16 +66,12 @@ export const computePolicyTargetReleaseTargetSelectorWorkerEvent = createWorker(
 
     const policyTarget = await db.query.policyTarget.findFirst({
       where: eq(schema.policyTarget.id, id),
-      with: { policy: true },
     });
 
     if (policyTarget == null) throw new Error("Policy target not found");
 
-    const { policy } = policyTarget;
-    const { workspaceId } = policy;
-
     try {
-      await db.transaction(async (tx) => {
+      const actionableReleaseTargetIds = await db.transaction(async (tx) => {
         await tx.execute(
           sql`
             SELECT * from ${schema.computedPolicyTargetReleaseTarget}
@@ -85,43 +81,52 @@ export const computePolicyTargetReleaseTargetSelectorWorkerEvent = createWorker(
           `,
         );
 
-        await tx
+        const previous = await tx
           .delete(schema.computedPolicyTargetReleaseTarget)
           .where(
             eq(
               schema.computedPolicyTargetReleaseTarget.policyTargetId,
               policyTarget.id,
             ),
-          );
+          )
+          .returning();
 
         const releaseTargets = await findMatchingReleaseTargets(
           tx,
           policyTarget,
         );
 
-        if (releaseTargets.length === 0) return;
-        await tx
-          .insert(schema.computedPolicyTargetReleaseTarget)
-          .values(releaseTargets)
-          .onConflictDoNothing();
+        const unmatched = previous.filter(
+          (previousRt) =>
+            !releaseTargets.some(
+              (rt) => rt.releaseTargetId === previousRt.releaseTargetId,
+            ),
+        );
+
+        const newReleaseTargets = releaseTargets.filter(
+          (rt) =>
+            !previous.some(
+              (previousRt) => previousRt.releaseTargetId === rt.releaseTargetId,
+            ),
+        );
+
+        if (releaseTargets.length > 0)
+          await tx
+            .insert(schema.computedPolicyTargetReleaseTarget)
+            .values(releaseTargets)
+            .onConflictDoNothing();
+
+        return [...unmatched, ...newReleaseTargets].map(
+          (rt) => rt.releaseTargetId,
+        );
       });
 
-      const releaseTargets = await db
+      const actionableReleaseTargets = await db
         .select()
         .from(schema.releaseTarget)
-        .innerJoin(
-          schema.resource,
-          eq(schema.releaseTarget.resourceId, schema.resource.id),
-        )
-        .where(
-          and(
-            isNull(schema.resource.deletedAt),
-            eq(schema.resource.workspaceId, workspaceId),
-          ),
-        )
-        .then((rows) => rows.map((row) => row.release_target));
+        .where(inArray(schema.releaseTarget.id, actionableReleaseTargetIds));
 
-      await dispatchEvaluateJobs(releaseTargets);
+      await dispatchEvaluateJobs(actionableReleaseTargets);
     } catch (e: any) {
       const isRowLocked = e.code === "55P03";
       if (isRowLocked) {


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
	- Improved accuracy in updating and matching release targets, ensuring only affected targets are processed.
- **Performance**
	- Enhanced efficiency by reducing unnecessary data queries and focusing updates on relevant release targets.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->