### PR TITLE
fix: revert optimization change in compute policy release target worker

### DIFF
--- a/packages/db/src/queries/compute-policy-targets.ts
+++ b/packages/db/src/queries/compute-policy-targets.ts
@@ -57,11 +57,11 @@ export const computePolicyTargets = async (
   return db.transaction(async (tx) => {
     await tx.execute(
       sql`
-            SELECT * from ${schema.computedPolicyTargetReleaseTarget}
-            INNER JOIN ${schema.releaseTarget} ON ${eq(schema.releaseTarget.id, schema.computedPolicyTargetReleaseTarget.releaseTargetId)}
-            WHERE ${eq(schema.computedPolicyTargetReleaseTarget.policyTargetId, policyTarget.id)}
-            FOR UPDATE NOWAIT
-          `,
+        SELECT * from ${schema.computedPolicyTargetReleaseTarget}
+        INNER JOIN ${schema.releaseTarget} ON ${eq(schema.releaseTarget.id, schema.computedPolicyTargetReleaseTarget.releaseTargetId)}
+        WHERE ${eq(schema.computedPolicyTargetReleaseTarget.policyTargetId, policyTarget.id)}
+        FOR UPDATE NOWAIT
+      `,
     );
 
     await tx

--- a/packages/db/src/queries/compute-policy-targets.ts
+++ b/packages/db/src/queries/compute-policy-targets.ts
@@ -1,0 +1,84 @@
+import { and, eq, isNull, sql } from "drizzle-orm";
+
+import type { Tx } from "../common.js";
+import * as schema from "../schema/index.js";
+import { selector } from "../selectors/index.js";
+
+const findMatchingReleaseTargets = (
+  tx: Tx,
+  policyTarget: schema.PolicyTarget,
+) =>
+  tx
+    .select()
+    .from(schema.releaseTarget)
+    .innerJoin(
+      schema.resource,
+      eq(schema.releaseTarget.resourceId, schema.resource.id),
+    )
+    .innerJoin(
+      schema.deployment,
+      eq(schema.releaseTarget.deploymentId, schema.deployment.id),
+    )
+    .innerJoin(
+      schema.environment,
+      eq(schema.releaseTarget.environmentId, schema.environment.id),
+    )
+    .where(
+      and(
+        isNull(schema.resource.deletedAt),
+        selector()
+          .query()
+          .resources()
+          .where(policyTarget.resourceSelector)
+          .sql(),
+        selector()
+          .query()
+          .deployments()
+          .where(policyTarget.deploymentSelector)
+          .sql(),
+        selector()
+          .query()
+          .environments()
+          .where(policyTarget.environmentSelector)
+          .sql(),
+      ),
+    )
+    .then((rt) =>
+      rt.map((rt) => ({
+        policyTargetId: policyTarget.id,
+        releaseTargetId: rt.release_target.id,
+      })),
+    );
+
+export const computePolicyTargets = async (
+  db: Tx,
+  policyTarget: schema.PolicyTarget,
+) => {
+  return db.transaction(async (tx) => {
+    await tx.execute(
+      sql`
+            SELECT * from ${schema.computedPolicyTargetReleaseTarget}
+            INNER JOIN ${schema.releaseTarget} ON ${eq(schema.releaseTarget.id, schema.computedPolicyTargetReleaseTarget.releaseTargetId)}
+            WHERE ${eq(schema.computedPolicyTargetReleaseTarget.policyTargetId, policyTarget.id)}
+            FOR UPDATE NOWAIT
+          `,
+    );
+
+    await tx
+      .delete(schema.computedPolicyTargetReleaseTarget)
+      .where(
+        eq(
+          schema.computedPolicyTargetReleaseTarget.policyTargetId,
+          policyTarget.id,
+        ),
+      );
+
+    const releaseTargets = await findMatchingReleaseTargets(tx, policyTarget);
+
+    if (releaseTargets.length > 0)
+      await tx
+        .insert(schema.computedPolicyTargetReleaseTarget)
+        .values(releaseTargets)
+        .onConflictDoNothing();
+  });
+};

--- a/packages/db/src/queries/index.ts
+++ b/packages/db/src/queries/index.ts
@@ -1,2 +1,3 @@
 export * from "./get-resource-parents.js";
 export * from "./create-release-job.js";
+export * from "./compute-policy-targets.js";


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added an end-to-end test to verify that a release is created when a new resource does not match any existing policy target.

- **Refactor**
  - Simplified and improved the computation and updating of policy target release targets with enhanced transactional consistency.
  - Updated the release target evaluation process to handle all relevant targets more efficiently.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->