### PR TITLE
E2E: Allow yaml-entity creation order to be explicit 

### DIFF
--- a/e2e/api/entities-builder.ts
+++ b/e2e/api/entities-builder.ts
@@ -1,8 +1,8 @@
 import { faker } from "@faker-js/faker";
 
 import { WorkspaceFixture } from "../tests/auth.setup";
-import { ApiClient } from "./index";
 import { EntityFixtures, importEntityFixtures } from "./entity-fixtures";
+import { ApiClient } from "./index";
 
 // Entities info -- after creation
 export interface EntitiesCache {
@@ -136,11 +136,9 @@ export class EntitiesBuilder {
 
       if (resourceResponse.response.status !== 200) {
         throw new Error(
-          `Failed to create resource: ${
-            JSON.stringify(
-              resourceResponse.error,
-            )
-          }`,
+          `Failed to create resource: ${JSON.stringify(
+            resourceResponse.error,
+          )}`,
         );
       }
     }
@@ -156,7 +154,8 @@ export class EntitiesBuilder {
 
   async createEnvironments() {
     if (
-      !this.fixtures.environments || this.fixtures.environments.length === 0
+      !this.fixtures.environments ||
+      this.fixtures.environments.length === 0
     ) {
       throw new Error("No environments defined in YAML file");
     }
@@ -210,11 +209,9 @@ export class EntitiesBuilder {
 
       if (deploymentResponse.response.status !== 201) {
         throw new Error(
-          `Failed to create deployment: ${
-            JSON.stringify(
-              deploymentResponse.error,
-            )
-          }`,
+          `Failed to create deployment: ${JSON.stringify(
+            deploymentResponse.error,
+          )}`,
         );
       }
       this.cache.deployments.push({
@@ -235,11 +232,9 @@ export class EntitiesBuilder {
     for (const deployment of this.fixtures.deployments) {
       if (deployment.versions && deployment.versions.length > 0) {
         console.log(
-          `Adding deployment versions: ${deployment.name} -> ${
-            deployment.versions
-              .map((v) => v.tag)
-              .join(", ")
-          }`,
+          `Adding deployment versions: ${deployment.name} -> ${deployment.versions
+            .map((v) => v.tag)
+            .join(", ")}`,
         );
 
         const deploymentResult = this.cache.deployments.find(
@@ -262,11 +257,9 @@ export class EntitiesBuilder {
 
           if (versionResponse.response.status !== 201) {
             throw new Error(
-              `Failed to create deployment version: ${
-                JSON.stringify(
-                  versionResponse.error,
-                )
-              }`,
+              `Failed to create deployment version: ${JSON.stringify(
+                versionResponse.error,
+              )}`,
             );
           }
 
@@ -289,11 +282,9 @@ export class EntitiesBuilder {
     for (const deployment of this.fixtures.deployments) {
       if (deployment.variables && deployment.variables.length > 0) {
         console.log(
-          `Adding deployment variables: ${deployment.name} -> ${
-            deployment.variables
-              .map((v) => v.key)
-              .join(", ")
-          }`,
+          `Adding deployment variables: ${deployment.name} -> ${deployment.variables
+            .map((v) => v.key)
+            .join(", ")}`,
         );
 
         const deploymentResult = this.cache.deployments.find(
@@ -316,11 +307,9 @@ export class EntitiesBuilder {
 
           if (variableResponse.response.status !== 201) {
             throw new Error(
-              `Failed to create deployment variable: ${
-                JSON.stringify(
-                  variableResponse.error,
-                )
-              }`,
+              `Failed to create deployment variable: ${JSON.stringify(
+                variableResponse.error,
+              )}`,
             );
           }
 

--- a/e2e/api/entities-builder.ts
+++ b/e2e/api/entities-builder.ts
@@ -141,11 +141,9 @@ export class EntitiesBuilder {
 
       if (resourceResponse.response.status !== 200) {
         throw new Error(
-          `Failed to create resource: ${
-            JSON.stringify(
-              resourceResponse.error,
-            )
-          }`,
+          `Failed to create resource: ${JSON.stringify(
+            resourceResponse.error,
+          )}`,
         );
       }
     }
@@ -216,11 +214,9 @@ export class EntitiesBuilder {
 
       if (deploymentResponse.response.status !== 201) {
         throw new Error(
-          `Failed to create deployment: ${
-            JSON.stringify(
-              deploymentResponse.error,
-            )
-          }`,
+          `Failed to create deployment: ${JSON.stringify(
+            deploymentResponse.error,
+          )}`,
         );
       }
       this.cache.deployments.push({
@@ -241,11 +237,9 @@ export class EntitiesBuilder {
     for (const deployment of this.fixtures.deployments) {
       if (deployment.versions && deployment.versions.length > 0) {
         console.log(
-          `Adding deployment versions: ${deployment.name} -> ${
-            deployment.versions
-              .map((v) => v.tag)
-              .join(", ")
-          }`,
+          `Adding deployment versions: ${deployment.name} -> ${deployment.versions
+            .map((v) => v.tag)
+            .join(", ")}`,
         );
 
         const deploymentResult = this.cache.deployments.find(
@@ -268,11 +262,9 @@ export class EntitiesBuilder {
 
           if (versionResponse.response.status !== 201) {
             throw new Error(
-              `Failed to create deployment version: ${
-                JSON.stringify(
-                  versionResponse.error,
-                )
-              }`,
+              `Failed to create deployment version: ${JSON.stringify(
+                versionResponse.error,
+              )}`,
             );
           }
 
@@ -295,11 +287,9 @@ export class EntitiesBuilder {
     for (const deployment of this.fixtures.deployments) {
       if (deployment.variables && deployment.variables.length > 0) {
         console.log(
-          `Adding deployment variables: ${deployment.name} -> ${
-            deployment.variables
-              .map((v) => v.key)
-              .join(", ")
-          }`,
+          `Adding deployment variables: ${deployment.name} -> ${deployment.variables
+            .map((v) => v.key)
+            .join(", ")}`,
         );
 
         const deploymentResult = this.cache.deployments.find(
@@ -322,11 +312,9 @@ export class EntitiesBuilder {
 
           if (variableResponse.response.status !== 201) {
             throw new Error(
-              `Failed to create deployment variable: ${
-                JSON.stringify(
-                  variableResponse.error,
-                )
-              }`,
+              `Failed to create deployment variable: ${JSON.stringify(
+                variableResponse.error,
+              )}`,
             );
           }
 

--- a/e2e/api/entity-fixtures.ts
+++ b/e2e/api/entity-fixtures.ts
@@ -1,0 +1,130 @@
+import { z } from "zod";
+import yaml from "js-yaml";
+import path from "path";
+import fs from "fs";
+import { compile } from "handlebars";
+
+export type DeploymentVariableFixtureType = z.infer<
+    typeof DeploymentVariableFixture
+>;
+export type DeploymentVersionFixtureType = z.infer<
+    typeof DeploymentVersionFixture
+>;
+export type DeploymentFixtureType = z.infer<typeof DeploymentFixture>;
+export type EnvironmentFixtureType = z.infer<typeof EnvironmentFixture>;
+export type SystemFixtureType = z.infer<typeof SystemFixture>;
+export type ResourceFixtureType = z.infer<typeof ResourceFixture>;
+export type PolicyFixtureType = z.infer<typeof PolicyFixture>;
+export type EntityFixtures = z.infer<typeof EntityFixtures>;
+
+export const DeploymentVariableFixture = z.object({
+    key: z.string(),
+    description: z.string().optional(),
+    config: z.record(z.any()),
+    values: z
+        .array(
+            z.object({
+                value: z.any(),
+                valueType: z.enum(["direct", "reference"]).optional(),
+                sensitive: z.boolean().optional(),
+                resourceSelector: z.any().optional(),
+                default: z.boolean().optional(),
+            }),
+        )
+        .optional(),
+});
+
+export const DeploymentVersionFixture = z.object({
+    tag: z.string(),
+    name: z.string().optional(),
+    config: z.record(z.any()).optional(),
+    metadata: z.record(z.string()).optional(),
+    status: z.enum(["building", "ready", "failed"]).optional(),
+    message: z.string().optional(),
+});
+
+export const DeploymentFixture = z.object({
+    name: z.string(),
+    slug: z.string(),
+    description: z.string().optional(),
+    resourceSelector: z.any().optional(),
+    versions: z.array(DeploymentVersionFixture).optional(),
+    variables: z.array(DeploymentVariableFixture).optional(),
+});
+
+export const EnvironmentFixture = z.object({
+    name: z.string(),
+    description: z.string().optional(),
+    metadata: z.record(z.string()).optional(),
+    resourceSelector: z.any().optional(),
+});
+
+export const SystemFixture = z.object({
+    name: z.string(),
+    slug: z.string(),
+    description: z.string().optional(),
+});
+
+export const ResourceFixture = z.object({
+    name: z.string(),
+    kind: z.string(),
+    identifier: z.string(),
+    version: z.string(),
+    config: z.record(z.any()),
+    metadata: z.record(z.string()).optional(),
+});
+
+export const PolicyFixture = z.object({
+    name: z.string(),
+    targets: z.array(
+        z.object({
+            environmentSelector: z.any().optional(),
+            deploymentSelector: z.any().optional(),
+            resourceSelector: z.any().optional(),
+        }),
+    ),
+    versionAnyApprovals: z
+        .array(
+            z.object({
+                requiredApprovalsCount: z.number(),
+            }),
+        )
+        .optional(),
+    denyWindows: z
+        .array(
+            z.object({
+                timeZone: z.string(),
+                rrule: z.any(),
+            }),
+        )
+        .optional(),
+});
+
+export const EntityFixtures = z.object({
+    system: SystemFixture,
+    environments: z.array(EnvironmentFixture).optional(),
+    resources: z.array(ResourceFixture).optional(),
+    deployments: z.array(DeploymentFixture).optional(),
+    policies: z.array(PolicyFixture).optional(),
+});
+
+export function importEntityFixtures(
+    yamlFilePath: string,
+    prefix: string,
+): EntityFixtures {
+    const resolvedPath = path.isAbsolute(yamlFilePath)
+        ? yamlFilePath
+        : path.resolve(process.cwd(), yamlFilePath);
+
+    const fileContent = fs.readFileSync(resolvedPath, "utf8");
+    const template = compile(fileContent);
+    const fileTemplated = template({ prefix });
+    const data = yaml.load(fileTemplated);
+    const parseResult = EntityFixtures.safeParse(data);
+    if (!parseResult.success) {
+        throw new Error(
+            `Failed to parse entity fixtures in ${yamlFilePath}: ${parseResult.error.message}`,
+        );
+    }
+    return parseResult.data;
+}

--- a/e2e/api/entity-fixtures.ts
+++ b/e2e/api/entity-fixtures.ts
@@ -5,11 +5,9 @@ import yaml from "js-yaml";
 import { z } from "zod";
 
 export type DeploymentVariableFixture = z.infer<
-    typeof DeploymentVariableFixture
+  typeof DeploymentVariableFixture
 >;
-export type DeploymentVersionFixture = z.infer<
-    typeof DeploymentVersionFixture
->;
+export type DeploymentVersionFixture = z.infer<typeof DeploymentVersionFixture>;
 export type DeploymentFixture = z.infer<typeof DeploymentFixture>;
 export type EnvironmentFixture = z.infer<typeof EnvironmentFixture>;
 export type SystemFixture = z.infer<typeof SystemFixture>;
@@ -19,119 +17,119 @@ export type AgentFixture = z.infer<typeof AgentFixture>;
 export type EntityFixtures = z.infer<typeof EntityFixtures>;
 
 export const DeploymentVariableFixture = z.object({
-    key: z.string(),
-    description: z.string().optional(),
-    config: z.record(z.any()),
-    values: z
-        .array(
-            z.object({
-                value: z.any(),
-                valueType: z.enum(["direct", "reference"]).optional(),
-                sensitive: z.boolean().optional(),
-                resourceSelector: z.any().optional(),
-                default: z.boolean().optional(),
-            }),
-        )
-        .optional(),
+  key: z.string(),
+  description: z.string().optional(),
+  config: z.record(z.any()),
+  values: z
+    .array(
+      z.object({
+        value: z.any(),
+        valueType: z.enum(["direct", "reference"]).optional(),
+        sensitive: z.boolean().optional(),
+        resourceSelector: z.any().optional(),
+        default: z.boolean().optional(),
+      }),
+    )
+    .optional(),
 });
 
 export const DeploymentVersionFixture = z.object({
-    tag: z.string(),
-    name: z.string().optional(),
-    config: z.record(z.any()).optional(),
-    metadata: z.record(z.string()).optional(),
-    status: z.enum(["building", "ready", "failed"]).optional(),
-    message: z.string().optional(),
+  tag: z.string(),
+  name: z.string().optional(),
+  config: z.record(z.any()).optional(),
+  metadata: z.record(z.string()).optional(),
+  status: z.enum(["building", "ready", "failed"]).optional(),
+  message: z.string().optional(),
 });
 
 export const DeploymentFixture = z.object({
-    name: z.string(),
-    slug: z.string(),
-    description: z.string().optional(),
-    resourceSelector: z.any().optional(),
-    versions: z.array(DeploymentVersionFixture).optional(),
-    variables: z.array(DeploymentVariableFixture).optional(),
+  name: z.string(),
+  slug: z.string(),
+  description: z.string().optional(),
+  resourceSelector: z.any().optional(),
+  versions: z.array(DeploymentVersionFixture).optional(),
+  variables: z.array(DeploymentVariableFixture).optional(),
 });
 
 export const EnvironmentFixture = z.object({
-    name: z.string(),
-    description: z.string().optional(),
-    metadata: z.record(z.string()).optional(),
-    resourceSelector: z.any().optional(),
+  name: z.string(),
+  description: z.string().optional(),
+  metadata: z.record(z.string()).optional(),
+  resourceSelector: z.any().optional(),
 });
 
 export const SystemFixture = z.object({
-    name: z.string(),
-    slug: z.string(),
-    description: z.string().optional(),
+  name: z.string(),
+  slug: z.string(),
+  description: z.string().optional(),
 });
 
 export const ResourceFixture = z.object({
-    name: z.string(),
-    kind: z.string(),
-    identifier: z.string(),
-    version: z.string(),
-    config: z.record(z.any()),
-    metadata: z.record(z.string()).optional(),
+  name: z.string(),
+  kind: z.string(),
+  identifier: z.string(),
+  version: z.string(),
+  config: z.record(z.any()),
+  metadata: z.record(z.string()).optional(),
 });
 
 export const PolicyFixture = z.object({
-    name: z.string(),
-    targets: z.array(
-        z.object({
-            environmentSelector: z.any().optional(),
-            deploymentSelector: z.any().optional(),
-            resourceSelector: z.any().optional(),
-        }),
-    ),
-    versionAnyApprovals: z
-        .array(
-            z.object({
-                requiredApprovalsCount: z.number(),
-            }),
-        )
-        .optional(),
-    denyWindows: z
-        .array(
-            z.object({
-                timeZone: z.string(),
-                rrule: z.any(),
-            }),
-        )
-        .optional(),
+  name: z.string(),
+  targets: z.array(
+    z.object({
+      environmentSelector: z.any().optional(),
+      deploymentSelector: z.any().optional(),
+      resourceSelector: z.any().optional(),
+    }),
+  ),
+  versionAnyApprovals: z
+    .array(
+      z.object({
+        requiredApprovalsCount: z.number(),
+      }),
+    )
+    .optional(),
+  denyWindows: z
+    .array(
+      z.object({
+        timeZone: z.string(),
+        rrule: z.any(),
+      }),
+    )
+    .optional(),
 });
 
 export const AgentFixture = z.object({
-    name: z.string(),
-    type: z.string(),
+  name: z.string(),
+  type: z.string(),
 });
 
 export const EntityFixtures = z.object({
-    system: SystemFixture,
-    environments: z.array(EnvironmentFixture).optional(),
-    resources: z.array(ResourceFixture).optional(),
-    deployments: z.array(DeploymentFixture).optional(),
-    policies: z.array(PolicyFixture).optional(),
-    agents: z.array(AgentFixture).optional(),
+  system: SystemFixture,
+  environments: z.array(EnvironmentFixture).optional(),
+  resources: z.array(ResourceFixture).optional(),
+  deployments: z.array(DeploymentFixture).optional(),
+  policies: z.array(PolicyFixture).optional(),
+  agents: z.array(AgentFixture).optional(),
 });
 
 export function importEntityFixtures(
-    yamlFilePath: string,
-    prefix: string,
+  yamlFilePath: string,
+  prefix: string,
 ): EntityFixtures {
-    const resolvedPath = path.isAbsolute(yamlFilePath)
-        ? yamlFilePath
-        : path.resolve(process.cwd(), yamlFilePath);
+  const resolvedPath = path.isAbsolute(yamlFilePath)
+    ? yamlFilePath
+    : path.resolve(process.cwd(), yamlFilePath);
 
-    const fileContent = fs.readFileSync(resolvedPath, "utf8");
-    const template = compile(fileContent);
-    const fileTemplated = template({ prefix });
-    const data = yaml.load(fileTemplated);
-    const parseResult = EntityFixtures.safeParse(data);
-    if (!parseResult.success) {
-        throw new Error(
-            `Failed to parse entity fixtures in ${yamlFilePath}: ${parseResult.error.message}`,
-        );
-    }
-    return parseResult.data;
+  const fileContent = fs.readFileSync(resolvedPath, "utf8");
+  const template = compile(fileContent);
+  const fileTemplated = template({ prefix });
+  const data = yaml.load(fileTemplated);
+  const parseResult = EntityFixtures.safeParse(data);
+  if (!parseResult.success) {
+    throw new Error(
+      `Failed to parse entity fixtures in ${yamlFilePath}: ${parseResult.error.message}`,
+    );
+  }
+  return parseResult.data;
 }

--- a/e2e/api/entity-fixtures.ts
+++ b/e2e/api/entity-fixtures.ts
@@ -4,127 +4,134 @@ import { compile } from "handlebars";
 import yaml from "js-yaml";
 import { z } from "zod";
 
-export type DeploymentVariableFixtureType = z.infer<
-  typeof DeploymentVariableFixture
+export type DeploymentVariableFixture = z.infer<
+    typeof DeploymentVariableFixture
 >;
-export type DeploymentVersionFixtureType = z.infer<
-  typeof DeploymentVersionFixture
+export type DeploymentVersionFixture = z.infer<
+    typeof DeploymentVersionFixture
 >;
-export type DeploymentFixtureType = z.infer<typeof DeploymentFixture>;
-export type EnvironmentFixtureType = z.infer<typeof EnvironmentFixture>;
-export type SystemFixtureType = z.infer<typeof SystemFixture>;
-export type ResourceFixtureType = z.infer<typeof ResourceFixture>;
-export type PolicyFixtureType = z.infer<typeof PolicyFixture>;
+export type DeploymentFixture = z.infer<typeof DeploymentFixture>;
+export type EnvironmentFixture = z.infer<typeof EnvironmentFixture>;
+export type SystemFixture = z.infer<typeof SystemFixture>;
+export type ResourceFixture = z.infer<typeof ResourceFixture>;
+export type PolicyFixture = z.infer<typeof PolicyFixture>;
+export type AgentFixture = z.infer<typeof AgentFixture>;
 export type EntityFixtures = z.infer<typeof EntityFixtures>;
 
 export const DeploymentVariableFixture = z.object({
-  key: z.string(),
-  description: z.string().optional(),
-  config: z.record(z.any()),
-  values: z
-    .array(
-      z.object({
-        value: z.any(),
-        valueType: z.enum(["direct", "reference"]).optional(),
-        sensitive: z.boolean().optional(),
-        resourceSelector: z.any().optional(),
-        default: z.boolean().optional(),
-      }),
-    )
-    .optional(),
+    key: z.string(),
+    description: z.string().optional(),
+    config: z.record(z.any()),
+    values: z
+        .array(
+            z.object({
+                value: z.any(),
+                valueType: z.enum(["direct", "reference"]).optional(),
+                sensitive: z.boolean().optional(),
+                resourceSelector: z.any().optional(),
+                default: z.boolean().optional(),
+            }),
+        )
+        .optional(),
 });
 
 export const DeploymentVersionFixture = z.object({
-  tag: z.string(),
-  name: z.string().optional(),
-  config: z.record(z.any()).optional(),
-  metadata: z.record(z.string()).optional(),
-  status: z.enum(["building", "ready", "failed"]).optional(),
-  message: z.string().optional(),
+    tag: z.string(),
+    name: z.string().optional(),
+    config: z.record(z.any()).optional(),
+    metadata: z.record(z.string()).optional(),
+    status: z.enum(["building", "ready", "failed"]).optional(),
+    message: z.string().optional(),
 });
 
 export const DeploymentFixture = z.object({
-  name: z.string(),
-  slug: z.string(),
-  description: z.string().optional(),
-  resourceSelector: z.any().optional(),
-  versions: z.array(DeploymentVersionFixture).optional(),
-  variables: z.array(DeploymentVariableFixture).optional(),
+    name: z.string(),
+    slug: z.string(),
+    description: z.string().optional(),
+    resourceSelector: z.any().optional(),
+    versions: z.array(DeploymentVersionFixture).optional(),
+    variables: z.array(DeploymentVariableFixture).optional(),
 });
 
 export const EnvironmentFixture = z.object({
-  name: z.string(),
-  description: z.string().optional(),
-  metadata: z.record(z.string()).optional(),
-  resourceSelector: z.any().optional(),
+    name: z.string(),
+    description: z.string().optional(),
+    metadata: z.record(z.string()).optional(),
+    resourceSelector: z.any().optional(),
 });
 
 export const SystemFixture = z.object({
-  name: z.string(),
-  slug: z.string(),
-  description: z.string().optional(),
+    name: z.string(),
+    slug: z.string(),
+    description: z.string().optional(),
 });
 
 export const ResourceFixture = z.object({
-  name: z.string(),
-  kind: z.string(),
-  identifier: z.string(),
-  version: z.string(),
-  config: z.record(z.any()),
-  metadata: z.record(z.string()).optional(),
+    name: z.string(),
+    kind: z.string(),
+    identifier: z.string(),
+    version: z.string(),
+    config: z.record(z.any()),
+    metadata: z.record(z.string()).optional(),
 });
 
 export const PolicyFixture = z.object({
-  name: z.string(),
-  targets: z.array(
-    z.object({
-      environmentSelector: z.any().optional(),
-      deploymentSelector: z.any().optional(),
-      resourceSelector: z.any().optional(),
-    }),
-  ),
-  versionAnyApprovals: z
-    .array(
-      z.object({
-        requiredApprovalsCount: z.number(),
-      }),
-    )
-    .optional(),
-  denyWindows: z
-    .array(
-      z.object({
-        timeZone: z.string(),
-        rrule: z.any(),
-      }),
-    )
-    .optional(),
+    name: z.string(),
+    targets: z.array(
+        z.object({
+            environmentSelector: z.any().optional(),
+            deploymentSelector: z.any().optional(),
+            resourceSelector: z.any().optional(),
+        }),
+    ),
+    versionAnyApprovals: z
+        .array(
+            z.object({
+                requiredApprovalsCount: z.number(),
+            }),
+        )
+        .optional(),
+    denyWindows: z
+        .array(
+            z.object({
+                timeZone: z.string(),
+                rrule: z.any(),
+            }),
+        )
+        .optional(),
+});
+
+export const AgentFixture = z.object({
+    name: z.string(),
+    type: z.string(),
 });
 
 export const EntityFixtures = z.object({
-  system: SystemFixture,
-  environments: z.array(EnvironmentFixture).optional(),
-  resources: z.array(ResourceFixture).optional(),
-  deployments: z.array(DeploymentFixture).optional(),
-  policies: z.array(PolicyFixture).optional(),
+    system: SystemFixture,
+    environments: z.array(EnvironmentFixture).optional(),
+    resources: z.array(ResourceFixture).optional(),
+    deployments: z.array(DeploymentFixture).optional(),
+    policies: z.array(PolicyFixture).optional(),
+    agents: z.array(AgentFixture).optional(),
 });
 
 export function importEntityFixtures(
-  yamlFilePath: string,
-  prefix: string,
+    yamlFilePath: string,
+    prefix: string,
 ): EntityFixtures {
-  const resolvedPath = path.isAbsolute(yamlFilePath)
-    ? yamlFilePath
-    : path.resolve(process.cwd(), yamlFilePath);
+    const resolvedPath = path.isAbsolute(yamlFilePath)
+        ? yamlFilePath
+        : path.resolve(process.cwd(), yamlFilePath);
 
-  const fileContent = fs.readFileSync(resolvedPath, "utf8");
-  const template = compile(fileContent);
-  const fileTemplated = template({ prefix });
-  const data = yaml.load(fileTemplated);
-  const parseResult = EntityFixtures.safeParse(data);
-  if (!parseResult.success) {
-    throw new Error(
-      `Failed to parse entity fixtures in ${yamlFilePath}: ${parseResult.error.message}`,
-    );
-  }
-  return parseResult.data;
+    const fileContent = fs.readFileSync(resolvedPath, "utf8");
+    const template = compile(fileContent);
+    const fileTemplated = template({ prefix });
+    const data = yaml.load(fileTemplated);
+    const parseResult = EntityFixtures.safeParse(data);
+    if (!parseResult.success) {
+        throw new Error(
+            `Failed to parse entity fixtures in ${yamlFilePath}: ${parseResult.error.message}`,
+        );
+    }
+    return parseResult.data;
 }

--- a/e2e/api/entity-fixtures.ts
+++ b/e2e/api/entity-fixtures.ts
@@ -1,14 +1,14 @@
-import { z } from "zod";
-import yaml from "js-yaml";
-import path from "path";
 import fs from "fs";
+import path from "path";
 import { compile } from "handlebars";
+import yaml from "js-yaml";
+import { z } from "zod";
 
 export type DeploymentVariableFixtureType = z.infer<
-    typeof DeploymentVariableFixture
+  typeof DeploymentVariableFixture
 >;
 export type DeploymentVersionFixtureType = z.infer<
-    typeof DeploymentVersionFixture
+  typeof DeploymentVersionFixture
 >;
 export type DeploymentFixtureType = z.infer<typeof DeploymentFixture>;
 export type EnvironmentFixtureType = z.infer<typeof EnvironmentFixture>;
@@ -18,113 +18,113 @@ export type PolicyFixtureType = z.infer<typeof PolicyFixture>;
 export type EntityFixtures = z.infer<typeof EntityFixtures>;
 
 export const DeploymentVariableFixture = z.object({
-    key: z.string(),
-    description: z.string().optional(),
-    config: z.record(z.any()),
-    values: z
-        .array(
-            z.object({
-                value: z.any(),
-                valueType: z.enum(["direct", "reference"]).optional(),
-                sensitive: z.boolean().optional(),
-                resourceSelector: z.any().optional(),
-                default: z.boolean().optional(),
-            }),
-        )
-        .optional(),
+  key: z.string(),
+  description: z.string().optional(),
+  config: z.record(z.any()),
+  values: z
+    .array(
+      z.object({
+        value: z.any(),
+        valueType: z.enum(["direct", "reference"]).optional(),
+        sensitive: z.boolean().optional(),
+        resourceSelector: z.any().optional(),
+        default: z.boolean().optional(),
+      }),
+    )
+    .optional(),
 });
 
 export const DeploymentVersionFixture = z.object({
-    tag: z.string(),
-    name: z.string().optional(),
-    config: z.record(z.any()).optional(),
-    metadata: z.record(z.string()).optional(),
-    status: z.enum(["building", "ready", "failed"]).optional(),
-    message: z.string().optional(),
+  tag: z.string(),
+  name: z.string().optional(),
+  config: z.record(z.any()).optional(),
+  metadata: z.record(z.string()).optional(),
+  status: z.enum(["building", "ready", "failed"]).optional(),
+  message: z.string().optional(),
 });
 
 export const DeploymentFixture = z.object({
-    name: z.string(),
-    slug: z.string(),
-    description: z.string().optional(),
-    resourceSelector: z.any().optional(),
-    versions: z.array(DeploymentVersionFixture).optional(),
-    variables: z.array(DeploymentVariableFixture).optional(),
+  name: z.string(),
+  slug: z.string(),
+  description: z.string().optional(),
+  resourceSelector: z.any().optional(),
+  versions: z.array(DeploymentVersionFixture).optional(),
+  variables: z.array(DeploymentVariableFixture).optional(),
 });
 
 export const EnvironmentFixture = z.object({
-    name: z.string(),
-    description: z.string().optional(),
-    metadata: z.record(z.string()).optional(),
-    resourceSelector: z.any().optional(),
+  name: z.string(),
+  description: z.string().optional(),
+  metadata: z.record(z.string()).optional(),
+  resourceSelector: z.any().optional(),
 });
 
 export const SystemFixture = z.object({
-    name: z.string(),
-    slug: z.string(),
-    description: z.string().optional(),
+  name: z.string(),
+  slug: z.string(),
+  description: z.string().optional(),
 });
 
 export const ResourceFixture = z.object({
-    name: z.string(),
-    kind: z.string(),
-    identifier: z.string(),
-    version: z.string(),
-    config: z.record(z.any()),
-    metadata: z.record(z.string()).optional(),
+  name: z.string(),
+  kind: z.string(),
+  identifier: z.string(),
+  version: z.string(),
+  config: z.record(z.any()),
+  metadata: z.record(z.string()).optional(),
 });
 
 export const PolicyFixture = z.object({
-    name: z.string(),
-    targets: z.array(
-        z.object({
-            environmentSelector: z.any().optional(),
-            deploymentSelector: z.any().optional(),
-            resourceSelector: z.any().optional(),
-        }),
-    ),
-    versionAnyApprovals: z
-        .array(
-            z.object({
-                requiredApprovalsCount: z.number(),
-            }),
-        )
-        .optional(),
-    denyWindows: z
-        .array(
-            z.object({
-                timeZone: z.string(),
-                rrule: z.any(),
-            }),
-        )
-        .optional(),
+  name: z.string(),
+  targets: z.array(
+    z.object({
+      environmentSelector: z.any().optional(),
+      deploymentSelector: z.any().optional(),
+      resourceSelector: z.any().optional(),
+    }),
+  ),
+  versionAnyApprovals: z
+    .array(
+      z.object({
+        requiredApprovalsCount: z.number(),
+      }),
+    )
+    .optional(),
+  denyWindows: z
+    .array(
+      z.object({
+        timeZone: z.string(),
+        rrule: z.any(),
+      }),
+    )
+    .optional(),
 });
 
 export const EntityFixtures = z.object({
-    system: SystemFixture,
-    environments: z.array(EnvironmentFixture).optional(),
-    resources: z.array(ResourceFixture).optional(),
-    deployments: z.array(DeploymentFixture).optional(),
-    policies: z.array(PolicyFixture).optional(),
+  system: SystemFixture,
+  environments: z.array(EnvironmentFixture).optional(),
+  resources: z.array(ResourceFixture).optional(),
+  deployments: z.array(DeploymentFixture).optional(),
+  policies: z.array(PolicyFixture).optional(),
 });
 
 export function importEntityFixtures(
-    yamlFilePath: string,
-    prefix: string,
+  yamlFilePath: string,
+  prefix: string,
 ): EntityFixtures {
-    const resolvedPath = path.isAbsolute(yamlFilePath)
-        ? yamlFilePath
-        : path.resolve(process.cwd(), yamlFilePath);
+  const resolvedPath = path.isAbsolute(yamlFilePath)
+    ? yamlFilePath
+    : path.resolve(process.cwd(), yamlFilePath);
 
-    const fileContent = fs.readFileSync(resolvedPath, "utf8");
-    const template = compile(fileContent);
-    const fileTemplated = template({ prefix });
-    const data = yaml.load(fileTemplated);
-    const parseResult = EntityFixtures.safeParse(data);
-    if (!parseResult.success) {
-        throw new Error(
-            `Failed to parse entity fixtures in ${yamlFilePath}: ${parseResult.error.message}`,
-        );
-    }
-    return parseResult.data;
+  const fileContent = fs.readFileSync(resolvedPath, "utf8");
+  const template = compile(fileContent);
+  const fileTemplated = template({ prefix });
+  const data = yaml.load(fileTemplated);
+  const parseResult = EntityFixtures.safeParse(data);
+  if (!parseResult.success) {
+    throw new Error(
+      `Failed to parse entity fixtures in ${yamlFilePath}: ${parseResult.error.message}`,
+    );
+  }
+  return parseResult.data;
 }

--- a/e2e/api/index.ts
+++ b/e2e/api/index.ts
@@ -3,7 +3,7 @@ import createOClient, { ClientOptions } from "openapi-fetch";
 import { paths } from "./schema";
 
 export * from "./schema";
-export * from "./yaml-loader";
+export * from "./entities-builder";
 
 export { operations as Operations } from "./schema";
 

--- a/e2e/api/schema.ts
+++ b/e2e/api/schema.ts
@@ -4,4396 +4,4429 @@
  */
 
 export interface paths {
-    "/api/v1/cloud-locations/{provider}": {
-        parameters: {
-            query?: never;
-            header?: never;
-            path?: never;
-            cookie?: never;
-        };
-        /**
-         * Get all regions for a specific cloud provider
-         * @description Returns geographic data for all regions of a specific cloud provider
-         */
-        get: operations["getCloudProviderRegions"];
-        put?: never;
-        post?: never;
-        delete?: never;
-        options?: never;
-        head?: never;
-        patch?: never;
-        trace?: never;
+  "/api/v1/cloud-locations/{provider}": {
+    parameters: {
+      query?: never;
+      header?: never;
+      path?: never;
+      cookie?: never;
     };
-    "/v1/deployment-version-channels": {
-        parameters: {
-            query?: never;
-            header?: never;
-            path?: never;
-            cookie?: never;
-        };
-        get?: never;
-        put?: never;
-        /** Create a deployment version channel */
-        post: operations["createDeploymentVersionChannel"];
-        delete?: never;
-        options?: never;
-        head?: never;
-        patch?: never;
-        trace?: never;
+    /**
+     * Get all regions for a specific cloud provider
+     * @description Returns geographic data for all regions of a specific cloud provider
+     */
+    get: operations["getCloudProviderRegions"];
+    put?: never;
+    post?: never;
+    delete?: never;
+    options?: never;
+    head?: never;
+    patch?: never;
+    trace?: never;
+  };
+  "/v1/deployment-version-channels": {
+    parameters: {
+      query?: never;
+      header?: never;
+      path?: never;
+      cookie?: never;
     };
-    "/v1/deployment-versions/{deploymentVersionId}": {
-        parameters: {
-            query?: never;
-            header?: never;
-            path?: never;
-            cookie?: never;
-        };
-        get?: never;
-        put?: never;
-        post?: never;
-        delete?: never;
-        options?: never;
-        head?: never;
-        /** Updates a deployment version */
-        patch: operations["updateDeploymentVersion"];
-        trace?: never;
+    get?: never;
+    put?: never;
+    /** Create a deployment version channel */
+    post: operations["createDeploymentVersionChannel"];
+    delete?: never;
+    options?: never;
+    head?: never;
+    patch?: never;
+    trace?: never;
+  };
+  "/v1/deployment-versions/{deploymentVersionId}": {
+    parameters: {
+      query?: never;
+      header?: never;
+      path?: never;
+      cookie?: never;
     };
-    "/v1/deployment-versions": {
-        parameters: {
-            query?: never;
-            header?: never;
-            path?: never;
-            cookie?: never;
-        };
-        get?: never;
-        put?: never;
-        /** Upserts a deployment version */
-        post: operations["upsertDeploymentVersion"];
-        delete?: never;
-        options?: never;
-        head?: never;
-        patch?: never;
-        trace?: never;
+    get?: never;
+    put?: never;
+    post?: never;
+    delete?: never;
+    options?: never;
+    head?: never;
+    /** Updates a deployment version */
+    patch: operations["updateDeploymentVersion"];
+    trace?: never;
+  };
+  "/v1/deployment-versions": {
+    parameters: {
+      query?: never;
+      header?: never;
+      path?: never;
+      cookie?: never;
     };
-    "/v1/deployments/{deploymentId}/deployment-version-channels/name/{name}": {
-        parameters: {
-            query?: never;
-            header?: never;
-            path?: never;
-            cookie?: never;
-        };
-        get?: never;
-        put?: never;
-        post?: never;
-        /** Delete a deployment version channel */
-        delete: operations["deleteDeploymentVersionChannel"];
-        options?: never;
-        head?: never;
-        patch?: never;
-        trace?: never;
+    get?: never;
+    put?: never;
+    /** Upserts a deployment version */
+    post: operations["upsertDeploymentVersion"];
+    delete?: never;
+    options?: never;
+    head?: never;
+    patch?: never;
+    trace?: never;
+  };
+  "/v1/deployments/{deploymentId}/deployment-version-channels/name/{name}": {
+    parameters: {
+      query?: never;
+      header?: never;
+      path?: never;
+      cookie?: never;
     };
-    "/v1/deployments/{deploymentId}": {
-        parameters: {
-            query?: never;
-            header?: never;
-            path?: never;
-            cookie?: never;
-        };
-        /** Get a deployment */
-        get: operations["getDeployment"];
-        put?: never;
-        post?: never;
-        /** Delete a deployment */
-        delete: operations["deleteDeployment"];
-        options?: never;
-        head?: never;
-        /** Update a deployment */
-        patch: operations["updateDeployment"];
-        trace?: never;
+    get?: never;
+    put?: never;
+    post?: never;
+    /** Delete a deployment version channel */
+    delete: operations["deleteDeploymentVersionChannel"];
+    options?: never;
+    head?: never;
+    patch?: never;
+    trace?: never;
+  };
+  "/v1/deployments/{deploymentId}": {
+    parameters: {
+      query?: never;
+      header?: never;
+      path?: never;
+      cookie?: never;
     };
-    "/v1/deployments/{deploymentId}/release-channels/name/{name}": {
-        parameters: {
-            query?: never;
-            header?: never;
-            path?: never;
-            cookie?: never;
-        };
-        get?: never;
-        put?: never;
-        post?: never;
-        /** Delete a release channel */
-        delete: operations["deleteReleaseChannel"];
-        options?: never;
-        head?: never;
-        patch?: never;
-        trace?: never;
+    /** Get a deployment */
+    get: operations["getDeployment"];
+    put?: never;
+    post?: never;
+    /** Delete a deployment */
+    delete: operations["deleteDeployment"];
+    options?: never;
+    head?: never;
+    /** Update a deployment */
+    patch: operations["updateDeployment"];
+    trace?: never;
+  };
+  "/v1/deployments/{deploymentId}/release-channels/name/{name}": {
+    parameters: {
+      query?: never;
+      header?: never;
+      path?: never;
+      cookie?: never;
     };
-    "/v1/deployments/{deploymentId}/resources": {
-        parameters: {
-            query?: never;
-            header?: never;
-            path?: never;
-            cookie?: never;
-        };
-        /** Get resources for a deployment */
-        get: operations["getResourcesForDeployment"];
-        put?: never;
-        post?: never;
-        delete?: never;
-        options?: never;
-        head?: never;
-        patch?: never;
-        trace?: never;
+    get?: never;
+    put?: never;
+    post?: never;
+    /** Delete a release channel */
+    delete: operations["deleteReleaseChannel"];
+    options?: never;
+    head?: never;
+    patch?: never;
+    trace?: never;
+  };
+  "/v1/deployments/{deploymentId}/resources": {
+    parameters: {
+      query?: never;
+      header?: never;
+      path?: never;
+      cookie?: never;
     };
-    "/v1/deployments/{deploymentId}/variables": {
-        parameters: {
-            query?: never;
-            header?: never;
-            path?: never;
-            cookie?: never;
-        };
-        /** Get all variables for a deployment */
-        get: operations["getDeploymentVariables"];
-        put?: never;
-        /** Create a new variable for a deployment */
-        post: operations["createDeploymentVariable"];
-        delete?: never;
-        options?: never;
-        head?: never;
-        patch?: never;
-        trace?: never;
+    /** Get resources for a deployment */
+    get: operations["getResourcesForDeployment"];
+    put?: never;
+    post?: never;
+    delete?: never;
+    options?: never;
+    head?: never;
+    patch?: never;
+    trace?: never;
+  };
+  "/v1/deployments/{deploymentId}/variables": {
+    parameters: {
+      query?: never;
+      header?: never;
+      path?: never;
+      cookie?: never;
     };
-    "/v1/deployments": {
-        parameters: {
-            query?: never;
-            header?: never;
-            path?: never;
-            cookie?: never;
-        };
-        get?: never;
-        put?: never;
-        /** Create a deployment */
-        post: operations["createDeployment"];
-        delete?: never;
-        options?: never;
-        head?: never;
-        patch?: never;
-        trace?: never;
+    /** Get all variables for a deployment */
+    get: operations["getDeploymentVariables"];
+    put?: never;
+    /** Create a new variable for a deployment */
+    post: operations["createDeploymentVariable"];
+    delete?: never;
+    options?: never;
+    head?: never;
+    patch?: never;
+    trace?: never;
+  };
+  "/v1/deployments": {
+    parameters: {
+      query?: never;
+      header?: never;
+      path?: never;
+      cookie?: never;
     };
-    "/v1/environments/{environmentId}": {
-        parameters: {
-            query?: never;
-            header?: never;
-            path?: never;
-            cookie?: never;
-        };
-        /** Get an environment */
-        get: operations["getEnvironment"];
-        put?: never;
-        post?: never;
-        /** Delete an environment */
-        delete: operations["deleteEnvironment"];
-        options?: never;
-        head?: never;
-        patch?: never;
-        trace?: never;
+    get?: never;
+    put?: never;
+    /** Create a deployment */
+    post: operations["createDeployment"];
+    delete?: never;
+    options?: never;
+    head?: never;
+    patch?: never;
+    trace?: never;
+  };
+  "/v1/environments/{environmentId}": {
+    parameters: {
+      query?: never;
+      header?: never;
+      path?: never;
+      cookie?: never;
     };
-    "/v1/environments/{environmentId}/resources": {
-        parameters: {
-            query?: never;
-            header?: never;
-            path?: never;
-            cookie?: never;
-        };
-        /** Get resources for an environment */
-        get: operations["getResourcesForEnvironment"];
-        put?: never;
-        post?: never;
-        delete?: never;
-        options?: never;
-        head?: never;
-        patch?: never;
-        trace?: never;
+    /** Get an environment */
+    get: operations["getEnvironment"];
+    put?: never;
+    post?: never;
+    /** Delete an environment */
+    delete: operations["deleteEnvironment"];
+    options?: never;
+    head?: never;
+    patch?: never;
+    trace?: never;
+  };
+  "/v1/environments/{environmentId}/resources": {
+    parameters: {
+      query?: never;
+      header?: never;
+      path?: never;
+      cookie?: never;
     };
-    "/v1/environments": {
-        parameters: {
-            query?: never;
-            header?: never;
-            path?: never;
-            cookie?: never;
-        };
-        get?: never;
-        put?: never;
-        /** Create an environment */
-        post: operations["createEnvironment"];
-        delete?: never;
-        options?: never;
-        head?: never;
-        patch?: never;
-        trace?: never;
+    /** Get resources for an environment */
+    get: operations["getResourcesForEnvironment"];
+    put?: never;
+    post?: never;
+    delete?: never;
+    options?: never;
+    head?: never;
+    patch?: never;
+    trace?: never;
+  };
+  "/v1/environments": {
+    parameters: {
+      query?: never;
+      header?: never;
+      path?: never;
+      cookie?: never;
     };
-    "/v1/job-agents/{agentId}/jobs/running": {
-        parameters: {
-            query?: never;
-            header?: never;
-            path?: never;
-            cookie?: never;
-        };
-        /** Get a agents running jobs */
-        get: operations["getAgentRunningJobs"];
-        put?: never;
-        post?: never;
-        delete?: never;
-        options?: never;
-        head?: never;
-        patch?: never;
-        trace?: never;
+    get?: never;
+    put?: never;
+    /** Create an environment */
+    post: operations["createEnvironment"];
+    delete?: never;
+    options?: never;
+    head?: never;
+    patch?: never;
+    trace?: never;
+  };
+  "/v1/job-agents/{agentId}/jobs/running": {
+    parameters: {
+      query?: never;
+      header?: never;
+      path?: never;
+      cookie?: never;
     };
-    "/v1/job-agents/{agentId}/queue/acknowledge": {
-        parameters: {
-            query?: never;
-            header?: never;
-            path?: never;
-            cookie?: never;
-        };
-        get?: never;
-        put?: never;
-        /**
-         * Acknowledge a job for an agent
-         * @description Marks a job as acknowledged by the agent
-         */
-        post: operations["acknowledgeAgentJob"];
-        delete?: never;
-        options?: never;
-        head?: never;
-        patch?: never;
-        trace?: never;
+    /** Get a agents running jobs */
+    get: operations["getAgentRunningJobs"];
+    put?: never;
+    post?: never;
+    delete?: never;
+    options?: never;
+    head?: never;
+    patch?: never;
+    trace?: never;
+  };
+  "/v1/job-agents/{agentId}/queue/acknowledge": {
+    parameters: {
+      query?: never;
+      header?: never;
+      path?: never;
+      cookie?: never;
     };
-    "/v1/job-agents/{agentId}/queue/next": {
-        parameters: {
-            query?: never;
-            header?: never;
-            path?: never;
-            cookie?: never;
-        };
-        /** Get the next jobs */
-        get: operations["getNextJobs"];
-        put?: never;
-        post?: never;
-        delete?: never;
-        options?: never;
-        head?: never;
-        patch?: never;
-        trace?: never;
+    get?: never;
+    put?: never;
+    /**
+     * Acknowledge a job for an agent
+     * @description Marks a job as acknowledged by the agent
+     */
+    post: operations["acknowledgeAgentJob"];
+    delete?: never;
+    options?: never;
+    head?: never;
+    patch?: never;
+    trace?: never;
+  };
+  "/v1/job-agents/{agentId}/queue/next": {
+    parameters: {
+      query?: never;
+      header?: never;
+      path?: never;
+      cookie?: never;
     };
-    "/v1/job-agents/name": {
-        parameters: {
-            query?: never;
-            header?: never;
-            path?: never;
-            cookie?: never;
-        };
-        get?: never;
-        put?: never;
-        post?: never;
-        delete?: never;
-        options?: never;
-        head?: never;
-        /** Upserts the agent */
-        patch: operations["upsertJobAgent"];
-        trace?: never;
+    /** Get the next jobs */
+    get: operations["getNextJobs"];
+    put?: never;
+    post?: never;
+    delete?: never;
+    options?: never;
+    head?: never;
+    patch?: never;
+    trace?: never;
+  };
+  "/v1/job-agents/name": {
+    parameters: {
+      query?: never;
+      header?: never;
+      path?: never;
+      cookie?: never;
     };
-    "/v1/jobs/{jobId}/acknowledge": {
-        parameters: {
-            query?: never;
-            header?: never;
-            path?: never;
-            cookie?: never;
-        };
-        get?: never;
-        put?: never;
-        /** Acknowledge a job */
-        post: operations["acknowledgeJob"];
-        delete?: never;
-        options?: never;
-        head?: never;
-        patch?: never;
-        trace?: never;
+    get?: never;
+    put?: never;
+    post?: never;
+    delete?: never;
+    options?: never;
+    head?: never;
+    /** Upserts the agent */
+    patch: operations["upsertJobAgent"];
+    trace?: never;
+  };
+  "/v1/jobs/{jobId}/acknowledge": {
+    parameters: {
+      query?: never;
+      header?: never;
+      path?: never;
+      cookie?: never;
     };
-    "/v1/jobs/{jobId}": {
-        parameters: {
-            query?: never;
-            header?: never;
-            path?: never;
-            cookie?: never;
-        };
-        /** Get a Job */
-        get: operations["getJob"];
-        put?: never;
-        post?: never;
-        delete?: never;
-        options?: never;
-        head?: never;
-        /** Update a job */
-        patch: operations["updateJob"];
-        trace?: never;
+    get?: never;
+    put?: never;
+    /** Acknowledge a job */
+    post: operations["acknowledgeJob"];
+    delete?: never;
+    options?: never;
+    head?: never;
+    patch?: never;
+    trace?: never;
+  };
+  "/v1/jobs/{jobId}": {
+    parameters: {
+      query?: never;
+      header?: never;
+      path?: never;
+      cookie?: never;
     };
-    "/v1/policies/{policyId}": {
-        parameters: {
-            query?: never;
-            header?: never;
-            path?: never;
-            cookie?: never;
-        };
-        get?: never;
-        put?: never;
-        post?: never;
-        /** Delete a policy */
-        delete: operations["deletePolicy"];
-        options?: never;
-        head?: never;
-        /** Update a policy */
-        patch: operations["updatePolicy"];
-        trace?: never;
+    /** Get a Job */
+    get: operations["getJob"];
+    put?: never;
+    post?: never;
+    delete?: never;
+    options?: never;
+    head?: never;
+    /** Update a job */
+    patch: operations["updateJob"];
+    trace?: never;
+  };
+  "/v1/policies/{policyId}": {
+    parameters: {
+      query?: never;
+      header?: never;
+      path?: never;
+      cookie?: never;
     };
-    "/v1/policies/{policyId}/release-targets": {
-        parameters: {
-            query?: never;
-            header?: never;
-            path?: never;
-            cookie?: never;
-        };
-        /** Get release targets for a policy */
-        get: operations["getReleaseTargetsForPolicy"];
-        put?: never;
-        post?: never;
-        delete?: never;
-        options?: never;
-        head?: never;
-        patch?: never;
-        trace?: never;
+    get?: never;
+    put?: never;
+    post?: never;
+    /** Delete a policy */
+    delete: operations["deletePolicy"];
+    options?: never;
+    head?: never;
+    /** Update a policy */
+    patch: operations["updatePolicy"];
+    trace?: never;
+  };
+  "/v1/policies/{policyId}/release-targets": {
+    parameters: {
+      query?: never;
+      header?: never;
+      path?: never;
+      cookie?: never;
     };
-    "/v1/policies": {
-        parameters: {
-            query?: never;
-            header?: never;
-            path?: never;
-            cookie?: never;
-        };
-        get?: never;
-        put?: never;
-        /** Upsert a policy */
-        post: operations["upsertPolicy"];
-        delete?: never;
-        options?: never;
-        head?: never;
-        patch?: never;
-        trace?: never;
+    /** Get release targets for a policy */
+    get: operations["getReleaseTargetsForPolicy"];
+    put?: never;
+    post?: never;
+    delete?: never;
+    options?: never;
+    head?: never;
+    patch?: never;
+    trace?: never;
+  };
+  "/v1/policies": {
+    parameters: {
+      query?: never;
+      header?: never;
+      path?: never;
+      cookie?: never;
     };
-    "/v1/relationship/job-to-resource": {
-        parameters: {
-            query?: never;
-            header?: never;
-            path?: never;
-            cookie?: never;
-        };
-        get?: never;
-        put?: never;
-        /** Create a relationship between a job and a resource */
-        post: operations["createJobToResourceRelationship"];
-        delete?: never;
-        options?: never;
-        head?: never;
-        patch?: never;
-        trace?: never;
+    get?: never;
+    put?: never;
+    /** Upsert a policy */
+    post: operations["upsertPolicy"];
+    delete?: never;
+    options?: never;
+    head?: never;
+    patch?: never;
+    trace?: never;
+  };
+  "/v1/relationship/job-to-resource": {
+    parameters: {
+      query?: never;
+      header?: never;
+      path?: never;
+      cookie?: never;
     };
-    "/v1/relationship/resource-to-resource": {
-        parameters: {
-            query?: never;
-            header?: never;
-            path?: never;
-            cookie?: never;
-        };
-        get?: never;
-        put?: never;
-        /** Create a relationship between two resources */
-        post: operations["createResourceToResourceRelationship"];
-        delete?: never;
-        options?: never;
-        head?: never;
-        patch?: never;
-        trace?: never;
+    get?: never;
+    put?: never;
+    /** Create a relationship between a job and a resource */
+    post: operations["createJobToResourceRelationship"];
+    delete?: never;
+    options?: never;
+    head?: never;
+    patch?: never;
+    trace?: never;
+  };
+  "/v1/relationship/resource-to-resource": {
+    parameters: {
+      query?: never;
+      header?: never;
+      path?: never;
+      cookie?: never;
     };
-    "/v1/release-channels": {
-        parameters: {
-            query?: never;
-            header?: never;
-            path?: never;
-            cookie?: never;
-        };
-        get?: never;
-        put?: never;
-        /** Create a release channel */
-        post: operations["createReleaseChannel"];
-        delete?: never;
-        options?: never;
-        head?: never;
-        patch?: never;
-        trace?: never;
+    get?: never;
+    put?: never;
+    /** Create a relationship between two resources */
+    post: operations["createResourceToResourceRelationship"];
+    delete?: never;
+    options?: never;
+    head?: never;
+    patch?: never;
+    trace?: never;
+  };
+  "/v1/release-channels": {
+    parameters: {
+      query?: never;
+      header?: never;
+      path?: never;
+      cookie?: never;
     };
-    "/v1/release-targets/{releaseTargetId}/releases": {
-        parameters: {
-            query?: never;
-            header?: never;
-            path?: never;
-            cookie?: never;
-        };
-        /** Get the latest 100 releases for a release target */
-        get: operations["getReleaseTargetReleases"];
-        put?: never;
-        post?: never;
-        delete?: never;
-        options?: never;
-        head?: never;
-        patch?: never;
-        trace?: never;
+    get?: never;
+    put?: never;
+    /** Create a release channel */
+    post: operations["createReleaseChannel"];
+    delete?: never;
+    options?: never;
+    head?: never;
+    patch?: never;
+    trace?: never;
+  };
+  "/v1/release-targets/{releaseTargetId}/releases": {
+    parameters: {
+      query?: never;
+      header?: never;
+      path?: never;
+      cookie?: never;
     };
-    "/v1/releases/{releaseId}": {
-        parameters: {
-            query?: never;
-            header?: never;
-            path?: never;
-            cookie?: never;
-        };
-        get?: never;
-        put?: never;
-        post?: never;
-        delete?: never;
-        options?: never;
-        head?: never;
-        /** Updates a release */
-        patch: operations["updateRelease"];
-        trace?: never;
+    /** Get the latest 100 releases for a release target */
+    get: operations["getReleaseTargetReleases"];
+    put?: never;
+    post?: never;
+    delete?: never;
+    options?: never;
+    head?: never;
+    patch?: never;
+    trace?: never;
+  };
+  "/v1/releases/{releaseId}": {
+    parameters: {
+      query?: never;
+      header?: never;
+      path?: never;
+      cookie?: never;
     };
-    "/v1/releases": {
-        parameters: {
-            query?: never;
-            header?: never;
-            path?: never;
-            cookie?: never;
-        };
-        get?: never;
-        put?: never;
-        /** Upserts a release */
-        post: operations["upsertRelease"];
-        delete?: never;
-        options?: never;
-        head?: never;
-        patch?: never;
-        trace?: never;
+    get?: never;
+    put?: never;
+    post?: never;
+    delete?: never;
+    options?: never;
+    head?: never;
+    /** Updates a release */
+    patch: operations["updateRelease"];
+    trace?: never;
+  };
+  "/v1/releases": {
+    parameters: {
+      query?: never;
+      header?: never;
+      path?: never;
+      cookie?: never;
     };
-    "/v1/resource-providers/{providerId}/set": {
-        parameters: {
-            query?: never;
-            header?: never;
-            path?: never;
-            cookie?: never;
-        };
-        get?: never;
-        put?: never;
-        post?: never;
-        delete?: never;
-        options?: never;
-        head?: never;
-        /** Sets the resource for a provider. */
-        patch: operations["setResourceProvidersResources"];
-        trace?: never;
+    get?: never;
+    put?: never;
+    /** Upserts a release */
+    post: operations["upsertRelease"];
+    delete?: never;
+    options?: never;
+    head?: never;
+    patch?: never;
+    trace?: never;
+  };
+  "/v1/resource-providers/{providerId}/set": {
+    parameters: {
+      query?: never;
+      header?: never;
+      path?: never;
+      cookie?: never;
     };
-    "/v1/resource-relationship-rules/{ruleId}": {
-        parameters: {
-            query?: never;
-            header?: never;
-            path?: never;
-            cookie?: never;
-        };
-        get?: never;
-        put?: never;
-        post?: never;
-        delete?: never;
-        options?: never;
-        head?: never;
-        /** Update a resource relationship rule */
-        patch: operations["updateResourceRelationshipRule"];
-        trace?: never;
+    get?: never;
+    put?: never;
+    post?: never;
+    delete?: never;
+    options?: never;
+    head?: never;
+    /** Sets the resource for a provider. */
+    patch: operations["setResourceProvidersResources"];
+    trace?: never;
+  };
+  "/v1/resource-relationship-rules/{ruleId}": {
+    parameters: {
+      query?: never;
+      header?: never;
+      path?: never;
+      cookie?: never;
     };
-    "/v1/resource-relationship-rules": {
-        parameters: {
-            query?: never;
-            header?: never;
-            path?: never;
-            cookie?: never;
-        };
-        get?: never;
-        put?: never;
-        /** Create a resource relationship rule */
-        post: operations["createResourceRelationshipRule"];
-        delete?: never;
-        options?: never;
-        head?: never;
-        patch?: never;
-        trace?: never;
+    get?: never;
+    put?: never;
+    post?: never;
+    delete?: never;
+    options?: never;
+    head?: never;
+    /** Update a resource relationship rule */
+    patch: operations["updateResourceRelationshipRule"];
+    trace?: never;
+  };
+  "/v1/resource-relationship-rules": {
+    parameters: {
+      query?: never;
+      header?: never;
+      path?: never;
+      cookie?: never;
     };
-    "/v1/resource-schemas": {
-        parameters: {
-            query?: never;
-            header?: never;
-            path?: never;
-            cookie?: never;
-        };
-        get?: never;
-        put?: never;
-        /** Create a resource schema */
-        post: operations["createResourceSchema"];
-        delete?: never;
-        options?: never;
-        head?: never;
-        patch?: never;
-        trace?: never;
+    get?: never;
+    put?: never;
+    /** Create a resource relationship rule */
+    post: operations["createResourceRelationshipRule"];
+    delete?: never;
+    options?: never;
+    head?: never;
+    patch?: never;
+    trace?: never;
+  };
+  "/v1/resource-schemas": {
+    parameters: {
+      query?: never;
+      header?: never;
+      path?: never;
+      cookie?: never;
     };
-    "/v1/resource-schemas/{schemaId}": {
-        parameters: {
-            query?: never;
-            header?: never;
-            path?: never;
-            cookie?: never;
-        };
-        get?: never;
-        put?: never;
-        post?: never;
-        /** Delete a resource schema */
-        delete: operations["deleteResourceSchema"];
-        options?: never;
-        head?: never;
-        patch?: never;
-        trace?: never;
+    get?: never;
+    put?: never;
+    /** Create a resource schema */
+    post: operations["createResourceSchema"];
+    delete?: never;
+    options?: never;
+    head?: never;
+    patch?: never;
+    trace?: never;
+  };
+  "/v1/resource-schemas/{schemaId}": {
+    parameters: {
+      query?: never;
+      header?: never;
+      path?: never;
+      cookie?: never;
     };
-    "/v1/resources/{resourceId}": {
-        parameters: {
-            query?: never;
-            header?: never;
-            path?: never;
-            cookie?: never;
-        };
-        /** Get a resource */
-        get: operations["getResource"];
-        put?: never;
-        post?: never;
-        /** Delete a resource */
-        delete: operations["deleteResource"];
-        options?: never;
-        head?: never;
-        /** Update a resource */
-        patch: operations["updateResource"];
-        trace?: never;
+    get?: never;
+    put?: never;
+    post?: never;
+    /** Delete a resource schema */
+    delete: operations["deleteResourceSchema"];
+    options?: never;
+    head?: never;
+    patch?: never;
+    trace?: never;
+  };
+  "/v1/resources/{resourceId}": {
+    parameters: {
+      query?: never;
+      header?: never;
+      path?: never;
+      cookie?: never;
     };
-    "/v1/resources/{resourceId}/release-targets": {
-        parameters: {
-            query?: never;
-            header?: never;
-            path?: never;
-            cookie?: never;
-        };
-        /** Get release targets for a resource */
-        get: operations["getReleaseTargets"];
-        put?: never;
-        post?: never;
-        delete?: never;
-        options?: never;
-        head?: never;
-        patch?: never;
-        trace?: never;
+    /** Get a resource */
+    get: operations["getResource"];
+    put?: never;
+    post?: never;
+    /** Delete a resource */
+    delete: operations["deleteResource"];
+    options?: never;
+    head?: never;
+    /** Update a resource */
+    patch: operations["updateResource"];
+    trace?: never;
+  };
+  "/v1/resources/{resourceId}/release-targets": {
+    parameters: {
+      query?: never;
+      header?: never;
+      path?: never;
+      cookie?: never;
     };
-    "/v1/resources": {
-        parameters: {
-            query?: never;
-            header?: never;
-            path?: never;
-            cookie?: never;
-        };
-        get?: never;
-        put?: never;
-        /** Create or update a resource */
-        post: operations["upsertResource"];
-        delete?: never;
-        options?: never;
-        head?: never;
-        patch?: never;
-        trace?: never;
+    /** Get release targets for a resource */
+    get: operations["getReleaseTargets"];
+    put?: never;
+    post?: never;
+    delete?: never;
+    options?: never;
+    head?: never;
+    patch?: never;
+    trace?: never;
+  };
+  "/v1/resources": {
+    parameters: {
+      query?: never;
+      header?: never;
+      path?: never;
+      cookie?: never;
     };
-    "/v1/systems/{systemId}/environments/{name}": {
-        parameters: {
-            query?: never;
-            header?: never;
-            path?: never;
-            cookie?: never;
-        };
-        get?: never;
-        put?: never;
-        post?: never;
-        /** Delete an environment */
-        delete: operations["deleteEnvironmentByName"];
-        options?: never;
-        head?: never;
-        patch?: never;
-        trace?: never;
+    get?: never;
+    put?: never;
+    /** Create or update a resource */
+    post: operations["upsertResource"];
+    delete?: never;
+    options?: never;
+    head?: never;
+    patch?: never;
+    trace?: never;
+  };
+  "/v1/systems/{systemId}/environments/{name}": {
+    parameters: {
+      query?: never;
+      header?: never;
+      path?: never;
+      cookie?: never;
     };
-    "/v1/systems/{systemId}": {
-        parameters: {
-            query?: never;
-            header?: never;
-            path?: never;
-            cookie?: never;
-        };
-        /** Get a system */
-        get: operations["getSystem"];
-        put?: never;
-        post?: never;
-        /** Delete a system */
-        delete: operations["deleteSystem"];
-        options?: never;
-        head?: never;
-        /** Update a system */
-        patch: operations["updateSystem"];
-        trace?: never;
+    get?: never;
+    put?: never;
+    post?: never;
+    /** Delete an environment */
+    delete: operations["deleteEnvironmentByName"];
+    options?: never;
+    head?: never;
+    patch?: never;
+    trace?: never;
+  };
+  "/v1/systems/{systemId}": {
+    parameters: {
+      query?: never;
+      header?: never;
+      path?: never;
+      cookie?: never;
     };
-    "/v1/systems": {
-        parameters: {
-            query?: never;
-            header?: never;
-            path?: never;
-            cookie?: never;
-        };
-        get?: never;
-        put?: never;
-        /** Create a system */
-        post: operations["createSystem"];
-        delete?: never;
-        options?: never;
-        head?: never;
-        patch?: never;
-        trace?: never;
+    /** Get a system */
+    get: operations["getSystem"];
+    put?: never;
+    post?: never;
+    /** Delete a system */
+    delete: operations["deleteSystem"];
+    options?: never;
+    head?: never;
+    /** Update a system */
+    patch: operations["updateSystem"];
+    trace?: never;
+  };
+  "/v1/systems": {
+    parameters: {
+      query?: never;
+      header?: never;
+      path?: never;
+      cookie?: never;
     };
-    "/v1/workspaces/{workspaceId}/deployments": {
-        parameters: {
-            query?: never;
-            header?: never;
-            path: {
-                /** @description The ID of the workspace */
-                workspaceId: string;
-            };
-            cookie?: never;
-        };
-        /** List all deployments */
-        get: operations["listDeployments"];
-        put?: never;
-        post?: never;
-        delete?: never;
-        options?: never;
-        head?: never;
-        patch?: never;
-        trace?: never;
+    get?: never;
+    put?: never;
+    /** Create a system */
+    post: operations["createSystem"];
+    delete?: never;
+    options?: never;
+    head?: never;
+    patch?: never;
+    trace?: never;
+  };
+  "/v1/workspaces/{workspaceId}/deployments": {
+    parameters: {
+      query?: never;
+      header?: never;
+      path: {
+        /** @description The ID of the workspace */
+        workspaceId: string;
+      };
+      cookie?: never;
     };
-    "/v1/workspaces/{workspaceId}/environments": {
-        parameters: {
-            query?: never;
-            header?: never;
-            path: {
-                /** @description The ID of the workspace */
-                workspaceId: string;
-            };
-            cookie?: never;
-        };
-        /** List all environments */
-        get: operations["listEnvironments"];
-        put?: never;
-        post?: never;
-        delete?: never;
-        options?: never;
-        head?: never;
-        patch?: never;
-        trace?: never;
+    /** List all deployments */
+    get: operations["listDeployments"];
+    put?: never;
+    post?: never;
+    delete?: never;
+    options?: never;
+    head?: never;
+    patch?: never;
+    trace?: never;
+  };
+  "/v1/workspaces/{workspaceId}/environments": {
+    parameters: {
+      query?: never;
+      header?: never;
+      path: {
+        /** @description The ID of the workspace */
+        workspaceId: string;
+      };
+      cookie?: never;
     };
-    "/v1/workspaces/{workspaceId}/events/{action}": {
-        parameters: {
-            query?: never;
-            header?: never;
-            path: {
-                /** @description The ID of the workspace */
-                workspaceId: string;
-                action: string;
-            };
-            cookie?: never;
-        };
-        /** Get events by action */
-        get: operations["getEventsByAction"];
-        put?: never;
-        post?: never;
-        delete?: never;
-        options?: never;
-        head?: never;
-        patch?: never;
-        trace?: never;
+    /** List all environments */
+    get: operations["listEnvironments"];
+    put?: never;
+    post?: never;
+    delete?: never;
+    options?: never;
+    head?: never;
+    patch?: never;
+    trace?: never;
+  };
+  "/v1/workspaces/{workspaceId}/events/{action}": {
+    parameters: {
+      query?: never;
+      header?: never;
+      path: {
+        /** @description The ID of the workspace */
+        workspaceId: string;
+        action: string;
+      };
+      cookie?: never;
     };
-    "/v1/workspaces/{workspaceId}": {
-        parameters: {
-            query?: never;
-            header?: never;
-            path?: never;
-            cookie?: never;
-        };
-        /** Get a workspace */
-        get: operations["getWorkspace"];
-        put?: never;
-        post?: never;
-        delete?: never;
-        options?: never;
-        head?: never;
-        patch?: never;
-        trace?: never;
+    /** Get events by action */
+    get: operations["getEventsByAction"];
+    put?: never;
+    post?: never;
+    delete?: never;
+    options?: never;
+    head?: never;
+    patch?: never;
+    trace?: never;
+  };
+  "/v1/workspaces/{workspaceId}": {
+    parameters: {
+      query?: never;
+      header?: never;
+      path?: never;
+      cookie?: never;
     };
-    "/v1/workspaces/{workspaceId}/policies/{name}": {
-        parameters: {
-            query?: never;
-            header?: never;
-            path?: never;
-            cookie?: never;
-        };
-        get?: never;
-        put?: never;
-        post?: never;
-        /** Delete a policy by name */
-        delete: operations["deletePolicyByName"];
-        options?: never;
-        head?: never;
-        patch?: never;
-        trace?: never;
+    /** Get a workspace */
+    get: operations["getWorkspace"];
+    put?: never;
+    post?: never;
+    delete?: never;
+    options?: never;
+    head?: never;
+    patch?: never;
+    trace?: never;
+  };
+  "/v1/workspaces/{workspaceId}/policies/{name}": {
+    parameters: {
+      query?: never;
+      header?: never;
+      path?: never;
+      cookie?: never;
     };
-    "/v1/workspaces/{workspaceId}/resource-providers/name/{name}": {
-        parameters: {
-            query?: never;
-            header?: never;
-            path?: never;
-            cookie?: never;
-        };
-        /** Upserts a resource provider. */
-        get: operations["upsertResourceProvider"];
-        put?: never;
-        post?: never;
-        delete?: never;
-        options?: never;
-        head?: never;
-        patch?: never;
-        trace?: never;
+    get?: never;
+    put?: never;
+    post?: never;
+    /** Delete a policy by name */
+    delete: operations["deletePolicyByName"];
+    options?: never;
+    head?: never;
+    patch?: never;
+    trace?: never;
+  };
+  "/v1/workspaces/{workspaceId}/resource-providers/name/{name}": {
+    parameters: {
+      query?: never;
+      header?: never;
+      path?: never;
+      cookie?: never;
     };
-    "/v1/workspaces/{workspaceId}/resources/identifier/{identifier}": {
-        parameters: {
-            query?: never;
-            header?: never;
-            path?: never;
-            cookie?: never;
-        };
-        /** Get a resource by identifier */
-        get: operations["getResourceByIdentifier"];
-        put?: never;
-        post?: never;
-        /** Delete a resource by identifier */
-        delete: operations["deleteResourceByIdentifier"];
-        options?: never;
-        head?: never;
-        patch?: never;
-        trace?: never;
+    /** Upserts a resource provider. */
+    get: operations["upsertResourceProvider"];
+    put?: never;
+    post?: never;
+    delete?: never;
+    options?: never;
+    head?: never;
+    patch?: never;
+    trace?: never;
+  };
+  "/v1/workspaces/{workspaceId}/resources/identifier/{identifier}": {
+    parameters: {
+      query?: never;
+      header?: never;
+      path?: never;
+      cookie?: never;
     };
-    "/v1/workspaces/{workspaceId}/resources/metadata-grouped-counts": {
-        parameters: {
-            query?: never;
-            header?: never;
-            path?: never;
-            cookie?: never;
-        };
-        get?: never;
-        put?: never;
-        /** Get grouped counts of resources */
-        post: operations["getGroupedCounts"];
-        delete?: never;
-        options?: never;
-        head?: never;
-        patch?: never;
-        trace?: never;
+    /** Get a resource by identifier */
+    get: operations["getResourceByIdentifier"];
+    put?: never;
+    post?: never;
+    /** Delete a resource by identifier */
+    delete: operations["deleteResourceByIdentifier"];
+    options?: never;
+    head?: never;
+    patch?: never;
+    trace?: never;
+  };
+  "/v1/workspaces/{workspaceId}/resources/metadata-grouped-counts": {
+    parameters: {
+      query?: never;
+      header?: never;
+      path?: never;
+      cookie?: never;
     };
-    "/v1/workspaces/{workspaceId}/resources": {
-        parameters: {
-            query?: never;
-            header?: never;
-            path: {
-                /** @description The ID of the workspace */
-                workspaceId: string;
-            };
-            cookie?: never;
-        };
-        /** List all resources */
-        get: operations["listResources"];
-        put?: never;
-        post?: never;
-        delete?: never;
-        options?: never;
-        head?: never;
-        patch?: never;
-        trace?: never;
+    get?: never;
+    put?: never;
+    /** Get grouped counts of resources */
+    post: operations["getGroupedCounts"];
+    delete?: never;
+    options?: never;
+    head?: never;
+    patch?: never;
+    trace?: never;
+  };
+  "/v1/workspaces/{workspaceId}/resources": {
+    parameters: {
+      query?: never;
+      header?: never;
+      path: {
+        /** @description The ID of the workspace */
+        workspaceId: string;
+      };
+      cookie?: never;
     };
-    "/v1/workspaces/{workspaceId}/systems": {
-        parameters: {
-            query?: never;
-            header?: never;
-            path: {
-                /** @description The ID of the workspace */
-                workspaceId: string;
-            };
-            cookie?: never;
-        };
-        /** List all systems */
-        get: operations["listSystems"];
-        put?: never;
-        post?: never;
-        delete?: never;
-        options?: never;
-        head?: never;
-        patch?: never;
-        trace?: never;
+    /** List all resources */
+    get: operations["listResources"];
+    put?: never;
+    post?: never;
+    delete?: never;
+    options?: never;
+    head?: never;
+    patch?: never;
+    trace?: never;
+  };
+  "/v1/workspaces/{workspaceId}/systems": {
+    parameters: {
+      query?: never;
+      header?: never;
+      path: {
+        /** @description The ID of the workspace */
+        workspaceId: string;
+      };
+      cookie?: never;
     };
-    "/v1/workspaces/slug/{workspaceSlug}": {
-        parameters: {
-            query?: never;
-            header?: never;
-            path?: never;
-            cookie?: never;
-        };
-        /** Get a workspace by slug */
-        get: operations["getWorkspaceBySlug"];
-        put?: never;
-        post?: never;
-        delete?: never;
-        options?: never;
-        head?: never;
-        patch?: never;
-        trace?: never;
+    /** List all systems */
+    get: operations["listSystems"];
+    put?: never;
+    post?: never;
+    delete?: never;
+    options?: never;
+    head?: never;
+    patch?: never;
+    trace?: never;
+  };
+  "/v1/workspaces/slug/{workspaceSlug}": {
+    parameters: {
+      query?: never;
+      header?: never;
+      path?: never;
+      cookie?: never;
     };
+    /** Get a workspace by slug */
+    get: operations["getWorkspaceBySlug"];
+    put?: never;
+    post?: never;
+    delete?: never;
+    options?: never;
+    head?: never;
+    patch?: never;
+    trace?: never;
+  };
 }
 export type webhooks = Record<string, never>;
 export interface components {
-    schemas: {
-        CloudRegionGeoData: {
-            /**
-             * @description Timezone of the region in UTC format
-             * @example UTC+1
-             */
-            timezone: string;
-            /**
-             * Format: float
-             * @description Latitude coordinate for the region
-             * @example 50.1109
-             */
-            latitude: number;
-            /**
-             * Format: float
-             * @description Longitude coordinate for the region
-             * @example 8.6821
-             */
-            longitude: number;
-        };
-        BaseVariableValue: {
-            resourceSelector?: {
-                [key: string]: unknown;
-            } | null;
-            default?: boolean;
-        };
-        DeploymentVariableDirectValue: components["schemas"]["BaseVariableValue"] & {
-            /** @enum {string} */
-            valueType: "direct";
-            value: string | number | boolean | Record<string, never> | unknown[];
-            sensitive?: boolean;
-        };
-        DeploymentVariableReferenceValue: components["schemas"]["BaseVariableValue"] & {
-            /** @enum {string} */
-            valueType: "reference";
-            reference: string;
-            path: string[];
-            defaultValue?: string | number | boolean | Record<string, never> | unknown[];
-        };
-        VariableValue: components["schemas"]["DeploymentVariableDirectValue"] | components["schemas"]["DeploymentVariableReferenceValue"];
-        DeploymentVariableValue: components["schemas"]["VariableValue"] & {
-            /** Format: uuid */
-            id: string;
-        };
-        DeploymentVariable: {
-            /** Format: uuid */
-            id: string;
-            key: string;
-            description: string;
-            values: components["schemas"]["DeploymentVariableValue"][];
-            defaultValue?: components["schemas"]["DeploymentVariableValue"];
-            config: {
-                [key: string]: unknown;
-            };
-        };
-        JobWithTrigger: components["schemas"]["Job"] & {
-            release?: components["schemas"]["Release"];
-            version?: components["schemas"]["DeploymentVersion"];
-            deployment?: components["schemas"]["Deployment"];
-            runbook?: components["schemas"]["Runbook"];
-            resource?: components["schemas"]["ResourceWithVariablesAndMetadata"] & {
-                relationships?: {
-                    [key: string]: components["schemas"]["Resource"];
-                };
-            };
-            environment?: components["schemas"]["Environment"];
-            variables: components["schemas"]["VariableMap"];
-            approval?: {
-                id: string;
-                /** @enum {string} */
-                status: "pending" | "approved" | "rejected";
-                /** @description Null when status is pending, contains approver details when approved or rejected */
-                approver?: {
-                    id: string;
-                    name: string;
-                } | null;
-            } | null;
-        };
-        Workspace: {
-            /**
-             * Format: uuid
-             * @description The workspace ID
-             */
-            id: string;
-            /** @description The name of the workspace */
-            name: string;
-            /** @description The slug of the workspace */
-            slug: string;
-            /**
-             * @description The email of the Google service account attached to the workspace
-             * @example ctrlplane@ctrlplane-workspace.iam.gserviceaccount.com
-             */
-            googleServiceAccountEmail?: string | null;
-            /**
-             * @description The ARN of the AWS role attached to the workspace
-             * @example arn:aws:iam::123456789012:role/ctrlplane-workspace-role
-             */
-            awsRoleArn?: string | null;
-        };
-        System: {
-            /**
-             * Format: uuid
-             * @description The system ID
-             */
-            id: string;
-            /**
-             * Format: uuid
-             * @description The workspace ID of the system
-             */
-            workspaceId: string;
-            /** @description The name of the system */
-            name: string;
-            /** @description The slug of the system */
-            slug: string;
-            /** @description The description of the system */
-            description?: string;
-        };
-        Deployment: {
-            /** Format: uuid */
-            id: string;
-            name: string;
-            slug: string;
-            description: string;
-            /** Format: uuid */
-            systemId: string;
-            /** Format: uuid */
-            jobAgentId?: string | null;
-            jobAgentConfig: {
-                [key: string]: unknown;
-            };
-            retryCount?: number;
-            timeout?: number | null;
-        };
-        /** @description Schema for updating a deployment (all fields optional) */
-        UpdateDeployment: {
-            [key: string]: unknown;
-        } & (WithRequired<components["schemas"]["Deployment"], "id"> & {
-            [key: string]: unknown;
-        });
-        Release: {
-            /** Format: uuid */
-            id: string;
-            name: string;
-            version: string;
-            config: {
-                [key: string]: unknown;
-            };
-            jobAgentConfig: {
-                [key: string]: unknown;
-            };
-            /** Format: uuid */
-            deploymentId: string;
-            /** Format: date-time */
-            createdAt: string;
-            metadata?: {
-                [key: string]: unknown;
-            };
-        };
-        DeploymentVersion: {
-            /** Format: uuid */
-            id: string;
-            name: string;
-            tag: string;
-            config: {
-                [key: string]: unknown;
-            };
-            jobAgentConfig: {
-                [key: string]: unknown;
-            };
-            /** Format: uuid */
-            deploymentId: string;
-            /** Format: date-time */
-            createdAt: string;
-            metadata?: {
-                [key: string]: string;
-            };
-            /** @enum {string} */
-            status?: "building" | "ready" | "failed";
-        };
-        Policy: {
-            /**
-             * Format: uuid
-             * @description The policy ID
-             */
-            id: string;
-            /**
-             * Format: uuid
-             * @description The system ID
-             */
-            systemId: string;
-            /** @description The name of the policy */
-            name: string;
-            /** @description The description of the policy */
-            description?: string | null;
-            /**
-             * @description The approval requirement of the policy
-             * @enum {string}
-             */
-            approvalRequirement: "manual" | "automatic";
-            /**
-             * @description If a policy depends on an environment, whether or not the policy requires all, some, or optional successful releases in the environment
-             * @enum {string}
-             */
-            successType: "some" | "all" | "optional";
-            /** @description If a policy depends on an environment, the minimum number of successful releases in the environment */
-            successMinimum: number;
-            /** @description The maximum number of concurrent releases in the environment */
-            concurrencyLimit?: number | null;
-            /** @description The duration of the rollout in milliseconds */
-            rolloutDuration: number;
-            /** @description The minimum interval between releases in milliseconds */
-            minimumReleaseInterval: number;
-            /**
-             * @description If a new release is created, whether it will wait for the current release to finish before starting, or cancel the current release
-             * @enum {string}
-             */
-            releaseSequencing: "wait" | "cancel";
-        };
-        Environment: {
-            /** Format: uuid */
-            id: string;
-            /** Format: uuid */
-            systemId: string;
-            name: string;
-            description?: string;
-            /** Format: uuid */
-            policyId?: string | null;
-            resourceSelector?: {
-                [key: string]: unknown;
-            } | null;
-            /**
-             * @description The directory path of the environment
-             * @default
-             * @example my/env/path
-             */
-            directory: string;
-            /** Format: date-time */
-            createdAt: string;
-            metadata?: {
-                [key: string]: string;
-            };
-            policy?: components["schemas"]["Policy"];
-        };
-        Runbook: {
-            /** Format: uuid */
-            id: string;
-            name: string;
-            /** Format: uuid */
-            systemId: string;
-            /** Format: uuid */
-            jobAgentId: string;
-        };
-        Resource: {
-            /** Format: uuid */
-            id: string;
-            name: string;
-            version: string;
-            kind: string;
-            identifier: string;
-            config: {
-                [key: string]: unknown;
-            };
-            metadata: {
-                [key: string]: unknown;
-            };
-            /** Format: date-time */
-            createdAt: string;
-            /** Format: date-time */
-            updatedAt: string;
-            /** Format: uuid */
-            workspaceId: string;
-            /** Format: uuid */
-            providerId?: string;
-        };
-        ResourceWithVariables: components["schemas"]["Resource"] & {
-            variables?: components["schemas"]["VariableMap"];
-        };
-        ResourceWithMetadata: components["schemas"]["Resource"] & {
-            metadata?: components["schemas"]["MetadataMap"];
-        };
-        ResourceWithVariablesAndMetadata: components["schemas"]["ResourceWithVariables"] & components["schemas"]["ResourceWithMetadata"];
-        CreateResource: {
-            identifier: string;
-            name: string;
-            version: string;
-            kind: string;
-            config: {
-                [key: string]: unknown;
-            };
-            metadata: {
-                [key: string]: string;
-            };
-            variables?: components["schemas"]["Variable"][];
-        };
-        /** @enum {string} */
-        JobStatus: "successful" | "cancelled" | "skipped" | "in_progress" | "action_required" | "pending" | "failure" | "invalid_job_agent" | "invalid_integration" | "external_run_not_found";
-        Job: {
-            /** Format: uuid */
-            id: string;
-            status: components["schemas"]["JobStatus"];
-            /** @description External job identifier (e.g. GitHub workflow run ID) */
-            externalId?: string | null;
-            /** Format: date-time */
-            createdAt: string;
-            /** Format: date-time */
-            updatedAt: string;
-            /** Format: date-time */
-            startedAt?: string | null;
-            /** Format: date-time */
-            completedAt?: string | null;
-            /** Format: uuid */
-            jobAgentId?: string;
-            /** @description Configuration for the Job Agent */
-            jobAgentConfig: {
-                [key: string]: unknown;
-            };
-            message?: string;
-            reason?: string;
-        };
-        MetadataMap: {
-            [key: string]: string;
-        };
-        VariableMap: {
-            [key: string]: (string | boolean | number | Record<string, never> | unknown[]) | null;
-        };
-        ReferenceVariable: {
-            key: string;
-            reference: string;
-            path: string[];
-            defaultValue?: string | number | boolean | Record<string, never> | unknown[];
-        };
-        DirectVariable: {
-            key: string;
-            value: string | number | boolean | Record<string, never> | unknown[];
-            sensitive?: boolean;
-        };
-        Variable: components["schemas"]["DirectVariable"] | components["schemas"]["ReferenceVariable"];
-        PolicyTarget: {
-            deploymentSelector?: {
-                [key: string]: unknown;
-            } | null;
-            environmentSelector?: {
-                [key: string]: unknown;
-            } | null;
-            resourceSelector?: {
-                [key: string]: unknown;
-            } | null;
-        };
-        DenyWindow: {
-            timeZone: string;
-            rrule: {
-                [key: string]: unknown;
-            };
-            /** Format: date-time */
-            dtend?: string;
-        };
-        DeploymentVersionSelector: {
-            name: string;
-            deploymentVersionSelector: {
-                [key: string]: unknown;
-            };
-            description?: string;
-        };
-        VersionAnyApproval: {
-            requiredApprovalsCount: number;
-        };
-        VersionUserApproval: {
-            userId: string;
-        };
-        VersionRoleApproval: {
-            roleId: string;
-            requiredApprovalsCount: number;
-        };
-        Policy1: {
-            /** Format: uuid */
-            id: string;
-            name: string;
-            description?: string;
-            priority: number;
-            /** Format: date-time */
-            createdAt: string;
-            enabled: boolean;
-            /** Format: uuid */
-            workspaceId: string;
-            targets: components["schemas"]["PolicyTarget"][];
-            denyWindows: components["schemas"]["DenyWindow"][];
-            deploymentVersionSelector?: components["schemas"]["DeploymentVersionSelector"];
-            versionAnyApprovals?: components["schemas"]["VersionAnyApproval"];
-            versionUserApprovals: components["schemas"]["VersionUserApproval"][];
-            versionRoleApprovals: components["schemas"]["VersionRoleApproval"][];
-        };
-        UpdateResourceRelationshipRule: {
-            name?: string;
-            reference?: string;
-            dependencyType?: components["schemas"]["ResourceRelationshipRuleDependencyType"];
-            dependencyDescription?: string;
-            description?: string;
-            sourceKind?: string;
-            sourceVersion?: string;
-            targetKind?: string;
-            targetVersion?: string;
-            metadataKeysMatch?: string[];
-            targetMetadataEquals?: {
-                key: string;
-                value: string;
-            }[];
-        };
-        /** @enum {string} */
-        ResourceRelationshipRuleDependencyType: "depends_on" | "depends_indirectly_on" | "uses_at_runtime" | "created_after" | "provisioned_in" | "inherits_from";
-        ResourceRelationshipRule: {
-            /** Format: uuid */
-            id: string;
-            /** Format: uuid */
-            workspaceId: string;
-            name: string;
-            reference: string;
-            dependencyType: components["schemas"]["ResourceRelationshipRuleDependencyType"];
-            dependencyDescription?: string;
-            description?: string;
-            sourceKind: string;
-            sourceVersion: string;
-            targetKind?: string;
-            targetVersion?: string;
-            targetMetadataEquals?: {
-                key: string;
-                value: string;
-            }[];
-            metadataKeysMatches?: string[];
-        };
-        CreateResourceRelationshipRule: {
-            workspaceId: string;
-            name: string;
-            reference: string;
-            dependencyType: components["schemas"]["ResourceRelationshipRuleDependencyType"];
-            dependencyDescription?: string;
-            description?: string;
-            sourceKind: string;
-            sourceVersion: string;
-            targetKind: string;
-            targetVersion: string;
-            metadataKeysMatches?: string[];
-            targetMetadataEquals?: {
-                key: string;
-                value: string;
-            }[];
-        };
-        ReleaseTarget: {
-            /** Format: uuid */
-            id: string;
-            resource: components["schemas"]["Resource"];
-            environment: components["schemas"]["Environment"];
-            deployment: components["schemas"]["Deployment"];
-        };
-        Event: {
-            /** Format: uuid */
-            id: string;
-            action: string;
-            payload: {
-                [key: string]: unknown;
-            };
-            /** Format: date-time */
-            createdAt: string;
-        };
+  schemas: {
+    CloudRegionGeoData: {
+      /**
+       * @description Timezone of the region in UTC format
+       * @example UTC+1
+       */
+      timezone: string;
+      /**
+       * Format: float
+       * @description Latitude coordinate for the region
+       * @example 50.1109
+       */
+      latitude: number;
+      /**
+       * Format: float
+       * @description Longitude coordinate for the region
+       * @example 8.6821
+       */
+      longitude: number;
     };
-    responses: never;
-    parameters: never;
-    requestBodies: never;
-    headers: never;
-    pathItems: never;
+    BaseVariableValue: {
+      resourceSelector?: {
+        [key: string]: unknown;
+      } | null;
+      default?: boolean;
+    };
+    DeploymentVariableDirectValue: components["schemas"]["BaseVariableValue"] & {
+      /** @enum {string} */
+      valueType: "direct";
+      value: string | number | boolean | Record<string, never> | unknown[];
+      sensitive?: boolean;
+    };
+    DeploymentVariableReferenceValue: components["schemas"]["BaseVariableValue"] & {
+      /** @enum {string} */
+      valueType: "reference";
+      reference: string;
+      path: string[];
+      defaultValue?:
+        | string
+        | number
+        | boolean
+        | Record<string, never>
+        | unknown[];
+    };
+    VariableValue:
+      | components["schemas"]["DeploymentVariableDirectValue"]
+      | components["schemas"]["DeploymentVariableReferenceValue"];
+    DeploymentVariableValue: components["schemas"]["VariableValue"] & {
+      /** Format: uuid */
+      id: string;
+    };
+    DeploymentVariable: {
+      /** Format: uuid */
+      id: string;
+      key: string;
+      description: string;
+      values: components["schemas"]["DeploymentVariableValue"][];
+      defaultValue?: components["schemas"]["DeploymentVariableValue"];
+      config: {
+        [key: string]: unknown;
+      };
+    };
+    JobWithTrigger: components["schemas"]["Job"] & {
+      release?: components["schemas"]["Release"];
+      version?: components["schemas"]["DeploymentVersion"];
+      deployment?: components["schemas"]["Deployment"];
+      runbook?: components["schemas"]["Runbook"];
+      resource?: components["schemas"]["ResourceWithVariablesAndMetadata"] & {
+        relationships?: {
+          [key: string]: components["schemas"]["Resource"];
+        };
+      };
+      environment?: components["schemas"]["Environment"];
+      variables: components["schemas"]["VariableMap"];
+      approval?: {
+        id: string;
+        /** @enum {string} */
+        status: "pending" | "approved" | "rejected";
+        /** @description Null when status is pending, contains approver details when approved or rejected */
+        approver?: {
+          id: string;
+          name: string;
+        } | null;
+      } | null;
+    };
+    Workspace: {
+      /**
+       * Format: uuid
+       * @description The workspace ID
+       */
+      id: string;
+      /** @description The name of the workspace */
+      name: string;
+      /** @description The slug of the workspace */
+      slug: string;
+      /**
+       * @description The email of the Google service account attached to the workspace
+       * @example ctrlplane@ctrlplane-workspace.iam.gserviceaccount.com
+       */
+      googleServiceAccountEmail?: string | null;
+      /**
+       * @description The ARN of the AWS role attached to the workspace
+       * @example arn:aws:iam::123456789012:role/ctrlplane-workspace-role
+       */
+      awsRoleArn?: string | null;
+    };
+    System: {
+      /**
+       * Format: uuid
+       * @description The system ID
+       */
+      id: string;
+      /**
+       * Format: uuid
+       * @description The workspace ID of the system
+       */
+      workspaceId: string;
+      /** @description The name of the system */
+      name: string;
+      /** @description The slug of the system */
+      slug: string;
+      /** @description The description of the system */
+      description?: string;
+    };
+    Deployment: {
+      /** Format: uuid */
+      id: string;
+      name: string;
+      slug: string;
+      description: string;
+      /** Format: uuid */
+      systemId: string;
+      /** Format: uuid */
+      jobAgentId?: string | null;
+      jobAgentConfig: {
+        [key: string]: unknown;
+      };
+      retryCount?: number;
+      timeout?: number | null;
+    };
+    /** @description Schema for updating a deployment (all fields optional) */
+    UpdateDeployment: {
+      [key: string]: unknown;
+    } & (WithRequired<components["schemas"]["Deployment"], "id"> & {
+      [key: string]: unknown;
+    });
+    Release: {
+      /** Format: uuid */
+      id: string;
+      name: string;
+      version: string;
+      config: {
+        [key: string]: unknown;
+      };
+      jobAgentConfig: {
+        [key: string]: unknown;
+      };
+      /** Format: uuid */
+      deploymentId: string;
+      /** Format: date-time */
+      createdAt: string;
+      metadata?: {
+        [key: string]: unknown;
+      };
+    };
+    DeploymentVersion: {
+      /** Format: uuid */
+      id: string;
+      name: string;
+      tag: string;
+      config: {
+        [key: string]: unknown;
+      };
+      jobAgentConfig: {
+        [key: string]: unknown;
+      };
+      /** Format: uuid */
+      deploymentId: string;
+      /** Format: date-time */
+      createdAt: string;
+      metadata?: {
+        [key: string]: string;
+      };
+      /** @enum {string} */
+      status?: "building" | "ready" | "failed";
+    };
+    Policy: {
+      /**
+       * Format: uuid
+       * @description The policy ID
+       */
+      id: string;
+      /**
+       * Format: uuid
+       * @description The system ID
+       */
+      systemId: string;
+      /** @description The name of the policy */
+      name: string;
+      /** @description The description of the policy */
+      description?: string | null;
+      /**
+       * @description The approval requirement of the policy
+       * @enum {string}
+       */
+      approvalRequirement: "manual" | "automatic";
+      /**
+       * @description If a policy depends on an environment, whether or not the policy requires all, some, or optional successful releases in the environment
+       * @enum {string}
+       */
+      successType: "some" | "all" | "optional";
+      /** @description If a policy depends on an environment, the minimum number of successful releases in the environment */
+      successMinimum: number;
+      /** @description The maximum number of concurrent releases in the environment */
+      concurrencyLimit?: number | null;
+      /** @description The duration of the rollout in milliseconds */
+      rolloutDuration: number;
+      /** @description The minimum interval between releases in milliseconds */
+      minimumReleaseInterval: number;
+      /**
+       * @description If a new release is created, whether it will wait for the current release to finish before starting, or cancel the current release
+       * @enum {string}
+       */
+      releaseSequencing: "wait" | "cancel";
+    };
+    Environment: {
+      /** Format: uuid */
+      id: string;
+      /** Format: uuid */
+      systemId: string;
+      name: string;
+      description?: string;
+      /** Format: uuid */
+      policyId?: string | null;
+      resourceSelector?: {
+        [key: string]: unknown;
+      } | null;
+      /**
+       * @description The directory path of the environment
+       * @default
+       * @example my/env/path
+       */
+      directory: string;
+      /** Format: date-time */
+      createdAt: string;
+      metadata?: {
+        [key: string]: string;
+      };
+      policy?: components["schemas"]["Policy"];
+    };
+    Runbook: {
+      /** Format: uuid */
+      id: string;
+      name: string;
+      /** Format: uuid */
+      systemId: string;
+      /** Format: uuid */
+      jobAgentId: string;
+    };
+    Resource: {
+      /** Format: uuid */
+      id: string;
+      name: string;
+      version: string;
+      kind: string;
+      identifier: string;
+      config: {
+        [key: string]: unknown;
+      };
+      metadata: {
+        [key: string]: unknown;
+      };
+      /** Format: date-time */
+      createdAt: string;
+      /** Format: date-time */
+      updatedAt: string;
+      /** Format: uuid */
+      workspaceId: string;
+      /** Format: uuid */
+      providerId?: string;
+    };
+    ResourceWithVariables: components["schemas"]["Resource"] & {
+      variables?: components["schemas"]["VariableMap"];
+    };
+    ResourceWithMetadata: components["schemas"]["Resource"] & {
+      metadata?: components["schemas"]["MetadataMap"];
+    };
+    ResourceWithVariablesAndMetadata: components["schemas"]["ResourceWithVariables"] &
+      components["schemas"]["ResourceWithMetadata"];
+    CreateResource: {
+      identifier: string;
+      name: string;
+      version: string;
+      kind: string;
+      config: {
+        [key: string]: unknown;
+      };
+      metadata: {
+        [key: string]: string;
+      };
+      variables?: components["schemas"]["Variable"][];
+    };
+    /** @enum {string} */
+    JobStatus:
+      | "successful"
+      | "cancelled"
+      | "skipped"
+      | "in_progress"
+      | "action_required"
+      | "pending"
+      | "failure"
+      | "invalid_job_agent"
+      | "invalid_integration"
+      | "external_run_not_found";
+    Job: {
+      /** Format: uuid */
+      id: string;
+      status: components["schemas"]["JobStatus"];
+      /** @description External job identifier (e.g. GitHub workflow run ID) */
+      externalId?: string | null;
+      /** Format: date-time */
+      createdAt: string;
+      /** Format: date-time */
+      updatedAt: string;
+      /** Format: date-time */
+      startedAt?: string | null;
+      /** Format: date-time */
+      completedAt?: string | null;
+      /** Format: uuid */
+      jobAgentId?: string;
+      /** @description Configuration for the Job Agent */
+      jobAgentConfig: {
+        [key: string]: unknown;
+      };
+      message?: string;
+      reason?: string;
+    };
+    MetadataMap: {
+      [key: string]: string;
+    };
+    VariableMap: {
+      [key: string]:
+        | (string | boolean | number | Record<string, never> | unknown[])
+        | null;
+    };
+    ReferenceVariable: {
+      key: string;
+      reference: string;
+      path: string[];
+      defaultValue?:
+        | string
+        | number
+        | boolean
+        | Record<string, never>
+        | unknown[];
+    };
+    DirectVariable: {
+      key: string;
+      value: string | number | boolean | Record<string, never> | unknown[];
+      sensitive?: boolean;
+    };
+    Variable:
+      | components["schemas"]["DirectVariable"]
+      | components["schemas"]["ReferenceVariable"];
+    PolicyTarget: {
+      deploymentSelector?: {
+        [key: string]: unknown;
+      } | null;
+      environmentSelector?: {
+        [key: string]: unknown;
+      } | null;
+      resourceSelector?: {
+        [key: string]: unknown;
+      } | null;
+    };
+    DenyWindow: {
+      timeZone: string;
+      rrule: {
+        [key: string]: unknown;
+      };
+      /** Format: date-time */
+      dtend?: string;
+    };
+    DeploymentVersionSelector: {
+      name: string;
+      deploymentVersionSelector: {
+        [key: string]: unknown;
+      };
+      description?: string;
+    };
+    VersionAnyApproval: {
+      requiredApprovalsCount: number;
+    };
+    VersionUserApproval: {
+      userId: string;
+    };
+    VersionRoleApproval: {
+      roleId: string;
+      requiredApprovalsCount: number;
+    };
+    Policy1: {
+      /** Format: uuid */
+      id: string;
+      name: string;
+      description?: string;
+      priority: number;
+      /** Format: date-time */
+      createdAt: string;
+      enabled: boolean;
+      /** Format: uuid */
+      workspaceId: string;
+      targets: components["schemas"]["PolicyTarget"][];
+      denyWindows: components["schemas"]["DenyWindow"][];
+      deploymentVersionSelector?: components["schemas"]["DeploymentVersionSelector"];
+      versionAnyApprovals?: components["schemas"]["VersionAnyApproval"];
+      versionUserApprovals: components["schemas"]["VersionUserApproval"][];
+      versionRoleApprovals: components["schemas"]["VersionRoleApproval"][];
+    };
+    UpdateResourceRelationshipRule: {
+      name?: string;
+      reference?: string;
+      dependencyType?: components["schemas"]["ResourceRelationshipRuleDependencyType"];
+      dependencyDescription?: string;
+      description?: string;
+      sourceKind?: string;
+      sourceVersion?: string;
+      targetKind?: string;
+      targetVersion?: string;
+      metadataKeysMatch?: string[];
+      targetMetadataEquals?: {
+        key: string;
+        value: string;
+      }[];
+    };
+    /** @enum {string} */
+    ResourceRelationshipRuleDependencyType:
+      | "depends_on"
+      | "depends_indirectly_on"
+      | "uses_at_runtime"
+      | "created_after"
+      | "provisioned_in"
+      | "inherits_from";
+    ResourceRelationshipRule: {
+      /** Format: uuid */
+      id: string;
+      /** Format: uuid */
+      workspaceId: string;
+      name: string;
+      reference: string;
+      dependencyType: components["schemas"]["ResourceRelationshipRuleDependencyType"];
+      dependencyDescription?: string;
+      description?: string;
+      sourceKind: string;
+      sourceVersion: string;
+      targetKind?: string;
+      targetVersion?: string;
+      targetMetadataEquals?: {
+        key: string;
+        value: string;
+      }[];
+      metadataKeysMatches?: string[];
+    };
+    CreateResourceRelationshipRule: {
+      workspaceId: string;
+      name: string;
+      reference: string;
+      dependencyType: components["schemas"]["ResourceRelationshipRuleDependencyType"];
+      dependencyDescription?: string;
+      description?: string;
+      sourceKind: string;
+      sourceVersion: string;
+      targetKind: string;
+      targetVersion: string;
+      metadataKeysMatches?: string[];
+      targetMetadataEquals?: {
+        key: string;
+        value: string;
+      }[];
+    };
+    ReleaseTarget: {
+      /** Format: uuid */
+      id: string;
+      resource: components["schemas"]["Resource"];
+      environment: components["schemas"]["Environment"];
+      deployment: components["schemas"]["Deployment"];
+    };
+    Event: {
+      /** Format: uuid */
+      id: string;
+      action: string;
+      payload: {
+        [key: string]: unknown;
+      };
+      /** Format: date-time */
+      createdAt: string;
+    };
+  };
+  responses: never;
+  parameters: never;
+  requestBodies: never;
+  headers: never;
+  pathItems: never;
 }
 export type $defs = Record<string, never>;
 export interface operations {
-    getCloudProviderRegions: {
-        parameters: {
-            query?: never;
-            header?: never;
-            path: {
-                /** @description Cloud provider (aws, gcp, azure) */
-                provider: "aws" | "gcp" | "azure";
-            };
-            cookie?: never;
-        };
-        requestBody?: never;
-        responses: {
-            /** @description Successfully returned geographic data for cloud provider regions */
-            200: {
-                headers: {
-                    [name: string]: unknown;
-                };
-                content: {
-                    "application/json": {
-                        [key: string]: components["schemas"]["CloudRegionGeoData"];
-                    };
-                };
-            };
-            /** @description Cloud provider not found */
-            404: {
-                headers: {
-                    [name: string]: unknown;
-                };
-                content: {
-                    "application/json": {
-                        /** @example Cloud provider 'unknown' not found */
-                        error?: string;
-                    };
-                };
-            };
-        };
+  getCloudProviderRegions: {
+    parameters: {
+      query?: never;
+      header?: never;
+      path: {
+        /** @description Cloud provider (aws, gcp, azure) */
+        provider: "aws" | "gcp" | "azure";
+      };
+      cookie?: never;
     };
-    createDeploymentVersionChannel: {
-        parameters: {
-            query?: never;
-            header?: never;
-            path?: never;
-            cookie?: never;
+    requestBody?: never;
+    responses: {
+      /** @description Successfully returned geographic data for cloud provider regions */
+      200: {
+        headers: {
+          [name: string]: unknown;
         };
-        requestBody: {
-            content: {
-                "application/json": {
-                    deploymentId: string;
-                    name: string;
-                    description?: string | null;
-                    versionSelector: {
-                        [key: string]: unknown;
-                    };
-                };
-            };
+        content: {
+          "application/json": {
+            [key: string]: components["schemas"]["CloudRegionGeoData"];
+          };
         };
-        responses: {
-            /** @description Deployment version channel created successfully */
-            200: {
-                headers: {
-                    [name: string]: unknown;
-                };
-                content: {
-                    "application/json": {
-                        id: string;
-                        deploymentId: string;
-                        name: string;
-                        description?: string | null;
-                        /** Format: date-time */
-                        createdAt: string;
-                        versionSelector?: {
-                            [key: string]: unknown;
-                        };
-                    };
-                };
-            };
-            /** @description Unauthorized */
-            401: {
-                headers: {
-                    [name: string]: unknown;
-                };
-                content: {
-                    "application/json": {
-                        error: string;
-                    };
-                };
-            };
-            /** @description Forbidden */
-            403: {
-                headers: {
-                    [name: string]: unknown;
-                };
-                content: {
-                    "application/json": {
-                        error: string;
-                    };
-                };
-            };
-            /** @description Deployment version channel already exists */
-            409: {
-                headers: {
-                    [name: string]: unknown;
-                };
-                content: {
-                    "application/json": {
-                        error: string;
-                        id: string;
-                    };
-                };
-            };
-            /** @description Failed to create deployment version channel */
-            500: {
-                headers: {
-                    [name: string]: unknown;
-                };
-                content: {
-                    "application/json": {
-                        error: string;
-                    };
-                };
-            };
+      };
+      /** @description Cloud provider not found */
+      404: {
+        headers: {
+          [name: string]: unknown;
         };
+        content: {
+          "application/json": {
+            /** @example Cloud provider 'unknown' not found */
+            error?: string;
+          };
+        };
+      };
     };
-    updateDeploymentVersion: {
-        parameters: {
-            query?: never;
-            header?: never;
-            path: {
-                /** @description The deployment version ID */
-                deploymentVersionId: string;
-            };
-            cookie?: never;
-        };
-        requestBody: {
-            content: {
-                "application/json": {
-                    tag?: string;
-                    deploymentId?: string;
-                    /** Format: date-time */
-                    createdAt?: string;
-                    name?: string;
-                    config?: {
-                        [key: string]: unknown;
-                    };
-                    jobAgentConfig?: {
-                        [key: string]: unknown;
-                    };
-                    /** @enum {string} */
-                    status?: "ready" | "building" | "failed";
-                    message?: string;
-                    metadata?: {
-                        [key: string]: string;
-                    };
-                };
-            };
-        };
-        responses: {
-            /** @description OK */
-            200: {
-                headers: {
-                    [name: string]: unknown;
-                };
-                content: {
-                    "application/json": components["schemas"]["DeploymentVersion"];
-                };
-            };
-            /** @description Deployment version not found */
-            404: {
-                headers: {
-                    [name: string]: unknown;
-                };
-                content: {
-                    "application/json": {
-                        error?: string;
-                    };
-                };
-            };
-            /** @description Internal server error */
-            500: {
-                headers: {
-                    [name: string]: unknown;
-                };
-                content: {
-                    "application/json": {
-                        error?: string;
-                    };
-                };
-            };
-        };
+  };
+  createDeploymentVersionChannel: {
+    parameters: {
+      query?: never;
+      header?: never;
+      path?: never;
+      cookie?: never;
     };
-    upsertDeploymentVersion: {
-        parameters: {
-            query?: never;
-            header?: never;
-            path?: never;
-            cookie?: never;
+    requestBody: {
+      content: {
+        "application/json": {
+          deploymentId: string;
+          name: string;
+          description?: string | null;
+          versionSelector: {
+            [key: string]: unknown;
+          };
         };
-        requestBody: {
-            content: {
-                "application/json": {
-                    tag: string;
-                    deploymentId: string;
-                    /** Format: date-time */
-                    createdAt?: string;
-                    name?: string;
-                    config?: {
-                        [key: string]: unknown;
-                    };
-                    jobAgentConfig?: {
-                        [key: string]: unknown;
-                    };
-                    /** @enum {string} */
-                    status?: "ready" | "building" | "failed";
-                    message?: string;
-                    metadata?: {
-                        [key: string]: string;
-                    };
-                };
-            };
-        };
-        responses: {
-            /** @description OK */
-            201: {
-                headers: {
-                    [name: string]: unknown;
-                };
-                content: {
-                    "application/json": components["schemas"]["DeploymentVersion"];
-                };
-            };
-            /** @description Internal server error */
-            500: {
-                headers: {
-                    [name: string]: unknown;
-                };
-                content: {
-                    "application/json": {
-                        error?: string;
-                    };
-                };
-            };
-        };
+      };
     };
-    deleteDeploymentVersionChannel: {
-        parameters: {
-            query?: never;
-            header?: never;
-            path: {
-                deploymentId: string;
-                name: string;
-            };
-            cookie?: never;
+    responses: {
+      /** @description Deployment version channel created successfully */
+      200: {
+        headers: {
+          [name: string]: unknown;
         };
-        requestBody?: never;
-        responses: {
-            /** @description Deployment version channel deleted */
-            200: {
-                headers: {
-                    [name: string]: unknown;
-                };
-                content: {
-                    "application/json": {
-                        message: string;
-                    };
-                };
+        content: {
+          "application/json": {
+            id: string;
+            deploymentId: string;
+            name: string;
+            description?: string | null;
+            /** Format: date-time */
+            createdAt: string;
+            versionSelector?: {
+              [key: string]: unknown;
             };
-            /** @description Permission denied */
-            403: {
-                headers: {
-                    [name: string]: unknown;
-                };
-                content: {
-                    "application/json": {
-                        error: string;
-                    };
-                };
-            };
-            /** @description Deployment version channel not found */
-            404: {
-                headers: {
-                    [name: string]: unknown;
-                };
-                content: {
-                    "application/json": {
-                        error: string;
-                    };
-                };
-            };
-            /** @description Failed to delete deployment version channel */
-            500: {
-                headers: {
-                    [name: string]: unknown;
-                };
-                content: {
-                    "application/json": {
-                        error: string;
-                    };
-                };
-            };
+          };
         };
+      };
+      /** @description Unauthorized */
+      401: {
+        headers: {
+          [name: string]: unknown;
+        };
+        content: {
+          "application/json": {
+            error: string;
+          };
+        };
+      };
+      /** @description Forbidden */
+      403: {
+        headers: {
+          [name: string]: unknown;
+        };
+        content: {
+          "application/json": {
+            error: string;
+          };
+        };
+      };
+      /** @description Deployment version channel already exists */
+      409: {
+        headers: {
+          [name: string]: unknown;
+        };
+        content: {
+          "application/json": {
+            error: string;
+            id: string;
+          };
+        };
+      };
+      /** @description Failed to create deployment version channel */
+      500: {
+        headers: {
+          [name: string]: unknown;
+        };
+        content: {
+          "application/json": {
+            error: string;
+          };
+        };
+      };
     };
-    getDeployment: {
-        parameters: {
-            query?: never;
-            header?: never;
-            path: {
-                deploymentId: string;
-            };
-            cookie?: never;
-        };
-        requestBody?: never;
-        responses: {
-            /** @description Deployment found */
-            200: {
-                headers: {
-                    [name: string]: unknown;
-                };
-                content: {
-                    "application/json": components["schemas"]["Deployment"];
-                };
-            };
-            /** @description Deployment not found */
-            404: {
-                headers: {
-                    [name: string]: unknown;
-                };
-                content: {
-                    "application/json": {
-                        error: string;
-                    };
-                };
-            };
-        };
+  };
+  updateDeploymentVersion: {
+    parameters: {
+      query?: never;
+      header?: never;
+      path: {
+        /** @description The deployment version ID */
+        deploymentVersionId: string;
+      };
+      cookie?: never;
     };
-    deleteDeployment: {
-        parameters: {
-            query?: never;
-            header?: never;
-            path: {
-                deploymentId: string;
-            };
-            cookie?: never;
+    requestBody: {
+      content: {
+        "application/json": {
+          tag?: string;
+          deploymentId?: string;
+          /** Format: date-time */
+          createdAt?: string;
+          name?: string;
+          config?: {
+            [key: string]: unknown;
+          };
+          jobAgentConfig?: {
+            [key: string]: unknown;
+          };
+          /** @enum {string} */
+          status?: "ready" | "building" | "failed";
+          message?: string;
+          metadata?: {
+            [key: string]: string;
+          };
         };
-        requestBody?: never;
-        responses: {
-            /** @description Deployment deleted */
-            200: {
-                headers: {
-                    [name: string]: unknown;
-                };
-                content: {
-                    "application/json": components["schemas"]["Deployment"];
-                };
-            };
-            /** @description Deployment not found */
-            404: {
-                headers: {
-                    [name: string]: unknown;
-                };
-                content: {
-                    "application/json": {
-                        error: string;
-                    };
-                };
-            };
-            /** @description Failed to delete deployment */
-            500: {
-                headers: {
-                    [name: string]: unknown;
-                };
-                content: {
-                    "application/json": {
-                        error: string;
-                    };
-                };
-            };
-        };
+      };
     };
-    updateDeployment: {
-        parameters: {
-            query?: never;
-            header?: never;
-            path: {
-                deploymentId: string;
-            };
-            cookie?: never;
+    responses: {
+      /** @description OK */
+      200: {
+        headers: {
+          [name: string]: unknown;
         };
-        requestBody: {
-            content: {
-                "application/json": {
-                    name?: string;
-                    slug?: string;
-                    description?: string;
-                    /** Format: uuid */
-                    systemId?: string;
-                    /** Format: uuid */
-                    jobAgentId?: string | null;
-                    jobAgentConfig?: {
-                        [key: string]: unknown;
-                    };
-                    retryCount?: number;
-                    timeout?: number | null;
-                    resourceSelector?: {
-                        [key: string]: unknown;
-                    } | null;
-                };
-            };
+        content: {
+          "application/json": components["schemas"]["DeploymentVersion"];
         };
-        responses: {
-            /** @description Deployment updated */
-            200: {
-                headers: {
-                    [name: string]: unknown;
-                };
-                content: {
-                    "application/json": components["schemas"]["Deployment"];
-                };
-            };
-            /** @description Deployment not found */
-            404: {
-                headers: {
-                    [name: string]: unknown;
-                };
-                content: {
-                    "application/json": {
-                        error: string;
-                    };
-                };
-            };
-            /** @description Failed to update deployment */
-            500: {
-                headers: {
-                    [name: string]: unknown;
-                };
-                content: {
-                    "application/json": {
-                        error: string;
-                    };
-                };
-            };
+      };
+      /** @description Deployment version not found */
+      404: {
+        headers: {
+          [name: string]: unknown;
         };
+        content: {
+          "application/json": {
+            error?: string;
+          };
+        };
+      };
+      /** @description Internal server error */
+      500: {
+        headers: {
+          [name: string]: unknown;
+        };
+        content: {
+          "application/json": {
+            error?: string;
+          };
+        };
+      };
     };
-    deleteReleaseChannel: {
-        parameters: {
-            query?: never;
-            header?: never;
-            path: {
-                deploymentId: string;
-                name: string;
-            };
-            cookie?: never;
-        };
-        requestBody?: never;
-        responses: {
-            /** @description Release channel deleted */
-            200: {
-                headers: {
-                    [name: string]: unknown;
-                };
-                content: {
-                    "application/json": {
-                        message: string;
-                    };
-                };
-            };
-            /** @description Permission denied */
-            403: {
-                headers: {
-                    [name: string]: unknown;
-                };
-                content: {
-                    "application/json": {
-                        error: string;
-                    };
-                };
-            };
-            /** @description Release channel not found */
-            404: {
-                headers: {
-                    [name: string]: unknown;
-                };
-                content: {
-                    "application/json": {
-                        error: string;
-                    };
-                };
-            };
-            /** @description Failed to delete release channel */
-            500: {
-                headers: {
-                    [name: string]: unknown;
-                };
-                content: {
-                    "application/json": {
-                        error: string;
-                    };
-                };
-            };
-        };
+  };
+  upsertDeploymentVersion: {
+    parameters: {
+      query?: never;
+      header?: never;
+      path?: never;
+      cookie?: never;
     };
-    getResourcesForDeployment: {
-        parameters: {
-            query?: never;
-            header?: never;
-            path: {
-                /** @description UUID of the deployment */
-                deploymentId: string;
-            };
-            cookie?: never;
+    requestBody: {
+      content: {
+        "application/json": {
+          tag: string;
+          deploymentId: string;
+          /** Format: date-time */
+          createdAt?: string;
+          name?: string;
+          config?: {
+            [key: string]: unknown;
+          };
+          jobAgentConfig?: {
+            [key: string]: unknown;
+          };
+          /** @enum {string} */
+          status?: "ready" | "building" | "failed";
+          message?: string;
+          metadata?: {
+            [key: string]: string;
+          };
         };
-        requestBody?: never;
-        responses: {
-            /** @description OK */
-            200: {
-                headers: {
-                    [name: string]: unknown;
-                };
-                content: {
-                    "application/json": {
-                        resources?: components["schemas"]["Resource"][];
-                        count?: number;
-                    };
-                };
-            };
-            /** @description Internal Server Error */
-            500: {
-                headers: {
-                    [name: string]: unknown;
-                };
-                content: {
-                    "application/json": {
-                        error?: string;
-                    };
-                };
-            };
-        };
+      };
     };
-    getDeploymentVariables: {
-        parameters: {
-            query?: never;
-            header?: never;
-            path: {
-                deploymentId: string;
-            };
-            cookie?: never;
+    responses: {
+      /** @description OK */
+      201: {
+        headers: {
+          [name: string]: unknown;
         };
-        requestBody?: never;
-        responses: {
-            /** @description Variables fetched successfully */
-            200: {
-                headers: {
-                    [name: string]: unknown;
-                };
-                content: {
-                    "application/json": components["schemas"]["DeploymentVariable"][];
-                };
-            };
-            /** @description Deployment not found */
-            404: {
-                headers: {
-                    [name: string]: unknown;
-                };
-                content: {
-                    "application/json": {
-                        error: string;
-                    };
-                };
-            };
-            /** @description Failed to fetch variables */
-            500: {
-                headers: {
-                    [name: string]: unknown;
-                };
-                content: {
-                    "application/json": {
-                        error: string;
-                    };
-                };
-            };
+        content: {
+          "application/json": components["schemas"]["DeploymentVersion"];
         };
+      };
+      /** @description Internal server error */
+      500: {
+        headers: {
+          [name: string]: unknown;
+        };
+        content: {
+          "application/json": {
+            error?: string;
+          };
+        };
+      };
     };
-    createDeploymentVariable: {
-        parameters: {
-            query?: never;
-            header?: never;
-            path: {
-                deploymentId: string;
-            };
-            cookie?: never;
-        };
-        requestBody?: {
-            content: {
-                "application/json": {
-                    key: string;
-                    description?: string;
-                    config: {
-                        [key: string]: unknown;
-                    };
-                    values?: components["schemas"]["VariableValue"][];
-                };
-            };
-        };
-        responses: {
-            /** @description Variable created successfully */
-            200: {
-                headers: {
-                    [name: string]: unknown;
-                };
-                content: {
-                    "application/json": components["schemas"]["DeploymentVariable"];
-                };
-            };
-            /** @description Invalid request body */
-            400: {
-                headers: {
-                    [name: string]: unknown;
-                };
-                content: {
-                    "application/json": {
-                        error: string;
-                    };
-                };
-            };
-            /** @description Deployment not found */
-            404: {
-                headers: {
-                    [name: string]: unknown;
-                };
-                content: {
-                    "application/json": {
-                        error: string;
-                    };
-                };
-            };
-            /** @description Failed to create variable */
-            500: {
-                headers: {
-                    [name: string]: unknown;
-                };
-                content: {
-                    "application/json": {
-                        error: string;
-                    };
-                };
-            };
-        };
+  };
+  deleteDeploymentVersionChannel: {
+    parameters: {
+      query?: never;
+      header?: never;
+      path: {
+        deploymentId: string;
+        name: string;
+      };
+      cookie?: never;
     };
-    createDeployment: {
-        parameters: {
-            query?: never;
-            header?: never;
-            path?: never;
-            cookie?: never;
+    requestBody?: never;
+    responses: {
+      /** @description Deployment version channel deleted */
+      200: {
+        headers: {
+          [name: string]: unknown;
         };
-        requestBody?: {
-            content: {
-                "application/json": {
-                    /**
-                     * Format: uuid
-                     * @description The ID of the system to create the deployment for
-                     * @example 123e4567-e89b-12d3-a456-426614174000
-                     */
-                    systemId: string;
-                    /**
-                     * @description The name of the deployment
-                     * @example My Deployment
-                     */
-                    name: string;
-                    /**
-                     * @description The slug of the deployment
-                     * @example my-deployment
-                     */
-                    slug: string;
-                    /**
-                     * @description The description of the deployment
-                     * @example This is a deployment for my system
-                     */
-                    description?: string;
-                    /**
-                     * Format: uuid
-                     * @description The ID of the job agent to use for the deployment
-                     * @example 123e4567-e89b-12d3-a456-426614174000
-                     */
-                    jobAgentId?: string;
-                    /**
-                     * @description The configuration for the job agent
-                     * @example {
-                     *       "key": "value"
-                     *     }
-                     */
-                    jobAgentConfig?: Record<string, never>;
-                    /**
-                     * @description The number of times to retry the deployment
-                     * @example 3
-                     */
-                    retryCount?: number;
-                    /**
-                     * @description The timeout for the deployment
-                     * @example 60
-                     */
-                    timeout?: number;
-                    /**
-                     * @description The resource selector for the deployment
-                     * @example {
-                     *       "key": "value"
-                     *     }
-                     */
-                    resourceSelector?: {
-                        [key: string]: unknown;
-                    };
-                };
-            };
+        content: {
+          "application/json": {
+            message: string;
+          };
         };
-        responses: {
-            /** @description Deployment updated */
-            200: {
-                headers: {
-                    [name: string]: unknown;
-                };
-                content: {
-                    "application/json": components["schemas"]["Deployment"];
-                };
-            };
-            /** @description Deployment created */
-            201: {
-                headers: {
-                    [name: string]: unknown;
-                };
-                content: {
-                    "application/json": components["schemas"]["Deployment"];
-                };
-            };
-            /** @description Deployment already exists */
-            409: {
-                headers: {
-                    [name: string]: unknown;
-                };
-                content: {
-                    "application/json": {
-                        error: string;
-                        /** Format: uuid */
-                        id: string;
-                    };
-                };
-            };
-            /** @description Failed to create deployment */
-            500: {
-                headers: {
-                    [name: string]: unknown;
-                };
-                content: {
-                    "application/json": {
-                        error: string;
-                    };
-                };
-            };
+      };
+      /** @description Permission denied */
+      403: {
+        headers: {
+          [name: string]: unknown;
         };
+        content: {
+          "application/json": {
+            error: string;
+          };
+        };
+      };
+      /** @description Deployment version channel not found */
+      404: {
+        headers: {
+          [name: string]: unknown;
+        };
+        content: {
+          "application/json": {
+            error: string;
+          };
+        };
+      };
+      /** @description Failed to delete deployment version channel */
+      500: {
+        headers: {
+          [name: string]: unknown;
+        };
+        content: {
+          "application/json": {
+            error: string;
+          };
+        };
+      };
     };
-    getEnvironment: {
-        parameters: {
-            query?: never;
-            header?: never;
-            path: {
-                /** @description UUID of the environment */
-                environmentId: string;
-            };
-            cookie?: never;
-        };
-        requestBody?: never;
-        responses: {
-            /** @description Successful response */
-            200: {
-                headers: {
-                    [name: string]: unknown;
-                };
-                content: {
-                    "application/json": components["schemas"]["Environment"];
-                };
-            };
-            /** @description Environment not found */
-            404: {
-                headers: {
-                    [name: string]: unknown;
-                };
-                content: {
-                    "application/json": {
-                        /** @example Environment not found */
-                        error: string;
-                    };
-                };
-            };
-        };
+  };
+  getDeployment: {
+    parameters: {
+      query?: never;
+      header?: never;
+      path: {
+        deploymentId: string;
+      };
+      cookie?: never;
     };
-    deleteEnvironment: {
-        parameters: {
-            query?: never;
-            header?: never;
-            path: {
-                /** @description UUID of the environment */
-                environmentId: string;
-            };
-            cookie?: never;
+    requestBody?: never;
+    responses: {
+      /** @description Deployment found */
+      200: {
+        headers: {
+          [name: string]: unknown;
         };
-        requestBody?: never;
-        responses: {
-            /** @description Environment deleted successfully */
-            200: {
-                headers: {
-                    [name: string]: unknown;
-                };
-                content?: never;
-            };
+        content: {
+          "application/json": components["schemas"]["Deployment"];
         };
+      };
+      /** @description Deployment not found */
+      404: {
+        headers: {
+          [name: string]: unknown;
+        };
+        content: {
+          "application/json": {
+            error: string;
+          };
+        };
+      };
     };
-    getResourcesForEnvironment: {
-        parameters: {
-            query?: never;
-            header?: never;
-            path: {
-                /** @description UUID of the environment */
-                environmentId: string;
-            };
-            cookie?: never;
-        };
-        requestBody?: never;
-        responses: {
-            /** @description OK */
-            200: {
-                headers: {
-                    [name: string]: unknown;
-                };
-                content: {
-                    "application/json": {
-                        resources?: components["schemas"]["Resource"][];
-                        count?: number;
-                    };
-                };
-            };
-            /** @description Internal Server Error */
-            500: {
-                headers: {
-                    [name: string]: unknown;
-                };
-                content: {
-                    "application/json": {
-                        error?: string;
-                    };
-                };
-            };
-        };
+  };
+  deleteDeployment: {
+    parameters: {
+      query?: never;
+      header?: never;
+      path: {
+        deploymentId: string;
+      };
+      cookie?: never;
     };
-    createEnvironment: {
-        parameters: {
-            query?: never;
-            header?: never;
-            path?: never;
-            cookie?: never;
+    requestBody?: never;
+    responses: {
+      /** @description Deployment deleted */
+      200: {
+        headers: {
+          [name: string]: unknown;
         };
-        requestBody: {
-            content: {
-                "application/json": {
-                    /**
-                     * @description The directory path of the environment
-                     * @default
-                     * @example my/env/path
-                     */
-                    directory?: string;
-                    systemId: string;
-                    name: string;
-                    description?: string;
-                    resourceSelector?: {
-                        [key: string]: unknown;
-                    };
-                    policyId?: string;
-                    releaseChannels?: string[];
-                    deploymentVersionChannels?: string[];
-                    metadata?: {
-                        [key: string]: string;
-                    };
-                };
-            };
+        content: {
+          "application/json": components["schemas"]["Deployment"];
         };
-        responses: {
-            /** @description Environment created successfully */
-            200: {
-                headers: {
-                    [name: string]: unknown;
-                };
-                content: {
-                    "application/json": components["schemas"]["Environment"];
-                };
-            };
-            /** @description Environment already exists */
-            409: {
-                headers: {
-                    [name: string]: unknown;
-                };
-                content: {
-                    "application/json": {
-                        error?: string;
-                        id?: string;
-                    };
-                };
-            };
-            /** @description Failed to create environment */
-            500: {
-                headers: {
-                    [name: string]: unknown;
-                };
-                content: {
-                    "application/json": {
-                        error: string;
-                    };
-                };
-            };
+      };
+      /** @description Deployment not found */
+      404: {
+        headers: {
+          [name: string]: unknown;
         };
+        content: {
+          "application/json": {
+            error: string;
+          };
+        };
+      };
+      /** @description Failed to delete deployment */
+      500: {
+        headers: {
+          [name: string]: unknown;
+        };
+        content: {
+          "application/json": {
+            error: string;
+          };
+        };
+      };
     };
-    getAgentRunningJobs: {
-        parameters: {
-            query?: never;
-            header?: never;
-            path: {
-                /** @description The execution ID */
-                agentId: string;
-            };
-            cookie?: never;
-        };
-        requestBody?: never;
-        responses: {
-            /** @description OK */
-            200: {
-                headers: {
-                    [name: string]: unknown;
-                };
-                content: {
-                    "application/json": {
-                        jobs: components["schemas"]["Job"][];
-                    };
-                };
-            };
-        };
+  };
+  updateDeployment: {
+    parameters: {
+      query?: never;
+      header?: never;
+      path: {
+        deploymentId: string;
+      };
+      cookie?: never;
     };
-    acknowledgeAgentJob: {
-        parameters: {
-            query?: never;
-            header?: never;
-            path: {
-                /** @description The ID of the job agent */
-                agentId: string;
-            };
-            cookie?: never;
+    requestBody: {
+      content: {
+        "application/json": {
+          name?: string;
+          slug?: string;
+          description?: string;
+          /** Format: uuid */
+          systemId?: string;
+          /** Format: uuid */
+          jobAgentId?: string | null;
+          jobAgentConfig?: {
+            [key: string]: unknown;
+          };
+          retryCount?: number;
+          timeout?: number | null;
+          resourceSelector?: {
+            [key: string]: unknown;
+          } | null;
         };
-        requestBody?: never;
-        responses: {
-            /** @description Successfully acknowledged job */
-            200: {
-                headers: {
-                    [name: string]: unknown;
-                };
-                content: {
-                    "application/json": {
-                        job?: components["schemas"]["Job"];
-                    };
-                };
-            };
-            /** @description Unauthorized */
-            401: {
-                headers: {
-                    [name: string]: unknown;
-                };
-                content: {
-                    "application/json": {
-                        error?: string;
-                    };
-                };
-            };
-            /** @description Workspace not found */
-            404: {
-                headers: {
-                    [name: string]: unknown;
-                };
-                content: {
-                    "application/json": {
-                        error?: string;
-                    };
-                };
-            };
-        };
+      };
     };
-    getNextJobs: {
-        parameters: {
-            query?: never;
-            header?: never;
-            path: {
-                /** @description The agent ID */
-                agentId: string;
-            };
-            cookie?: never;
+    responses: {
+      /** @description Deployment updated */
+      200: {
+        headers: {
+          [name: string]: unknown;
         };
-        requestBody?: never;
-        responses: {
-            /** @description OK */
-            200: {
-                headers: {
-                    [name: string]: unknown;
-                };
-                content: {
-                    "application/json": {
-                        jobs?: components["schemas"]["Job"][];
-                    };
-                };
-            };
+        content: {
+          "application/json": components["schemas"]["Deployment"];
         };
+      };
+      /** @description Deployment not found */
+      404: {
+        headers: {
+          [name: string]: unknown;
+        };
+        content: {
+          "application/json": {
+            error: string;
+          };
+        };
+      };
+      /** @description Failed to update deployment */
+      500: {
+        headers: {
+          [name: string]: unknown;
+        };
+        content: {
+          "application/json": {
+            error: string;
+          };
+        };
+      };
     };
-    upsertJobAgent: {
-        parameters: {
-            query?: never;
-            header?: never;
-            path?: never;
-            cookie?: never;
-        };
-        requestBody: {
-            content: {
-                "application/json": {
-                    workspaceId: string;
-                    name: string;
-                    type: string;
-                };
-            };
-        };
-        responses: {
-            /** @description Successfully retrieved or created the agent */
-            200: {
-                headers: {
-                    [name: string]: unknown;
-                };
-                content: {
-                    "application/json": {
-                        id: string;
-                        name: string;
-                        workspaceId: string;
-                    };
-                };
-            };
-            /** @description Internal server error */
-            500: {
-                headers: {
-                    [name: string]: unknown;
-                };
-                content?: never;
-            };
-        };
+  };
+  deleteReleaseChannel: {
+    parameters: {
+      query?: never;
+      header?: never;
+      path: {
+        deploymentId: string;
+        name: string;
+      };
+      cookie?: never;
     };
-    acknowledgeJob: {
-        parameters: {
-            query?: never;
-            header?: never;
-            path: {
-                /** @description The job ID */
-                jobId: string;
-            };
-            cookie?: never;
+    requestBody?: never;
+    responses: {
+      /** @description Release channel deleted */
+      200: {
+        headers: {
+          [name: string]: unknown;
         };
-        requestBody?: never;
-        responses: {
-            /** @description OK */
-            200: {
-                headers: {
-                    [name: string]: unknown;
-                };
-                content: {
-                    "application/json": {
-                        sucess: boolean;
-                    };
-                };
-            };
-            /** @description Unauthorized */
-            401: {
-                headers: {
-                    [name: string]: unknown;
-                };
-                content: {
-                    "application/json": {
-                        error: string;
-                    };
-                };
-            };
+        content: {
+          "application/json": {
+            message: string;
+          };
         };
+      };
+      /** @description Permission denied */
+      403: {
+        headers: {
+          [name: string]: unknown;
+        };
+        content: {
+          "application/json": {
+            error: string;
+          };
+        };
+      };
+      /** @description Release channel not found */
+      404: {
+        headers: {
+          [name: string]: unknown;
+        };
+        content: {
+          "application/json": {
+            error: string;
+          };
+        };
+      };
+      /** @description Failed to delete release channel */
+      500: {
+        headers: {
+          [name: string]: unknown;
+        };
+        content: {
+          "application/json": {
+            error: string;
+          };
+        };
+      };
     };
-    getJob: {
-        parameters: {
-            query?: never;
-            header?: never;
-            path: {
-                /** @description The job ID */
-                jobId: string;
-            };
-            cookie?: never;
-        };
-        requestBody?: never;
-        responses: {
-            /** @description OK */
-            200: {
-                headers: {
-                    [name: string]: unknown;
-                };
-                content: {
-                    "application/json": components["schemas"]["JobWithTrigger"];
-                };
-            };
-            /** @description Not Found */
-            404: {
-                headers: {
-                    [name: string]: unknown;
-                };
-                content: {
-                    "application/json": {
-                        /** @example Job not found. */
-                        error?: string;
-                    };
-                };
-            };
-        };
+  };
+  getResourcesForDeployment: {
+    parameters: {
+      query?: never;
+      header?: never;
+      path: {
+        /** @description UUID of the deployment */
+        deploymentId: string;
+      };
+      cookie?: never;
     };
-    updateJob: {
-        parameters: {
-            query?: never;
-            header?: never;
-            path: {
-                /** @description The execution ID */
-                jobId: string;
-            };
-            cookie?: never;
+    requestBody?: never;
+    responses: {
+      /** @description OK */
+      200: {
+        headers: {
+          [name: string]: unknown;
         };
-        requestBody: {
-            content: {
-                "application/json": {
-                    status?: components["schemas"]["JobStatus"];
-                    message?: string | null;
-                    externalId?: string | null;
-                };
-            };
+        content: {
+          "application/json": {
+            resources?: components["schemas"]["Resource"][];
+            count?: number;
+          };
         };
-        responses: {
-            /** @description OK */
-            200: {
-                headers: {
-                    [name: string]: unknown;
-                };
-                content: {
-                    "application/json": {
-                        id: string;
-                    };
-                };
-            };
+      };
+      /** @description Internal Server Error */
+      500: {
+        headers: {
+          [name: string]: unknown;
         };
+        content: {
+          "application/json": {
+            error?: string;
+          };
+        };
+      };
     };
-    deletePolicy: {
-        parameters: {
-            query?: never;
-            header?: never;
-            path: {
-                policyId: string;
-            };
-            cookie?: never;
-        };
-        requestBody?: never;
-        responses: {
-            /** @description OK */
-            200: {
-                headers: {
-                    [name: string]: unknown;
-                };
-                content: {
-                    "application/json": {
-                        count?: number;
-                    };
-                };
-            };
-            /** @description Internal Server Error */
-            500: {
-                headers: {
-                    [name: string]: unknown;
-                };
-                content: {
-                    "application/json": {
-                        error?: string;
-                    };
-                };
-            };
-        };
+  };
+  getDeploymentVariables: {
+    parameters: {
+      query?: never;
+      header?: never;
+      path: {
+        deploymentId: string;
+      };
+      cookie?: never;
     };
-    updatePolicy: {
-        parameters: {
-            query?: never;
-            header?: never;
-            path: {
-                policyId: string;
-            };
-            cookie?: never;
+    requestBody?: never;
+    responses: {
+      /** @description Variables fetched successfully */
+      200: {
+        headers: {
+          [name: string]: unknown;
         };
-        requestBody: {
-            content: {
-                "application/json": {
-                    name?: string;
-                    description?: string;
-                    priority?: number;
-                    enabled?: boolean;
-                    workspaceId?: string;
-                    targets?: components["schemas"]["PolicyTarget"][];
-                    denyWindows?: {
-                        timeZone: string;
-                        rrule?: {
-                            [key: string]: unknown;
-                        };
-                        /** Format: date-time */
-                        dtend?: string;
-                    }[];
-                    deploymentVersionSelector?: components["schemas"]["DeploymentVersionSelector"];
-                    versionAnyApprovals?: {
-                        requiredApprovalsCount?: number;
-                    }[];
-                    versionUserApprovals?: components["schemas"]["VersionUserApproval"][];
-                    versionRoleApprovals?: {
-                        roleId: string;
-                        requiredApprovalsCount?: number;
-                    }[];
-                };
-            };
+        content: {
+          "application/json": components["schemas"]["DeploymentVariable"][];
         };
-        responses: {
-            /** @description OK */
-            200: {
-                headers: {
-                    [name: string]: unknown;
-                };
-                content: {
-                    "application/json": components["schemas"]["Policy"];
-                };
-            };
-            /** @description Policy not found */
-            404: {
-                headers: {
-                    [name: string]: unknown;
-                };
-                content: {
-                    "application/json": {
-                        error?: string;
-                    };
-                };
-            };
-            /** @description Internal Server Error */
-            500: {
-                headers: {
-                    [name: string]: unknown;
-                };
-                content: {
-                    "application/json": {
-                        error?: string;
-                    };
-                };
-            };
+      };
+      /** @description Deployment not found */
+      404: {
+        headers: {
+          [name: string]: unknown;
         };
+        content: {
+          "application/json": {
+            error: string;
+          };
+        };
+      };
+      /** @description Failed to fetch variables */
+      500: {
+        headers: {
+          [name: string]: unknown;
+        };
+        content: {
+          "application/json": {
+            error: string;
+          };
+        };
+      };
     };
-    getReleaseTargetsForPolicy: {
-        parameters: {
-            query?: never;
-            header?: never;
-            path: {
-                /** @description UUID of the policy */
-                policyId: string;
-            };
-            cookie?: never;
-        };
-        requestBody?: never;
-        responses: {
-            /** @description OK */
-            200: {
-                headers: {
-                    [name: string]: unknown;
-                };
-                content: {
-                    "application/json": {
-                        releaseTargets?: components["schemas"]["ReleaseTarget"][];
-                        count?: number;
-                    };
-                };
-            };
-            /** @description Internal Server Error */
-            500: {
-                headers: {
-                    [name: string]: unknown;
-                };
-                content: {
-                    "application/json": {
-                        error?: string;
-                    };
-                };
-            };
-        };
+  };
+  createDeploymentVariable: {
+    parameters: {
+      query?: never;
+      header?: never;
+      path: {
+        deploymentId: string;
+      };
+      cookie?: never;
     };
-    upsertPolicy: {
-        parameters: {
-            query?: never;
-            header?: never;
-            path?: never;
-            cookie?: never;
+    requestBody?: {
+      content: {
+        "application/json": {
+          key: string;
+          description?: string;
+          config: {
+            [key: string]: unknown;
+          };
+          values?: components["schemas"]["VariableValue"][];
         };
-        requestBody: {
-            content: {
-                "application/json": {
-                    name: string;
-                    description?: string;
-                    priority?: number;
-                    enabled?: boolean;
-                    workspaceId: string;
-                    targets: components["schemas"]["PolicyTarget"][];
-                    denyWindows?: {
-                        timeZone: string;
-                        rrule?: {
-                            [key: string]: unknown;
-                        };
-                        /** Format: date-time */
-                        dtend?: string;
-                    }[];
-                    deploymentVersionSelector?: components["schemas"]["DeploymentVersionSelector"];
-                    versionAnyApprovals?: components["schemas"]["VersionAnyApproval"];
-                    versionUserApprovals?: components["schemas"]["VersionUserApproval"][];
-                    versionRoleApprovals?: components["schemas"]["VersionRoleApproval"][];
-                };
-            };
-        };
-        responses: {
-            /** @description OK */
-            200: {
-                headers: {
-                    [name: string]: unknown;
-                };
-                content: {
-                    "application/json": components["schemas"]["Policy1"];
-                };
-            };
-            /** @description Internal Server Error */
-            500: {
-                headers: {
-                    [name: string]: unknown;
-                };
-                content: {
-                    "application/json": {
-                        error?: string;
-                    };
-                };
-            };
-        };
+      };
     };
-    createJobToResourceRelationship: {
-        parameters: {
-            query?: never;
-            header?: never;
-            path?: never;
-            cookie?: never;
+    responses: {
+      /** @description Variable created successfully */
+      200: {
+        headers: {
+          [name: string]: unknown;
         };
-        requestBody: {
-            content: {
-                "application/json": {
-                    /**
-                     * Format: uuid
-                     * @description Unique identifier of the job
-                     * @example 123e4567-e89b-12d3-a456-426614174000
-                     */
-                    jobId: string;
-                    /**
-                     * @description Unique identifier of the resource
-                     * @example resource-123
-                     */
-                    resourceIdentifier: string;
-                };
-            };
+        content: {
+          "application/json": components["schemas"]["DeploymentVariable"];
         };
-        responses: {
-            /** @description Relationship created successfully */
-            200: {
-                headers: {
-                    [name: string]: unknown;
-                };
-                content: {
-                    "application/json": {
-                        /** @example Relationship created successfully */
-                        message?: string;
-                    };
-                };
-            };
-            /** @description Invalid request body */
-            400: {
-                headers: {
-                    [name: string]: unknown;
-                };
-                content: {
-                    "application/json": {
-                        /** @example Invalid jobId format */
-                        error?: string;
-                    };
-                };
-            };
-            /** @description Job or resource not found */
-            404: {
-                headers: {
-                    [name: string]: unknown;
-                };
-                content: {
-                    "application/json": {
-                        /** @example Job with specified ID not found */
-                        error?: string;
-                    };
-                };
-            };
-            /** @description Relationship already exists */
-            409: {
-                headers: {
-                    [name: string]: unknown;
-                };
-                content: {
-                    "application/json": {
-                        /** @example Relationship between job and resource already exists */
-                        error?: string;
-                    };
-                };
-            };
-            /** @description Internal server error */
-            500: {
-                headers: {
-                    [name: string]: unknown;
-                };
-                content: {
-                    "application/json": {
-                        /** @example Internal server error occurred */
-                        error?: string;
-                    };
-                };
-            };
+      };
+      /** @description Invalid request body */
+      400: {
+        headers: {
+          [name: string]: unknown;
         };
+        content: {
+          "application/json": {
+            error: string;
+          };
+        };
+      };
+      /** @description Deployment not found */
+      404: {
+        headers: {
+          [name: string]: unknown;
+        };
+        content: {
+          "application/json": {
+            error: string;
+          };
+        };
+      };
+      /** @description Failed to create variable */
+      500: {
+        headers: {
+          [name: string]: unknown;
+        };
+        content: {
+          "application/json": {
+            error: string;
+          };
+        };
+      };
     };
-    createResourceToResourceRelationship: {
-        parameters: {
-            query?: never;
-            header?: never;
-            path?: never;
-            cookie?: never;
-        };
-        requestBody: {
-            content: {
-                "application/json": {
-                    /**
-                     * Format: uuid
-                     * @description The workspace ID
-                     * @example 123e4567-e89b-12d3-a456-426614174000
-                     */
-                    workspaceId: string;
-                    /**
-                     * @description The identifier of the resource to connect
-                     * @example my-resource
-                     */
-                    fromIdentifier: string;
-                    /**
-                     * @description The identifier of the resource to connect to
-                     * @example my-resource
-                     */
-                    toIdentifier: string;
-                    /**
-                     * @description The type of relationship
-                     * @example depends_on
-                     */
-                    type: string;
-                };
-            };
-        };
-        responses: {
-            /** @description Relationship created */
-            200: {
-                headers: {
-                    [name: string]: unknown;
-                };
-                content: {
-                    "application/json": {
-                        /** @example Relationship created successfully */
-                        message?: string;
-                    };
-                };
-            };
-            /** @description Invalid request body */
-            400: {
-                headers: {
-                    [name: string]: unknown;
-                };
-                content: {
-                    "application/json": {
-                        error?: string;
-                    };
-                };
-            };
-            /** @description Resource not found */
-            404: {
-                headers: {
-                    [name: string]: unknown;
-                };
-                content: {
-                    "application/json": {
-                        error?: string;
-                    };
-                };
-            };
-            /** @description Relationship already exists */
-            409: {
-                headers: {
-                    [name: string]: unknown;
-                };
-                content: {
-                    "application/json": {
-                        error?: string;
-                    };
-                };
-            };
-            /** @description Internal server error */
-            500: {
-                headers: {
-                    [name: string]: unknown;
-                };
-                content: {
-                    "application/json": {
-                        error?: string;
-                    };
-                };
-            };
-        };
+  };
+  createDeployment: {
+    parameters: {
+      query?: never;
+      header?: never;
+      path?: never;
+      cookie?: never;
     };
-    createReleaseChannel: {
-        parameters: {
-            query?: never;
-            header?: never;
-            path?: never;
-            cookie?: never;
+    requestBody?: {
+      content: {
+        "application/json": {
+          /**
+           * Format: uuid
+           * @description The ID of the system to create the deployment for
+           * @example 123e4567-e89b-12d3-a456-426614174000
+           */
+          systemId: string;
+          /**
+           * @description The name of the deployment
+           * @example My Deployment
+           */
+          name: string;
+          /**
+           * @description The slug of the deployment
+           * @example my-deployment
+           */
+          slug: string;
+          /**
+           * @description The description of the deployment
+           * @example This is a deployment for my system
+           */
+          description?: string;
+          /**
+           * Format: uuid
+           * @description The ID of the job agent to use for the deployment
+           * @example 123e4567-e89b-12d3-a456-426614174000
+           */
+          jobAgentId?: string;
+          /**
+           * @description The configuration for the job agent
+           * @example {
+           *       "key": "value"
+           *     }
+           */
+          jobAgentConfig?: Record<string, never>;
+          /**
+           * @description The number of times to retry the deployment
+           * @example 3
+           */
+          retryCount?: number;
+          /**
+           * @description The timeout for the deployment
+           * @example 60
+           */
+          timeout?: number;
+          /**
+           * @description The resource selector for the deployment
+           * @example {
+           *       "key": "value"
+           *     }
+           */
+          resourceSelector?: {
+            [key: string]: unknown;
+          };
         };
-        requestBody: {
-            content: {
-                "application/json": {
-                    deploymentId: string;
-                    name: string;
-                    description?: string | null;
-                    releaseSelector: {
-                        [key: string]: unknown;
-                    };
-                };
-            };
-        };
-        responses: {
-            /** @description Release channel created successfully */
-            200: {
-                headers: {
-                    [name: string]: unknown;
-                };
-                content: {
-                    "application/json": {
-                        id: string;
-                        deploymentId: string;
-                        name: string;
-                        description?: string | null;
-                        /** Format: date-time */
-                        createdAt: string;
-                        releaseSelector?: {
-                            [key: string]: unknown;
-                        };
-                    };
-                };
-            };
-            /** @description Unauthorized */
-            401: {
-                headers: {
-                    [name: string]: unknown;
-                };
-                content: {
-                    "application/json": {
-                        error: string;
-                    };
-                };
-            };
-            /** @description Forbidden */
-            403: {
-                headers: {
-                    [name: string]: unknown;
-                };
-                content: {
-                    "application/json": {
-                        error: string;
-                    };
-                };
-            };
-            /** @description Release channel already exists */
-            409: {
-                headers: {
-                    [name: string]: unknown;
-                };
-                content: {
-                    "application/json": {
-                        error: string;
-                        id: string;
-                    };
-                };
-            };
-            /** @description Failed to create release channel */
-            500: {
-                headers: {
-                    [name: string]: unknown;
-                };
-                content: {
-                    "application/json": {
-                        error: string;
-                    };
-                };
-            };
-        };
+      };
     };
-    getReleaseTargetReleases: {
-        parameters: {
-            query?: never;
-            header?: never;
-            path: {
-                releaseTargetId: string;
-            };
-            cookie?: never;
+    responses: {
+      /** @description Deployment updated */
+      200: {
+        headers: {
+          [name: string]: unknown;
         };
-        requestBody?: never;
-        responses: {
-            /** @description The latest 100 releases for the release target */
-            200: {
-                headers: {
-                    [name: string]: unknown;
-                };
-                content: {
-                    "application/json": {
-                        deployment: components["schemas"]["Deployment"];
-                        version: components["schemas"]["DeploymentVersion"];
-                        variables: {
-                            key: string;
-                            value: string;
-                        }[];
-                    }[];
-                };
-            };
-            /** @description The release target was not found */
-            404: {
-                headers: {
-                    [name: string]: unknown;
-                };
-                content: {
-                    "application/json": {
-                        error: string;
-                    };
-                };
-            };
-            /** @description An internal server error occurred */
-            500: {
-                headers: {
-                    [name: string]: unknown;
-                };
-                content: {
-                    "application/json": {
-                        error: string;
-                    };
-                };
-            };
+        content: {
+          "application/json": components["schemas"]["Deployment"];
         };
+      };
+      /** @description Deployment created */
+      201: {
+        headers: {
+          [name: string]: unknown;
+        };
+        content: {
+          "application/json": components["schemas"]["Deployment"];
+        };
+      };
+      /** @description Deployment already exists */
+      409: {
+        headers: {
+          [name: string]: unknown;
+        };
+        content: {
+          "application/json": {
+            error: string;
+            /** Format: uuid */
+            id: string;
+          };
+        };
+      };
+      /** @description Failed to create deployment */
+      500: {
+        headers: {
+          [name: string]: unknown;
+        };
+        content: {
+          "application/json": {
+            error: string;
+          };
+        };
+      };
     };
-    updateRelease: {
-        parameters: {
-            query?: never;
-            header?: never;
-            path: {
-                /** @description The release ID */
-                releaseId: string;
-            };
-            cookie?: never;
-        };
-        requestBody: {
-            content: {
-                "application/json": {
-                    version?: string;
-                    deploymentId?: string;
-                    /** Format: date-time */
-                    createdAt?: string;
-                    name?: string;
-                    config?: {
-                        [key: string]: unknown;
-                    };
-                    jobAgentConfig?: {
-                        [key: string]: unknown;
-                    };
-                    /** @enum {string} */
-                    status?: "ready" | "building" | "failed";
-                    message?: string;
-                    metadata?: {
-                        [key: string]: string;
-                    };
-                };
-            };
-        };
-        responses: {
-            /** @description OK */
-            200: {
-                headers: {
-                    [name: string]: unknown;
-                };
-                content: {
-                    "application/json": components["schemas"]["Release"];
-                };
-            };
-        };
+  };
+  getEnvironment: {
+    parameters: {
+      query?: never;
+      header?: never;
+      path: {
+        /** @description UUID of the environment */
+        environmentId: string;
+      };
+      cookie?: never;
     };
-    upsertRelease: {
-        parameters: {
-            query?: never;
-            header?: never;
-            path?: never;
-            cookie?: never;
+    requestBody?: never;
+    responses: {
+      /** @description Successful response */
+      200: {
+        headers: {
+          [name: string]: unknown;
         };
-        requestBody: {
-            content: {
-                "application/json": {
-                    version: string;
-                    deploymentId: string;
-                    /** Format: date-time */
-                    createdAt?: string;
-                    name?: string;
-                    config?: {
-                        [key: string]: unknown;
-                    };
-                    jobAgentConfig?: {
-                        [key: string]: unknown;
-                    };
-                    /** @enum {string} */
-                    status?: "ready" | "building" | "failed";
-                    message?: string;
-                    metadata?: {
-                        [key: string]: string;
-                    };
-                };
-            };
+        content: {
+          "application/json": components["schemas"]["Environment"];
         };
-        responses: {
-            /** @description OK */
-            200: {
-                headers: {
-                    [name: string]: unknown;
-                };
-                content: {
-                    "application/json": components["schemas"]["Release"];
-                };
-            };
-            /** @description Release already exists */
-            409: {
-                headers: {
-                    [name: string]: unknown;
-                };
-                content: {
-                    "application/json": {
-                        error?: string;
-                        id?: string;
-                    };
-                };
-            };
+      };
+      /** @description Environment not found */
+      404: {
+        headers: {
+          [name: string]: unknown;
         };
+        content: {
+          "application/json": {
+            /** @example Environment not found */
+            error: string;
+          };
+        };
+      };
     };
-    setResourceProvidersResources: {
-        parameters: {
-            query?: never;
-            header?: never;
-            path: {
-                /** @description UUID of the scanner */
-                providerId: string;
-            };
-            cookie?: never;
-        };
-        requestBody: {
-            content: {
-                "application/json": {
-                    resources: components["schemas"]["CreateResource"][];
-                };
-            };
-        };
-        responses: {
-            /** @description Successfully updated the deployment resources */
-            200: {
-                headers: {
-                    [name: string]: unknown;
-                };
-                content: {
-                    "application/json": {
-                        resources?: {
-                            ignored?: {
-                                identifier?: string;
-                                name?: string;
-                                version?: string;
-                                kind?: string;
-                                workspaceId?: string;
-                            }[];
-                            inserted?: {
-                                id?: string;
-                                name?: string;
-                                version?: string;
-                                kind?: string;
-                                config?: {
-                                    [key: string]: unknown;
-                                };
-                            }[];
-                            updated?: {
-                                id?: string;
-                                name?: string;
-                                version?: string;
-                                kind?: string;
-                                config?: {
-                                    [key: string]: unknown;
-                                };
-                            }[];
-                            deleted?: {
-                                id?: string;
-                                name?: string;
-                                version?: string;
-                                kind?: string;
-                                config?: {
-                                    [key: string]: unknown;
-                                };
-                            }[];
-                        };
-                    };
-                };
-            };
-            /** @description Invalid request */
-            400: {
-                headers: {
-                    [name: string]: unknown;
-                };
-                content?: never;
-            };
-            /** @description Deployment resources not found */
-            404: {
-                headers: {
-                    [name: string]: unknown;
-                };
-                content: {
-                    "application/json": {
-                        error?: string;
-                    };
-                };
-            };
-            /** @description Internal server error */
-            500: {
-                headers: {
-                    [name: string]: unknown;
-                };
-                content?: never;
-            };
-        };
+  };
+  deleteEnvironment: {
+    parameters: {
+      query?: never;
+      header?: never;
+      path: {
+        /** @description UUID of the environment */
+        environmentId: string;
+      };
+      cookie?: never;
     };
-    updateResourceRelationshipRule: {
-        parameters: {
-            query?: never;
-            header?: never;
-            path: {
+    requestBody?: never;
+    responses: {
+      /** @description Environment deleted successfully */
+      200: {
+        headers: {
+          [name: string]: unknown;
+        };
+        content?: never;
+      };
+    };
+  };
+  getResourcesForEnvironment: {
+    parameters: {
+      query?: never;
+      header?: never;
+      path: {
+        /** @description UUID of the environment */
+        environmentId: string;
+      };
+      cookie?: never;
+    };
+    requestBody?: never;
+    responses: {
+      /** @description OK */
+      200: {
+        headers: {
+          [name: string]: unknown;
+        };
+        content: {
+          "application/json": {
+            resources?: components["schemas"]["Resource"][];
+            count?: number;
+          };
+        };
+      };
+      /** @description Internal Server Error */
+      500: {
+        headers: {
+          [name: string]: unknown;
+        };
+        content: {
+          "application/json": {
+            error?: string;
+          };
+        };
+      };
+    };
+  };
+  createEnvironment: {
+    parameters: {
+      query?: never;
+      header?: never;
+      path?: never;
+      cookie?: never;
+    };
+    requestBody: {
+      content: {
+        "application/json": {
+          /**
+           * @description The directory path of the environment
+           * @default
+           * @example my/env/path
+           */
+          directory?: string;
+          systemId: string;
+          name: string;
+          description?: string;
+          resourceSelector?: {
+            [key: string]: unknown;
+          };
+          policyId?: string;
+          releaseChannels?: string[];
+          deploymentVersionChannels?: string[];
+          metadata?: {
+            [key: string]: string;
+          };
+        };
+      };
+    };
+    responses: {
+      /** @description Environment created successfully */
+      200: {
+        headers: {
+          [name: string]: unknown;
+        };
+        content: {
+          "application/json": components["schemas"]["Environment"];
+        };
+      };
+      /** @description Environment already exists */
+      409: {
+        headers: {
+          [name: string]: unknown;
+        };
+        content: {
+          "application/json": {
+            error?: string;
+            id?: string;
+          };
+        };
+      };
+      /** @description Failed to create environment */
+      500: {
+        headers: {
+          [name: string]: unknown;
+        };
+        content: {
+          "application/json": {
+            error: string;
+          };
+        };
+      };
+    };
+  };
+  getAgentRunningJobs: {
+    parameters: {
+      query?: never;
+      header?: never;
+      path: {
+        /** @description The execution ID */
+        agentId: string;
+      };
+      cookie?: never;
+    };
+    requestBody?: never;
+    responses: {
+      /** @description OK */
+      200: {
+        headers: {
+          [name: string]: unknown;
+        };
+        content: {
+          "application/json": {
+            jobs: components["schemas"]["Job"][];
+          };
+        };
+      };
+    };
+  };
+  acknowledgeAgentJob: {
+    parameters: {
+      query?: never;
+      header?: never;
+      path: {
+        /** @description The ID of the job agent */
+        agentId: string;
+      };
+      cookie?: never;
+    };
+    requestBody?: never;
+    responses: {
+      /** @description Successfully acknowledged job */
+      200: {
+        headers: {
+          [name: string]: unknown;
+        };
+        content: {
+          "application/json": {
+            job?: components["schemas"]["Job"];
+          };
+        };
+      };
+      /** @description Unauthorized */
+      401: {
+        headers: {
+          [name: string]: unknown;
+        };
+        content: {
+          "application/json": {
+            error?: string;
+          };
+        };
+      };
+      /** @description Workspace not found */
+      404: {
+        headers: {
+          [name: string]: unknown;
+        };
+        content: {
+          "application/json": {
+            error?: string;
+          };
+        };
+      };
+    };
+  };
+  getNextJobs: {
+    parameters: {
+      query?: never;
+      header?: never;
+      path: {
+        /** @description The agent ID */
+        agentId: string;
+      };
+      cookie?: never;
+    };
+    requestBody?: never;
+    responses: {
+      /** @description OK */
+      200: {
+        headers: {
+          [name: string]: unknown;
+        };
+        content: {
+          "application/json": {
+            jobs?: components["schemas"]["Job"][];
+          };
+        };
+      };
+    };
+  };
+  upsertJobAgent: {
+    parameters: {
+      query?: never;
+      header?: never;
+      path?: never;
+      cookie?: never;
+    };
+    requestBody: {
+      content: {
+        "application/json": {
+          workspaceId: string;
+          name: string;
+          type: string;
+        };
+      };
+    };
+    responses: {
+      /** @description Successfully retrieved or created the agent */
+      200: {
+        headers: {
+          [name: string]: unknown;
+        };
+        content: {
+          "application/json": {
+            id: string;
+            name: string;
+            workspaceId: string;
+          };
+        };
+      };
+      /** @description Internal server error */
+      500: {
+        headers: {
+          [name: string]: unknown;
+        };
+        content?: never;
+      };
+    };
+  };
+  acknowledgeJob: {
+    parameters: {
+      query?: never;
+      header?: never;
+      path: {
+        /** @description The job ID */
+        jobId: string;
+      };
+      cookie?: never;
+    };
+    requestBody?: never;
+    responses: {
+      /** @description OK */
+      200: {
+        headers: {
+          [name: string]: unknown;
+        };
+        content: {
+          "application/json": {
+            sucess: boolean;
+          };
+        };
+      };
+      /** @description Unauthorized */
+      401: {
+        headers: {
+          [name: string]: unknown;
+        };
+        content: {
+          "application/json": {
+            error: string;
+          };
+        };
+      };
+    };
+  };
+  getJob: {
+    parameters: {
+      query?: never;
+      header?: never;
+      path: {
+        /** @description The job ID */
+        jobId: string;
+      };
+      cookie?: never;
+    };
+    requestBody?: never;
+    responses: {
+      /** @description OK */
+      200: {
+        headers: {
+          [name: string]: unknown;
+        };
+        content: {
+          "application/json": components["schemas"]["JobWithTrigger"];
+        };
+      };
+      /** @description Not Found */
+      404: {
+        headers: {
+          [name: string]: unknown;
+        };
+        content: {
+          "application/json": {
+            /** @example Job not found. */
+            error?: string;
+          };
+        };
+      };
+    };
+  };
+  updateJob: {
+    parameters: {
+      query?: never;
+      header?: never;
+      path: {
+        /** @description The execution ID */
+        jobId: string;
+      };
+      cookie?: never;
+    };
+    requestBody: {
+      content: {
+        "application/json": {
+          status?: components["schemas"]["JobStatus"];
+          message?: string | null;
+          externalId?: string | null;
+        };
+      };
+    };
+    responses: {
+      /** @description OK */
+      200: {
+        headers: {
+          [name: string]: unknown;
+        };
+        content: {
+          "application/json": {
+            id: string;
+          };
+        };
+      };
+    };
+  };
+  deletePolicy: {
+    parameters: {
+      query?: never;
+      header?: never;
+      path: {
+        policyId: string;
+      };
+      cookie?: never;
+    };
+    requestBody?: never;
+    responses: {
+      /** @description OK */
+      200: {
+        headers: {
+          [name: string]: unknown;
+        };
+        content: {
+          "application/json": {
+            count?: number;
+          };
+        };
+      };
+      /** @description Internal Server Error */
+      500: {
+        headers: {
+          [name: string]: unknown;
+        };
+        content: {
+          "application/json": {
+            error?: string;
+          };
+        };
+      };
+    };
+  };
+  updatePolicy: {
+    parameters: {
+      query?: never;
+      header?: never;
+      path: {
+        policyId: string;
+      };
+      cookie?: never;
+    };
+    requestBody: {
+      content: {
+        "application/json": {
+          name?: string;
+          description?: string;
+          priority?: number;
+          enabled?: boolean;
+          workspaceId?: string;
+          targets?: components["schemas"]["PolicyTarget"][];
+          denyWindows?: {
+            timeZone: string;
+            rrule?: {
+              [key: string]: unknown;
+            };
+            /** Format: date-time */
+            dtend?: string;
+          }[];
+          deploymentVersionSelector?: components["schemas"]["DeploymentVersionSelector"];
+          versionAnyApprovals?: {
+            requiredApprovalsCount?: number;
+          }[];
+          versionUserApprovals?: components["schemas"]["VersionUserApproval"][];
+          versionRoleApprovals?: {
+            roleId: string;
+            requiredApprovalsCount?: number;
+          }[];
+        };
+      };
+    };
+    responses: {
+      /** @description OK */
+      200: {
+        headers: {
+          [name: string]: unknown;
+        };
+        content: {
+          "application/json": components["schemas"]["Policy"];
+        };
+      };
+      /** @description Policy not found */
+      404: {
+        headers: {
+          [name: string]: unknown;
+        };
+        content: {
+          "application/json": {
+            error?: string;
+          };
+        };
+      };
+      /** @description Internal Server Error */
+      500: {
+        headers: {
+          [name: string]: unknown;
+        };
+        content: {
+          "application/json": {
+            error?: string;
+          };
+        };
+      };
+    };
+  };
+  getReleaseTargetsForPolicy: {
+    parameters: {
+      query?: never;
+      header?: never;
+      path: {
+        /** @description UUID of the policy */
+        policyId: string;
+      };
+      cookie?: never;
+    };
+    requestBody?: never;
+    responses: {
+      /** @description OK */
+      200: {
+        headers: {
+          [name: string]: unknown;
+        };
+        content: {
+          "application/json": {
+            releaseTargets?: components["schemas"]["ReleaseTarget"][];
+            count?: number;
+          };
+        };
+      };
+      /** @description Internal Server Error */
+      500: {
+        headers: {
+          [name: string]: unknown;
+        };
+        content: {
+          "application/json": {
+            error?: string;
+          };
+        };
+      };
+    };
+  };
+  upsertPolicy: {
+    parameters: {
+      query?: never;
+      header?: never;
+      path?: never;
+      cookie?: never;
+    };
+    requestBody: {
+      content: {
+        "application/json": {
+          name: string;
+          description?: string;
+          priority?: number;
+          enabled?: boolean;
+          workspaceId: string;
+          targets: components["schemas"]["PolicyTarget"][];
+          denyWindows?: {
+            timeZone: string;
+            rrule?: {
+              [key: string]: unknown;
+            };
+            /** Format: date-time */
+            dtend?: string;
+          }[];
+          deploymentVersionSelector?: components["schemas"]["DeploymentVersionSelector"];
+          versionAnyApprovals?: components["schemas"]["VersionAnyApproval"];
+          versionUserApprovals?: components["schemas"]["VersionUserApproval"][];
+          versionRoleApprovals?: components["schemas"]["VersionRoleApproval"][];
+        };
+      };
+    };
+    responses: {
+      /** @description OK */
+      200: {
+        headers: {
+          [name: string]: unknown;
+        };
+        content: {
+          "application/json": components["schemas"]["Policy1"];
+        };
+      };
+      /** @description Internal Server Error */
+      500: {
+        headers: {
+          [name: string]: unknown;
+        };
+        content: {
+          "application/json": {
+            error?: string;
+          };
+        };
+      };
+    };
+  };
+  createJobToResourceRelationship: {
+    parameters: {
+      query?: never;
+      header?: never;
+      path?: never;
+      cookie?: never;
+    };
+    requestBody: {
+      content: {
+        "application/json": {
+          /**
+           * Format: uuid
+           * @description Unique identifier of the job
+           * @example 123e4567-e89b-12d3-a456-426614174000
+           */
+          jobId: string;
+          /**
+           * @description Unique identifier of the resource
+           * @example resource-123
+           */
+          resourceIdentifier: string;
+        };
+      };
+    };
+    responses: {
+      /** @description Relationship created successfully */
+      200: {
+        headers: {
+          [name: string]: unknown;
+        };
+        content: {
+          "application/json": {
+            /** @example Relationship created successfully */
+            message?: string;
+          };
+        };
+      };
+      /** @description Invalid request body */
+      400: {
+        headers: {
+          [name: string]: unknown;
+        };
+        content: {
+          "application/json": {
+            /** @example Invalid jobId format */
+            error?: string;
+          };
+        };
+      };
+      /** @description Job or resource not found */
+      404: {
+        headers: {
+          [name: string]: unknown;
+        };
+        content: {
+          "application/json": {
+            /** @example Job with specified ID not found */
+            error?: string;
+          };
+        };
+      };
+      /** @description Relationship already exists */
+      409: {
+        headers: {
+          [name: string]: unknown;
+        };
+        content: {
+          "application/json": {
+            /** @example Relationship between job and resource already exists */
+            error?: string;
+          };
+        };
+      };
+      /** @description Internal server error */
+      500: {
+        headers: {
+          [name: string]: unknown;
+        };
+        content: {
+          "application/json": {
+            /** @example Internal server error occurred */
+            error?: string;
+          };
+        };
+      };
+    };
+  };
+  createResourceToResourceRelationship: {
+    parameters: {
+      query?: never;
+      header?: never;
+      path?: never;
+      cookie?: never;
+    };
+    requestBody: {
+      content: {
+        "application/json": {
+          /**
+           * Format: uuid
+           * @description The workspace ID
+           * @example 123e4567-e89b-12d3-a456-426614174000
+           */
+          workspaceId: string;
+          /**
+           * @description The identifier of the resource to connect
+           * @example my-resource
+           */
+          fromIdentifier: string;
+          /**
+           * @description The identifier of the resource to connect to
+           * @example my-resource
+           */
+          toIdentifier: string;
+          /**
+           * @description The type of relationship
+           * @example depends_on
+           */
+          type: string;
+        };
+      };
+    };
+    responses: {
+      /** @description Relationship created */
+      200: {
+        headers: {
+          [name: string]: unknown;
+        };
+        content: {
+          "application/json": {
+            /** @example Relationship created successfully */
+            message?: string;
+          };
+        };
+      };
+      /** @description Invalid request body */
+      400: {
+        headers: {
+          [name: string]: unknown;
+        };
+        content: {
+          "application/json": {
+            error?: string;
+          };
+        };
+      };
+      /** @description Resource not found */
+      404: {
+        headers: {
+          [name: string]: unknown;
+        };
+        content: {
+          "application/json": {
+            error?: string;
+          };
+        };
+      };
+      /** @description Relationship already exists */
+      409: {
+        headers: {
+          [name: string]: unknown;
+        };
+        content: {
+          "application/json": {
+            error?: string;
+          };
+        };
+      };
+      /** @description Internal server error */
+      500: {
+        headers: {
+          [name: string]: unknown;
+        };
+        content: {
+          "application/json": {
+            error?: string;
+          };
+        };
+      };
+    };
+  };
+  createReleaseChannel: {
+    parameters: {
+      query?: never;
+      header?: never;
+      path?: never;
+      cookie?: never;
+    };
+    requestBody: {
+      content: {
+        "application/json": {
+          deploymentId: string;
+          name: string;
+          description?: string | null;
+          releaseSelector: {
+            [key: string]: unknown;
+          };
+        };
+      };
+    };
+    responses: {
+      /** @description Release channel created successfully */
+      200: {
+        headers: {
+          [name: string]: unknown;
+        };
+        content: {
+          "application/json": {
+            id: string;
+            deploymentId: string;
+            name: string;
+            description?: string | null;
+            /** Format: date-time */
+            createdAt: string;
+            releaseSelector?: {
+              [key: string]: unknown;
+            };
+          };
+        };
+      };
+      /** @description Unauthorized */
+      401: {
+        headers: {
+          [name: string]: unknown;
+        };
+        content: {
+          "application/json": {
+            error: string;
+          };
+        };
+      };
+      /** @description Forbidden */
+      403: {
+        headers: {
+          [name: string]: unknown;
+        };
+        content: {
+          "application/json": {
+            error: string;
+          };
+        };
+      };
+      /** @description Release channel already exists */
+      409: {
+        headers: {
+          [name: string]: unknown;
+        };
+        content: {
+          "application/json": {
+            error: string;
+            id: string;
+          };
+        };
+      };
+      /** @description Failed to create release channel */
+      500: {
+        headers: {
+          [name: string]: unknown;
+        };
+        content: {
+          "application/json": {
+            error: string;
+          };
+        };
+      };
+    };
+  };
+  getReleaseTargetReleases: {
+    parameters: {
+      query?: never;
+      header?: never;
+      path: {
+        releaseTargetId: string;
+      };
+      cookie?: never;
+    };
+    requestBody?: never;
+    responses: {
+      /** @description The latest 100 releases for the release target */
+      200: {
+        headers: {
+          [name: string]: unknown;
+        };
+        content: {
+          "application/json": {
+            deployment: components["schemas"]["Deployment"];
+            version: components["schemas"]["DeploymentVersion"];
+            variables: {
+              key: string;
+              value: string;
+            }[];
+          }[];
+        };
+      };
+      /** @description The release target was not found */
+      404: {
+        headers: {
+          [name: string]: unknown;
+        };
+        content: {
+          "application/json": {
+            error: string;
+          };
+        };
+      };
+      /** @description An internal server error occurred */
+      500: {
+        headers: {
+          [name: string]: unknown;
+        };
+        content: {
+          "application/json": {
+            error: string;
+          };
+        };
+      };
+    };
+  };
+  updateRelease: {
+    parameters: {
+      query?: never;
+      header?: never;
+      path: {
+        /** @description The release ID */
+        releaseId: string;
+      };
+      cookie?: never;
+    };
+    requestBody: {
+      content: {
+        "application/json": {
+          version?: string;
+          deploymentId?: string;
+          /** Format: date-time */
+          createdAt?: string;
+          name?: string;
+          config?: {
+            [key: string]: unknown;
+          };
+          jobAgentConfig?: {
+            [key: string]: unknown;
+          };
+          /** @enum {string} */
+          status?: "ready" | "building" | "failed";
+          message?: string;
+          metadata?: {
+            [key: string]: string;
+          };
+        };
+      };
+    };
+    responses: {
+      /** @description OK */
+      200: {
+        headers: {
+          [name: string]: unknown;
+        };
+        content: {
+          "application/json": components["schemas"]["Release"];
+        };
+      };
+    };
+  };
+  upsertRelease: {
+    parameters: {
+      query?: never;
+      header?: never;
+      path?: never;
+      cookie?: never;
+    };
+    requestBody: {
+      content: {
+        "application/json": {
+          version: string;
+          deploymentId: string;
+          /** Format: date-time */
+          createdAt?: string;
+          name?: string;
+          config?: {
+            [key: string]: unknown;
+          };
+          jobAgentConfig?: {
+            [key: string]: unknown;
+          };
+          /** @enum {string} */
+          status?: "ready" | "building" | "failed";
+          message?: string;
+          metadata?: {
+            [key: string]: string;
+          };
+        };
+      };
+    };
+    responses: {
+      /** @description OK */
+      200: {
+        headers: {
+          [name: string]: unknown;
+        };
+        content: {
+          "application/json": components["schemas"]["Release"];
+        };
+      };
+      /** @description Release already exists */
+      409: {
+        headers: {
+          [name: string]: unknown;
+        };
+        content: {
+          "application/json": {
+            error?: string;
+            id?: string;
+          };
+        };
+      };
+    };
+  };
+  setResourceProvidersResources: {
+    parameters: {
+      query?: never;
+      header?: never;
+      path: {
+        /** @description UUID of the scanner */
+        providerId: string;
+      };
+      cookie?: never;
+    };
+    requestBody: {
+      content: {
+        "application/json": {
+          resources: components["schemas"]["CreateResource"][];
+        };
+      };
+    };
+    responses: {
+      /** @description Successfully updated the deployment resources */
+      200: {
+        headers: {
+          [name: string]: unknown;
+        };
+        content: {
+          "application/json": {
+            resources?: {
+              ignored?: {
+                identifier?: string;
+                name?: string;
+                version?: string;
+                kind?: string;
+                workspaceId?: string;
+              }[];
+              inserted?: {
+                id?: string;
+                name?: string;
+                version?: string;
+                kind?: string;
+                config?: {
+                  [key: string]: unknown;
+                };
+              }[];
+              updated?: {
+                id?: string;
+                name?: string;
+                version?: string;
+                kind?: string;
+                config?: {
+                  [key: string]: unknown;
+                };
+              }[];
+              deleted?: {
+                id?: string;
+                name?: string;
+                version?: string;
+                kind?: string;
+                config?: {
+                  [key: string]: unknown;
+                };
+              }[];
+            };
+          };
+        };
+      };
+      /** @description Invalid request */
+      400: {
+        headers: {
+          [name: string]: unknown;
+        };
+        content?: never;
+      };
+      /** @description Deployment resources not found */
+      404: {
+        headers: {
+          [name: string]: unknown;
+        };
+        content: {
+          "application/json": {
+            error?: string;
+          };
+        };
+      };
+      /** @description Internal server error */
+      500: {
+        headers: {
+          [name: string]: unknown;
+        };
+        content?: never;
+      };
+    };
+  };
+  updateResourceRelationshipRule: {
+    parameters: {
+      query?: never;
+      header?: never;
+      path: {
+        ruleId: string;
+      };
+      cookie?: never;
+    };
+    requestBody?: {
+      content: {
+        "application/json": components["schemas"]["UpdateResourceRelationshipRule"];
+      };
+    };
+    responses: {
+      /** @description The updated resource relationship rule */
+      200: {
+        headers: {
+          [name: string]: unknown;
+        };
+        content: {
+          "application/json": components["schemas"]["ResourceRelationshipRule"];
+        };
+      };
+      /** @description The resource relationship rule was not found */
+      404: {
+        headers: {
+          [name: string]: unknown;
+        };
+        content: {
+          "application/json": {
+            error: string;
+          };
+        };
+      };
+      /** @description An error occurred while updating the resource relationship rule */
+      500: {
+        headers: {
+          [name: string]: unknown;
+        };
+        content: {
+          "application/json": {
+            error: string;
+          };
+        };
+      };
+    };
+  };
+  createResourceRelationshipRule: {
+    parameters: {
+      query?: never;
+      header?: never;
+      path?: never;
+      cookie?: never;
+    };
+    requestBody: {
+      content: {
+        "application/json": components["schemas"]["CreateResourceRelationshipRule"];
+      };
+    };
+    responses: {
+      /** @description Resource relationship rule created successfully */
+      200: {
+        headers: {
+          [name: string]: unknown;
+        };
+        content: {
+          "application/json": components["schemas"]["ResourceRelationshipRule"];
+        };
+      };
+      /** @description Resource relationship rule already exists */
+      409: {
+        headers: {
+          [name: string]: unknown;
+        };
+        content: {
+          "application/json": {
+            error?: string;
+          };
+        };
+      };
+      /** @description Failed to create resource relationship rule */
+      500: {
+        headers: {
+          [name: string]: unknown;
+        };
+        content: {
+          "application/json": {
+            error?: string;
+          };
+        };
+      };
+    };
+  };
+  createResourceSchema: {
+    parameters: {
+      query?: never;
+      header?: never;
+      path?: never;
+      cookie?: never;
+    };
+    requestBody: {
+      content: {
+        "application/json": {
+          /**
+           * Format: uuid
+           * @description The ID of the workspace
+           */
+          workspaceId: string;
+          /** @description Version of the schema */
+          version: string;
+          /** @description Kind of resource this schema is for */
+          kind: string;
+          /** @description The JSON schema definition */
+          jsonSchema: Record<string, never>;
+        };
+      };
+    };
+    responses: {
+      /** @description Resource schema created successfully */
+      201: {
+        headers: {
+          [name: string]: unknown;
+        };
+        content: {
+          "application/json": {
+            /** Format: uuid */
+            id?: string;
+            /** Format: uuid */
+            workspaceId?: string;
+            version?: string;
+            kind?: string;
+            jsonSchema?: Record<string, never>;
+          };
+        };
+      };
+      /** @description Invalid request body */
+      400: {
+        headers: {
+          [name: string]: unknown;
+        };
+        content: {
+          "application/json": {
+            error?: string;
+          };
+        };
+      };
+      /** @description Schema already exists for this version and kind */
+      409: {
+        headers: {
+          [name: string]: unknown;
+        };
+        content: {
+          "application/json": {
+            error?: string;
+            /** Format: uuid */
+            id?: string;
+          };
+        };
+      };
+    };
+  };
+  deleteResourceSchema: {
+    parameters: {
+      query?: never;
+      header?: never;
+      path: {
+        /** @description UUID of the schema to delete */
+        schemaId: string;
+      };
+      cookie?: never;
+    };
+    requestBody?: never;
+    responses: {
+      /** @description Schema deleted successfully */
+      200: {
+        headers: {
+          [name: string]: unknown;
+        };
+        content: {
+          "application/json": {
+            /** Format: uuid */
+            id?: string;
+          };
+        };
+      };
+      /** @description Schema not found */
+      404: {
+        headers: {
+          [name: string]: unknown;
+        };
+        content: {
+          "application/json": {
+            /** @example Schema not found */
+            error?: string;
+          };
+        };
+      };
+    };
+  };
+  getResource: {
+    parameters: {
+      query?: never;
+      header?: never;
+      path: {
+        /** @description The resource ID */
+        resourceId: string;
+      };
+      cookie?: never;
+    };
+    requestBody?: never;
+    responses: {
+      /** @description OK */
+      200: {
+        headers: {
+          [name: string]: unknown;
+        };
+        content: {
+          "application/json": components["schemas"]["ResourceWithVariablesAndMetadata"];
+        };
+      };
+      /** @description Unauthorized */
+      401: {
+        headers: {
+          [name: string]: unknown;
+        };
+        content?: never;
+      };
+      /** @description Permission denied */
+      403: {
+        headers: {
+          [name: string]: unknown;
+        };
+        content?: never;
+      };
+      /** @description Resource not found */
+      404: {
+        headers: {
+          [name: string]: unknown;
+        };
+        content: {
+          "application/json": {
+            /** @example Resource not found */
+            error: string;
+          };
+        };
+      };
+    };
+  };
+  deleteResource: {
+    parameters: {
+      query?: never;
+      header?: never;
+      path: {
+        /** @description The resource ID */
+        resourceId: string;
+      };
+      cookie?: never;
+    };
+    requestBody?: never;
+    responses: {
+      /** @description Resource deleted successfully */
+      200: {
+        headers: {
+          [name: string]: unknown;
+        };
+        content: {
+          "application/json": {
+            success: boolean;
+          };
+        };
+      };
+      /** @description Unauthorized */
+      401: {
+        headers: {
+          [name: string]: unknown;
+        };
+        content?: never;
+      };
+      /** @description Permission denied */
+      403: {
+        headers: {
+          [name: string]: unknown;
+        };
+        content?: never;
+      };
+      /** @description Resource not found */
+      404: {
+        headers: {
+          [name: string]: unknown;
+        };
+        content: {
+          "application/json": {
+            error: string;
+          };
+        };
+      };
+    };
+  };
+  updateResource: {
+    parameters: {
+      query?: never;
+      header?: never;
+      path: {
+        resourceId: string;
+      };
+      cookie?: never;
+    };
+    requestBody: {
+      content: {
+        "application/json": {
+          name?: string;
+          version?: string;
+          kind?: string;
+          identifier?: string;
+          workspaceId?: string;
+          metadata?: components["schemas"]["MetadataMap"];
+          variables?: components["schemas"]["DirectVariable"][];
+        };
+      };
+    };
+    responses: {
+      /** @description Resource updated successfully */
+      200: {
+        headers: {
+          [name: string]: unknown;
+        };
+        content: {
+          "application/json": components["schemas"]["ResourceWithVariablesAndMetadata"];
+        };
+      };
+      /** @description Unauthorized */
+      401: {
+        headers: {
+          [name: string]: unknown;
+        };
+        content?: never;
+      };
+      /** @description Permission denied */
+      403: {
+        headers: {
+          [name: string]: unknown;
+        };
+        content?: never;
+      };
+      /** @description Resource not found */
+      404: {
+        headers: {
+          [name: string]: unknown;
+        };
+        content: {
+          "application/json": {
+            error: string;
+          };
+        };
+      };
+    };
+  };
+  getReleaseTargets: {
+    parameters: {
+      query?: never;
+      header?: never;
+      path: {
+        /** @description The resource ID */
+        resourceId: string;
+      };
+      cookie?: never;
+    };
+    requestBody?: never;
+    responses: {
+      /** @description OK */
+      200: {
+        headers: {
+          [name: string]: unknown;
+        };
+        content: {
+          "application/json": components["schemas"]["ReleaseTarget"][];
+        };
+      };
+    };
+  };
+  upsertResource: {
+    parameters: {
+      query?: never;
+      header?: never;
+      path?: never;
+      cookie?: never;
+    };
+    requestBody: {
+      content: {
+        "application/json": {
+          /** Format: uuid */
+          workspaceId: string;
+          name: string;
+          kind: string;
+          identifier: string;
+          version: string;
+          config: Record<string, never>;
+          metadata?: {
+            [key: string]: string;
+          };
+          variables?: components["schemas"]["Variable"][];
+        };
+      };
+    };
+    responses: {
+      /** @description The created or updated resource */
+      200: {
+        headers: {
+          [name: string]: unknown;
+        };
+        content: {
+          "application/json": components["schemas"]["Resource"];
+        };
+      };
+    };
+  };
+  deleteEnvironmentByName: {
+    parameters: {
+      query?: never;
+      header?: never;
+      path: {
+        /** @description UUID of the system */
+        systemId: string;
+        /** @description Name of the environment */
+        name: string;
+      };
+      cookie?: never;
+    };
+    requestBody?: never;
+    responses: {
+      /** @description Environment deleted successfully */
+      200: {
+        headers: {
+          [name: string]: unknown;
+        };
+        content?: never;
+      };
+    };
+  };
+  getSystem: {
+    parameters: {
+      query?: never;
+      header?: never;
+      path: {
+        /** @description UUID of the system */
+        systemId: string;
+      };
+      cookie?: never;
+    };
+    requestBody?: never;
+    responses: {
+      /** @description System retrieved successfully */
+      200: {
+        headers: {
+          [name: string]: unknown;
+        };
+        content: {
+          "application/json": components["schemas"]["System"] & {
+            environments?: components["schemas"]["Environment"][];
+            deployments?: components["schemas"]["Deployment"][];
+          };
+        };
+      };
+    };
+  };
+  deleteSystem: {
+    parameters: {
+      query?: never;
+      header?: never;
+      path: {
+        systemId: string;
+      };
+      cookie?: never;
+    };
+    requestBody?: never;
+    responses: {
+      /** @description System deleted successfully */
+      200: {
+        headers: {
+          [name: string]: unknown;
+        };
+        content: {
+          "application/json": {
+            /** @example System deleted */
+            message?: string;
+          };
+        };
+      };
+      /** @description System not found */
+      404: {
+        headers: {
+          [name: string]: unknown;
+        };
+        content: {
+          "application/json": {
+            /** @example System not found */
+            error?: string;
+          };
+        };
+      };
+      /** @description Internal server error */
+      500: {
+        headers: {
+          [name: string]: unknown;
+        };
+        content: {
+          "application/json": {
+            /** @example Internal server error */
+            error?: string;
+          };
+        };
+      };
+    };
+  };
+  updateSystem: {
+    parameters: {
+      query?: never;
+      header?: never;
+      path: {
+        /** @description UUID of the system */
+        systemId: string;
+      };
+      cookie?: never;
+    };
+    requestBody: {
+      content: {
+        "application/json": {
+          /** @description Name of the system */
+          name?: string;
+          /** @description Slug of the system */
+          slug?: string;
+          /** @description Description of the system */
+          description?: string;
+          /**
+           * Format: uuid
+           * @description UUID of the workspace
+           */
+          workspaceId?: string;
+        };
+      };
+    };
+    responses: {
+      /** @description System updated successfully */
+      200: {
+        headers: {
+          [name: string]: unknown;
+        };
+        content: {
+          "application/json": components["schemas"]["System"];
+        };
+      };
+      /** @description System not found */
+      404: {
+        headers: {
+          [name: string]: unknown;
+        };
+        content: {
+          "application/json": {
+            /** @example System not found */
+            error?: string;
+          };
+        };
+      };
+      /** @description Internal server error */
+      500: {
+        headers: {
+          [name: string]: unknown;
+        };
+        content: {
+          "application/json": {
+            /** @example Internal server error */
+            error?: string;
+          };
+        };
+      };
+    };
+  };
+  createSystem: {
+    parameters: {
+      query?: never;
+      header?: never;
+      path?: never;
+      cookie?: never;
+    };
+    requestBody?: {
+      content: {
+        "application/json": {
+          /**
+           * Format: uuid
+           * @description The workspace ID of the system
+           */
+          workspaceId: string;
+          /** @description The name of the system */
+          name: string;
+          /** @description The slug of the system */
+          slug: string;
+          /** @description The description of the system */
+          description?: string;
+        };
+      };
+    };
+    responses: {
+      /** @description System updated successfully */
+      200: {
+        headers: {
+          [name: string]: unknown;
+        };
+        content: {
+          "application/json": components["schemas"]["System"];
+        };
+      };
+      /** @description System created successfully */
+      201: {
+        headers: {
+          [name: string]: unknown;
+        };
+        content: {
+          "application/json": components["schemas"]["System"];
+        };
+      };
+      /** @description Bad request */
+      400: {
+        headers: {
+          [name: string]: unknown;
+        };
+        content: {
+          "application/json": {
+            error?: {
+              /** @enum {string} */
+              code: "invalid_type" | "invalid_literal" | "custom";
+              message: string;
+              path: (string | number)[];
+            }[];
+          };
+        };
+      };
+      /** @description Internal server error */
+      500: {
+        headers: {
+          [name: string]: unknown;
+        };
+        content: {
+          "application/json": {
+            /** @example Internal Server Error */
+            error?: string;
+          };
+        };
+      };
+    };
+  };
+  listDeployments: {
+    parameters: {
+      query?: never;
+      header?: never;
+      path: {
+        /** @description The ID of the workspace */
+        workspaceId: string;
+      };
+      cookie?: never;
+    };
+    requestBody?: never;
+    responses: {
+      /** @description All deployments */
+      200: {
+        headers: {
+          [name: string]: unknown;
+        };
+        content: {
+          "application/json": {
+            data?: components["schemas"]["Deployment"][];
+          };
+        };
+      };
+    };
+  };
+  listEnvironments: {
+    parameters: {
+      query?: never;
+      header?: never;
+      path: {
+        /** @description The ID of the workspace */
+        workspaceId: string;
+      };
+      cookie?: never;
+    };
+    requestBody?: never;
+    responses: {
+      /** @description All environments */
+      200: {
+        headers: {
+          [name: string]: unknown;
+        };
+        content: {
+          "application/json": {
+            data?: components["schemas"]["Environment"][];
+          };
+        };
+      };
+    };
+  };
+  getEventsByAction: {
+    parameters: {
+      query?: never;
+      header?: never;
+      path: {
+        /** @description The ID of the workspace */
+        workspaceId: string;
+        action: string;
+      };
+      cookie?: never;
+    };
+    requestBody?: never;
+    responses: {
+      /** @description Events */
+      200: {
+        headers: {
+          [name: string]: unknown;
+        };
+        content: {
+          "application/json": components["schemas"]["Event"][];
+        };
+      };
+      /** @description Workspace not found */
+      404: {
+        headers: {
+          [name: string]: unknown;
+        };
+        content: {
+          "application/json": {
+            error: string;
+          };
+        };
+      };
+      /** @description Internal server error */
+      500: {
+        headers: {
+          [name: string]: unknown;
+        };
+        content: {
+          "application/json": {
+            error: string;
+          };
+        };
+      };
+    };
+  };
+  getWorkspace: {
+    parameters: {
+      query?: never;
+      header?: never;
+      path: {
+        workspaceId: string;
+      };
+      cookie?: never;
+    };
+    requestBody?: never;
+    responses: {
+      /** @description Workspace found */
+      200: {
+        headers: {
+          [name: string]: unknown;
+        };
+        content: {
+          "application/json": components["schemas"]["Workspace"];
+        };
+      };
+      /** @description Workspace not found */
+      404: {
+        headers: {
+          [name: string]: unknown;
+        };
+        content: {
+          "application/json": {
+            error?: string;
+          };
+        };
+      };
+      /** @description Internal server error */
+      500: {
+        headers: {
+          [name: string]: unknown;
+        };
+        content: {
+          "application/json": {
+            error?: string;
+          };
+        };
+      };
+    };
+  };
+  deletePolicyByName: {
+    parameters: {
+      query?: never;
+      header?: never;
+      path: {
+        /** @description ID of the workspace */
+        workspaceId: string;
+        /** @description Name of the policy */
+        name: string;
+      };
+      cookie?: never;
+    };
+    requestBody?: never;
+    responses: {
+      /** @description Successfully deleted the policy */
+      200: {
+        headers: {
+          [name: string]: unknown;
+        };
+        content: {
+          "application/json": {
+            /** @example true */
+            success?: boolean;
+          };
+        };
+      };
+      /** @description Unauthorized */
+      401: {
+        headers: {
+          [name: string]: unknown;
+        };
+        content?: never;
+      };
+      /** @description Permission denied */
+      403: {
+        headers: {
+          [name: string]: unknown;
+        };
+        content?: never;
+      };
+      /** @description Policy not found */
+      404: {
+        headers: {
+          [name: string]: unknown;
+        };
+        content: {
+          "application/json": {
+            /** @example Policy not found */
+            error?: string;
+          };
+        };
+      };
+      /** @description Internal server error */
+      500: {
+        headers: {
+          [name: string]: unknown;
+        };
+        content?: never;
+      };
+    };
+  };
+  upsertResourceProvider: {
+    parameters: {
+      query?: never;
+      header?: never;
+      path: {
+        /** @description Name of the workspace */
+        workspaceId: string;
+        /** @description Name of the resource provider */
+        name: string;
+      };
+      cookie?: never;
+    };
+    requestBody?: never;
+    responses: {
+      /** @description Successfully retrieved or created the resource provider */
+      200: {
+        headers: {
+          [name: string]: unknown;
+        };
+        content: {
+          "application/json": {
+            id: string;
+            name: string;
+            workspaceId: string;
+          };
+        };
+      };
+      /** @description Unauthorized */
+      401: {
+        headers: {
+          [name: string]: unknown;
+        };
+        content?: never;
+      };
+      /** @description Permission denied */
+      403: {
+        headers: {
+          [name: string]: unknown;
+        };
+        content?: never;
+      };
+      /** @description Workspace not found */
+      404: {
+        headers: {
+          [name: string]: unknown;
+        };
+        content?: never;
+      };
+      /** @description Internal server error */
+      500: {
+        headers: {
+          [name: string]: unknown;
+        };
+        content?: never;
+      };
+    };
+  };
+  getResourceByIdentifier: {
+    parameters: {
+      query?: never;
+      header?: never;
+      path: {
+        /** @description ID of the workspace */
+        workspaceId: string;
+        /** @description Identifier of the resource */
+        identifier: string;
+      };
+      cookie?: never;
+    };
+    requestBody?: never;
+    responses: {
+      /** @description Successfully retrieved the resource */
+      200: {
+        headers: {
+          [name: string]: unknown;
+        };
+        content: {
+          "application/json": components["schemas"]["ResourceWithVariablesAndMetadata"] & {
+            relationships?: {
+              [key: string]: {
                 ruleId: string;
+                type: string;
+                reference: string;
+                target: components["schemas"]["Resource"];
+              };
             };
-            cookie?: never;
+          };
         };
-        requestBody?: {
-            content: {
-                "application/json": components["schemas"]["UpdateResourceRelationshipRule"];
-            };
+      };
+      /** @description Unauthorized */
+      401: {
+        headers: {
+          [name: string]: unknown;
         };
-        responses: {
-            /** @description The updated resource relationship rule */
-            200: {
-                headers: {
-                    [name: string]: unknown;
-                };
-                content: {
-                    "application/json": components["schemas"]["ResourceRelationshipRule"];
-                };
-            };
-            /** @description The resource relationship rule was not found */
-            404: {
-                headers: {
-                    [name: string]: unknown;
-                };
-                content: {
-                    "application/json": {
-                        error: string;
-                    };
-                };
-            };
-            /** @description An error occurred while updating the resource relationship rule */
-            500: {
-                headers: {
-                    [name: string]: unknown;
-                };
-                content: {
-                    "application/json": {
-                        error: string;
-                    };
-                };
-            };
+        content?: never;
+      };
+      /** @description Permission denied */
+      403: {
+        headers: {
+          [name: string]: unknown;
         };
+        content?: never;
+      };
+      /** @description Resource not found */
+      404: {
+        headers: {
+          [name: string]: unknown;
+        };
+        content: {
+          "application/json": {
+            /** @example Resource not found */
+            error?: string;
+          };
+        };
+      };
+      /** @description Internal server error */
+      500: {
+        headers: {
+          [name: string]: unknown;
+        };
+        content?: never;
+      };
     };
-    createResourceRelationshipRule: {
-        parameters: {
-            query?: never;
-            header?: never;
-            path?: never;
-            cookie?: never;
-        };
-        requestBody: {
-            content: {
-                "application/json": components["schemas"]["CreateResourceRelationshipRule"];
-            };
-        };
-        responses: {
-            /** @description Resource relationship rule created successfully */
-            200: {
-                headers: {
-                    [name: string]: unknown;
-                };
-                content: {
-                    "application/json": components["schemas"]["ResourceRelationshipRule"];
-                };
-            };
-            /** @description Resource relationship rule already exists */
-            409: {
-                headers: {
-                    [name: string]: unknown;
-                };
-                content: {
-                    "application/json": {
-                        error?: string;
-                    };
-                };
-            };
-            /** @description Failed to create resource relationship rule */
-            500: {
-                headers: {
-                    [name: string]: unknown;
-                };
-                content: {
-                    "application/json": {
-                        error?: string;
-                    };
-                };
-            };
-        };
+  };
+  deleteResourceByIdentifier: {
+    parameters: {
+      query?: never;
+      header?: never;
+      path: {
+        /** @description ID of the workspace */
+        workspaceId: string;
+        /** @description Identifier of the resource */
+        identifier: string;
+      };
+      cookie?: never;
     };
-    createResourceSchema: {
-        parameters: {
-            query?: never;
-            header?: never;
-            path?: never;
-            cookie?: never;
+    requestBody?: never;
+    responses: {
+      /** @description Successfully deleted the resource */
+      200: {
+        headers: {
+          [name: string]: unknown;
         };
-        requestBody: {
-            content: {
-                "application/json": {
-                    /**
-                     * Format: uuid
-                     * @description The ID of the workspace
-                     */
-                    workspaceId: string;
-                    /** @description Version of the schema */
-                    version: string;
-                    /** @description Kind of resource this schema is for */
-                    kind: string;
-                    /** @description The JSON schema definition */
-                    jsonSchema: Record<string, never>;
-                };
-            };
+        content: {
+          "application/json": {
+            /** @example true */
+            success?: boolean;
+          };
         };
-        responses: {
-            /** @description Resource schema created successfully */
-            201: {
-                headers: {
-                    [name: string]: unknown;
-                };
-                content: {
-                    "application/json": {
-                        /** Format: uuid */
-                        id?: string;
-                        /** Format: uuid */
-                        workspaceId?: string;
-                        version?: string;
-                        kind?: string;
-                        jsonSchema?: Record<string, never>;
-                    };
-                };
-            };
-            /** @description Invalid request body */
-            400: {
-                headers: {
-                    [name: string]: unknown;
-                };
-                content: {
-                    "application/json": {
-                        error?: string;
-                    };
-                };
-            };
-            /** @description Schema already exists for this version and kind */
-            409: {
-                headers: {
-                    [name: string]: unknown;
-                };
-                content: {
-                    "application/json": {
-                        error?: string;
-                        /** Format: uuid */
-                        id?: string;
-                    };
-                };
-            };
+      };
+      /** @description Unauthorized */
+      401: {
+        headers: {
+          [name: string]: unknown;
         };
+        content?: never;
+      };
+      /** @description Permission denied */
+      403: {
+        headers: {
+          [name: string]: unknown;
+        };
+        content?: never;
+      };
+      /** @description Resource not found */
+      404: {
+        headers: {
+          [name: string]: unknown;
+        };
+        content: {
+          "application/json": {
+            /** @example Resource not found */
+            error?: string;
+          };
+        };
+      };
+      /** @description Internal server error */
+      500: {
+        headers: {
+          [name: string]: unknown;
+        };
+        content?: never;
+      };
     };
-    deleteResourceSchema: {
-        parameters: {
-            query?: never;
-            header?: never;
-            path: {
-                /** @description UUID of the schema to delete */
-                schemaId: string;
-            };
-            cookie?: never;
-        };
-        requestBody?: never;
-        responses: {
-            /** @description Schema deleted successfully */
-            200: {
-                headers: {
-                    [name: string]: unknown;
-                };
-                content: {
-                    "application/json": {
-                        /** Format: uuid */
-                        id?: string;
-                    };
-                };
-            };
-            /** @description Schema not found */
-            404: {
-                headers: {
-                    [name: string]: unknown;
-                };
-                content: {
-                    "application/json": {
-                        /** @example Schema not found */
-                        error?: string;
-                    };
-                };
-            };
-        };
+  };
+  getGroupedCounts: {
+    parameters: {
+      query?: never;
+      header?: never;
+      path: {
+        /** @description ID of the workspace */
+        workspaceId: string;
+      };
+      cookie?: never;
     };
-    getResource: {
-        parameters: {
-            query?: never;
-            header?: never;
-            path: {
-                /** @description The resource ID */
-                resourceId: string;
-            };
-            cookie?: never;
+    requestBody: {
+      content: {
+        "application/json": {
+          metadataKeys: string[];
+          allowNullCombinations: boolean;
         };
-        requestBody?: never;
-        responses: {
-            /** @description OK */
-            200: {
-                headers: {
-                    [name: string]: unknown;
-                };
-                content: {
-                    "application/json": components["schemas"]["ResourceWithVariablesAndMetadata"];
-                };
-            };
-            /** @description Unauthorized */
-            401: {
-                headers: {
-                    [name: string]: unknown;
-                };
-                content?: never;
-            };
-            /** @description Permission denied */
-            403: {
-                headers: {
-                    [name: string]: unknown;
-                };
-                content?: never;
-            };
-            /** @description Resource not found */
-            404: {
-                headers: {
-                    [name: string]: unknown;
-                };
-                content: {
-                    "application/json": {
-                        /** @example Resource not found */
-                        error: string;
-                    };
-                };
-            };
-        };
+      };
     };
-    deleteResource: {
-        parameters: {
-            query?: never;
-            header?: never;
-            path: {
-                /** @description The resource ID */
-                resourceId: string;
-            };
-            cookie?: never;
+    responses: {
+      /** @description Success */
+      200: {
+        headers: {
+          [name: string]: unknown;
         };
-        requestBody?: never;
-        responses: {
-            /** @description Resource deleted successfully */
-            200: {
-                headers: {
-                    [name: string]: unknown;
-                };
-                content: {
-                    "application/json": {
-                        success: boolean;
-                    };
-                };
-            };
-            /** @description Unauthorized */
-            401: {
-                headers: {
-                    [name: string]: unknown;
-                };
-                content?: never;
-            };
-            /** @description Permission denied */
-            403: {
-                headers: {
-                    [name: string]: unknown;
-                };
-                content?: never;
-            };
-            /** @description Resource not found */
-            404: {
-                headers: {
-                    [name: string]: unknown;
-                };
-                content: {
-                    "application/json": {
-                        error: string;
-                    };
-                };
-            };
+        content: {
+          "application/json": {
+            keys: string[];
+            combinations: {
+              metadata: {
+                [key: string]: string;
+              };
+              resources: number;
+            }[];
+          };
         };
+      };
     };
-    updateResource: {
-        parameters: {
-            query?: never;
-            header?: never;
-            path: {
-                resourceId: string;
-            };
-            cookie?: never;
-        };
-        requestBody: {
-            content: {
-                "application/json": {
-                    name?: string;
-                    version?: string;
-                    kind?: string;
-                    identifier?: string;
-                    workspaceId?: string;
-                    metadata?: components["schemas"]["MetadataMap"];
-                    variables?: components["schemas"]["DirectVariable"][];
-                };
-            };
-        };
-        responses: {
-            /** @description Resource updated successfully */
-            200: {
-                headers: {
-                    [name: string]: unknown;
-                };
-                content: {
-                    "application/json": components["schemas"]["ResourceWithVariablesAndMetadata"];
-                };
-            };
-            /** @description Unauthorized */
-            401: {
-                headers: {
-                    [name: string]: unknown;
-                };
-                content?: never;
-            };
-            /** @description Permission denied */
-            403: {
-                headers: {
-                    [name: string]: unknown;
-                };
-                content?: never;
-            };
-            /** @description Resource not found */
-            404: {
-                headers: {
-                    [name: string]: unknown;
-                };
-                content: {
-                    "application/json": {
-                        error: string;
-                    };
-                };
-            };
-        };
+  };
+  listResources: {
+    parameters: {
+      query?: never;
+      header?: never;
+      path: {
+        /** @description The ID of the workspace */
+        workspaceId: string;
+      };
+      cookie?: never;
     };
-    getReleaseTargets: {
-        parameters: {
-            query?: never;
-            header?: never;
-            path: {
-                /** @description The resource ID */
-                resourceId: string;
-            };
-            cookie?: never;
+    requestBody?: never;
+    responses: {
+      /** @description All resources */
+      200: {
+        headers: {
+          [name: string]: unknown;
         };
-        requestBody?: never;
-        responses: {
-            /** @description OK */
-            200: {
-                headers: {
-                    [name: string]: unknown;
-                };
-                content: {
-                    "application/json": components["schemas"]["ReleaseTarget"][];
-                };
-            };
+        content: {
+          "application/json": {
+            resources?: components["schemas"]["Resource"][];
+          };
         };
+      };
     };
-    upsertResource: {
-        parameters: {
-            query?: never;
-            header?: never;
-            path?: never;
-            cookie?: never;
-        };
-        requestBody: {
-            content: {
-                "application/json": {
-                    /** Format: uuid */
-                    workspaceId: string;
-                    name: string;
-                    kind: string;
-                    identifier: string;
-                    version: string;
-                    config: Record<string, never>;
-                    metadata?: {
-                        [key: string]: string;
-                    };
-                    variables?: components["schemas"]["Variable"][];
-                };
-            };
-        };
-        responses: {
-            /** @description The created or updated resource */
-            200: {
-                headers: {
-                    [name: string]: unknown;
-                };
-                content: {
-                    "application/json": components["schemas"]["Resource"];
-                };
-            };
-        };
+  };
+  listSystems: {
+    parameters: {
+      query?: never;
+      header?: never;
+      path: {
+        /** @description The ID of the workspace */
+        workspaceId: string;
+      };
+      cookie?: never;
     };
-    deleteEnvironmentByName: {
-        parameters: {
-            query?: never;
-            header?: never;
-            path: {
-                /** @description UUID of the system */
-                systemId: string;
-                /** @description Name of the environment */
-                name: string;
-            };
-            cookie?: never;
+    requestBody?: never;
+    responses: {
+      /** @description All systems */
+      200: {
+        headers: {
+          [name: string]: unknown;
         };
-        requestBody?: never;
-        responses: {
-            /** @description Environment deleted successfully */
-            200: {
-                headers: {
-                    [name: string]: unknown;
-                };
-                content?: never;
-            };
+        content: {
+          "application/json": {
+            data?: components["schemas"]["System"][];
+          };
         };
+      };
     };
-    getSystem: {
-        parameters: {
-            query?: never;
-            header?: never;
-            path: {
-                /** @description UUID of the system */
-                systemId: string;
-            };
-            cookie?: never;
-        };
-        requestBody?: never;
-        responses: {
-            /** @description System retrieved successfully */
-            200: {
-                headers: {
-                    [name: string]: unknown;
-                };
-                content: {
-                    "application/json": components["schemas"]["System"] & {
-                        environments?: components["schemas"]["Environment"][];
-                        deployments?: components["schemas"]["Deployment"][];
-                    };
-                };
-            };
-        };
+  };
+  getWorkspaceBySlug: {
+    parameters: {
+      query?: never;
+      header?: never;
+      path: {
+        workspaceSlug: string;
+      };
+      cookie?: never;
     };
-    deleteSystem: {
-        parameters: {
-            query?: never;
-            header?: never;
-            path: {
-                systemId: string;
-            };
-            cookie?: never;
+    requestBody?: never;
+    responses: {
+      /** @description Workspace found */
+      200: {
+        headers: {
+          [name: string]: unknown;
         };
-        requestBody?: never;
-        responses: {
-            /** @description System deleted successfully */
-            200: {
-                headers: {
-                    [name: string]: unknown;
-                };
-                content: {
-                    "application/json": {
-                        /** @example System deleted */
-                        message?: string;
-                    };
-                };
-            };
-            /** @description System not found */
-            404: {
-                headers: {
-                    [name: string]: unknown;
-                };
-                content: {
-                    "application/json": {
-                        /** @example System not found */
-                        error?: string;
-                    };
-                };
-            };
-            /** @description Internal server error */
-            500: {
-                headers: {
-                    [name: string]: unknown;
-                };
-                content: {
-                    "application/json": {
-                        /** @example Internal server error */
-                        error?: string;
-                    };
-                };
-            };
+        content: {
+          "application/json": components["schemas"]["Workspace"];
         };
+      };
+      /** @description Workspace not found */
+      404: {
+        headers: {
+          [name: string]: unknown;
+        };
+        content: {
+          "application/json": {
+            error?: string;
+          };
+        };
+      };
+      /** @description Internal server error */
+      500: {
+        headers: {
+          [name: string]: unknown;
+        };
+        content: {
+          "application/json": {
+            error?: string;
+          };
+        };
+      };
     };
-    updateSystem: {
-        parameters: {
-            query?: never;
-            header?: never;
-            path: {
-                /** @description UUID of the system */
-                systemId: string;
-            };
-            cookie?: never;
-        };
-        requestBody: {
-            content: {
-                "application/json": {
-                    /** @description Name of the system */
-                    name?: string;
-                    /** @description Slug of the system */
-                    slug?: string;
-                    /** @description Description of the system */
-                    description?: string;
-                    /**
-                     * Format: uuid
-                     * @description UUID of the workspace
-                     */
-                    workspaceId?: string;
-                };
-            };
-        };
-        responses: {
-            /** @description System updated successfully */
-            200: {
-                headers: {
-                    [name: string]: unknown;
-                };
-                content: {
-                    "application/json": components["schemas"]["System"];
-                };
-            };
-            /** @description System not found */
-            404: {
-                headers: {
-                    [name: string]: unknown;
-                };
-                content: {
-                    "application/json": {
-                        /** @example System not found */
-                        error?: string;
-                    };
-                };
-            };
-            /** @description Internal server error */
-            500: {
-                headers: {
-                    [name: string]: unknown;
-                };
-                content: {
-                    "application/json": {
-                        /** @example Internal server error */
-                        error?: string;
-                    };
-                };
-            };
-        };
-    };
-    createSystem: {
-        parameters: {
-            query?: never;
-            header?: never;
-            path?: never;
-            cookie?: never;
-        };
-        requestBody?: {
-            content: {
-                "application/json": {
-                    /**
-                     * Format: uuid
-                     * @description The workspace ID of the system
-                     */
-                    workspaceId: string;
-                    /** @description The name of the system */
-                    name: string;
-                    /** @description The slug of the system */
-                    slug: string;
-                    /** @description The description of the system */
-                    description?: string;
-                };
-            };
-        };
-        responses: {
-            /** @description System updated successfully */
-            200: {
-                headers: {
-                    [name: string]: unknown;
-                };
-                content: {
-                    "application/json": components["schemas"]["System"];
-                };
-            };
-            /** @description System created successfully */
-            201: {
-                headers: {
-                    [name: string]: unknown;
-                };
-                content: {
-                    "application/json": components["schemas"]["System"];
-                };
-            };
-            /** @description Bad request */
-            400: {
-                headers: {
-                    [name: string]: unknown;
-                };
-                content: {
-                    "application/json": {
-                        error?: {
-                            /** @enum {string} */
-                            code: "invalid_type" | "invalid_literal" | "custom";
-                            message: string;
-                            path: (string | number)[];
-                        }[];
-                    };
-                };
-            };
-            /** @description Internal server error */
-            500: {
-                headers: {
-                    [name: string]: unknown;
-                };
-                content: {
-                    "application/json": {
-                        /** @example Internal Server Error */
-                        error?: string;
-                    };
-                };
-            };
-        };
-    };
-    listDeployments: {
-        parameters: {
-            query?: never;
-            header?: never;
-            path: {
-                /** @description The ID of the workspace */
-                workspaceId: string;
-            };
-            cookie?: never;
-        };
-        requestBody?: never;
-        responses: {
-            /** @description All deployments */
-            200: {
-                headers: {
-                    [name: string]: unknown;
-                };
-                content: {
-                    "application/json": {
-                        data?: components["schemas"]["Deployment"][];
-                    };
-                };
-            };
-        };
-    };
-    listEnvironments: {
-        parameters: {
-            query?: never;
-            header?: never;
-            path: {
-                /** @description The ID of the workspace */
-                workspaceId: string;
-            };
-            cookie?: never;
-        };
-        requestBody?: never;
-        responses: {
-            /** @description All environments */
-            200: {
-                headers: {
-                    [name: string]: unknown;
-                };
-                content: {
-                    "application/json": {
-                        data?: components["schemas"]["Environment"][];
-                    };
-                };
-            };
-        };
-    };
-    getEventsByAction: {
-        parameters: {
-            query?: never;
-            header?: never;
-            path: {
-                /** @description The ID of the workspace */
-                workspaceId: string;
-                action: string;
-            };
-            cookie?: never;
-        };
-        requestBody?: never;
-        responses: {
-            /** @description Events */
-            200: {
-                headers: {
-                    [name: string]: unknown;
-                };
-                content: {
-                    "application/json": components["schemas"]["Event"][];
-                };
-            };
-            /** @description Workspace not found */
-            404: {
-                headers: {
-                    [name: string]: unknown;
-                };
-                content: {
-                    "application/json": {
-                        error: string;
-                    };
-                };
-            };
-            /** @description Internal server error */
-            500: {
-                headers: {
-                    [name: string]: unknown;
-                };
-                content: {
-                    "application/json": {
-                        error: string;
-                    };
-                };
-            };
-        };
-    };
-    getWorkspace: {
-        parameters: {
-            query?: never;
-            header?: never;
-            path: {
-                workspaceId: string;
-            };
-            cookie?: never;
-        };
-        requestBody?: never;
-        responses: {
-            /** @description Workspace found */
-            200: {
-                headers: {
-                    [name: string]: unknown;
-                };
-                content: {
-                    "application/json": components["schemas"]["Workspace"];
-                };
-            };
-            /** @description Workspace not found */
-            404: {
-                headers: {
-                    [name: string]: unknown;
-                };
-                content: {
-                    "application/json": {
-                        error?: string;
-                    };
-                };
-            };
-            /** @description Internal server error */
-            500: {
-                headers: {
-                    [name: string]: unknown;
-                };
-                content: {
-                    "application/json": {
-                        error?: string;
-                    };
-                };
-            };
-        };
-    };
-    deletePolicyByName: {
-        parameters: {
-            query?: never;
-            header?: never;
-            path: {
-                /** @description ID of the workspace */
-                workspaceId: string;
-                /** @description Name of the policy */
-                name: string;
-            };
-            cookie?: never;
-        };
-        requestBody?: never;
-        responses: {
-            /** @description Successfully deleted the policy */
-            200: {
-                headers: {
-                    [name: string]: unknown;
-                };
-                content: {
-                    "application/json": {
-                        /** @example true */
-                        success?: boolean;
-                    };
-                };
-            };
-            /** @description Unauthorized */
-            401: {
-                headers: {
-                    [name: string]: unknown;
-                };
-                content?: never;
-            };
-            /** @description Permission denied */
-            403: {
-                headers: {
-                    [name: string]: unknown;
-                };
-                content?: never;
-            };
-            /** @description Policy not found */
-            404: {
-                headers: {
-                    [name: string]: unknown;
-                };
-                content: {
-                    "application/json": {
-                        /** @example Policy not found */
-                        error?: string;
-                    };
-                };
-            };
-            /** @description Internal server error */
-            500: {
-                headers: {
-                    [name: string]: unknown;
-                };
-                content?: never;
-            };
-        };
-    };
-    upsertResourceProvider: {
-        parameters: {
-            query?: never;
-            header?: never;
-            path: {
-                /** @description Name of the workspace */
-                workspaceId: string;
-                /** @description Name of the resource provider */
-                name: string;
-            };
-            cookie?: never;
-        };
-        requestBody?: never;
-        responses: {
-            /** @description Successfully retrieved or created the resource provider */
-            200: {
-                headers: {
-                    [name: string]: unknown;
-                };
-                content: {
-                    "application/json": {
-                        id: string;
-                        name: string;
-                        workspaceId: string;
-                    };
-                };
-            };
-            /** @description Unauthorized */
-            401: {
-                headers: {
-                    [name: string]: unknown;
-                };
-                content?: never;
-            };
-            /** @description Permission denied */
-            403: {
-                headers: {
-                    [name: string]: unknown;
-                };
-                content?: never;
-            };
-            /** @description Workspace not found */
-            404: {
-                headers: {
-                    [name: string]: unknown;
-                };
-                content?: never;
-            };
-            /** @description Internal server error */
-            500: {
-                headers: {
-                    [name: string]: unknown;
-                };
-                content?: never;
-            };
-        };
-    };
-    getResourceByIdentifier: {
-        parameters: {
-            query?: never;
-            header?: never;
-            path: {
-                /** @description ID of the workspace */
-                workspaceId: string;
-                /** @description Identifier of the resource */
-                identifier: string;
-            };
-            cookie?: never;
-        };
-        requestBody?: never;
-        responses: {
-            /** @description Successfully retrieved the resource */
-            200: {
-                headers: {
-                    [name: string]: unknown;
-                };
-                content: {
-                    "application/json": components["schemas"]["ResourceWithVariablesAndMetadata"] & {
-                        relationships?: {
-                            [key: string]: {
-                                ruleId: string;
-                                type: string;
-                                reference: string;
-                                target: components["schemas"]["Resource"];
-                            };
-                        };
-                    };
-                };
-            };
-            /** @description Unauthorized */
-            401: {
-                headers: {
-                    [name: string]: unknown;
-                };
-                content?: never;
-            };
-            /** @description Permission denied */
-            403: {
-                headers: {
-                    [name: string]: unknown;
-                };
-                content?: never;
-            };
-            /** @description Resource not found */
-            404: {
-                headers: {
-                    [name: string]: unknown;
-                };
-                content: {
-                    "application/json": {
-                        /** @example Resource not found */
-                        error?: string;
-                    };
-                };
-            };
-            /** @description Internal server error */
-            500: {
-                headers: {
-                    [name: string]: unknown;
-                };
-                content?: never;
-            };
-        };
-    };
-    deleteResourceByIdentifier: {
-        parameters: {
-            query?: never;
-            header?: never;
-            path: {
-                /** @description ID of the workspace */
-                workspaceId: string;
-                /** @description Identifier of the resource */
-                identifier: string;
-            };
-            cookie?: never;
-        };
-        requestBody?: never;
-        responses: {
-            /** @description Successfully deleted the resource */
-            200: {
-                headers: {
-                    [name: string]: unknown;
-                };
-                content: {
-                    "application/json": {
-                        /** @example true */
-                        success?: boolean;
-                    };
-                };
-            };
-            /** @description Unauthorized */
-            401: {
-                headers: {
-                    [name: string]: unknown;
-                };
-                content?: never;
-            };
-            /** @description Permission denied */
-            403: {
-                headers: {
-                    [name: string]: unknown;
-                };
-                content?: never;
-            };
-            /** @description Resource not found */
-            404: {
-                headers: {
-                    [name: string]: unknown;
-                };
-                content: {
-                    "application/json": {
-                        /** @example Resource not found */
-                        error?: string;
-                    };
-                };
-            };
-            /** @description Internal server error */
-            500: {
-                headers: {
-                    [name: string]: unknown;
-                };
-                content?: never;
-            };
-        };
-    };
-    getGroupedCounts: {
-        parameters: {
-            query?: never;
-            header?: never;
-            path: {
-                /** @description ID of the workspace */
-                workspaceId: string;
-            };
-            cookie?: never;
-        };
-        requestBody: {
-            content: {
-                "application/json": {
-                    metadataKeys: string[];
-                    allowNullCombinations: boolean;
-                };
-            };
-        };
-        responses: {
-            /** @description Success */
-            200: {
-                headers: {
-                    [name: string]: unknown;
-                };
-                content: {
-                    "application/json": {
-                        keys: string[];
-                        combinations: {
-                            metadata: {
-                                [key: string]: string;
-                            };
-                            resources: number;
-                        }[];
-                    };
-                };
-            };
-        };
-    };
-    listResources: {
-        parameters: {
-            query?: never;
-            header?: never;
-            path: {
-                /** @description The ID of the workspace */
-                workspaceId: string;
-            };
-            cookie?: never;
-        };
-        requestBody?: never;
-        responses: {
-            /** @description All resources */
-            200: {
-                headers: {
-                    [name: string]: unknown;
-                };
-                content: {
-                    "application/json": {
-                        resources?: components["schemas"]["Resource"][];
-                    };
-                };
-            };
-        };
-    };
-    listSystems: {
-        parameters: {
-            query?: never;
-            header?: never;
-            path: {
-                /** @description The ID of the workspace */
-                workspaceId: string;
-            };
-            cookie?: never;
-        };
-        requestBody?: never;
-        responses: {
-            /** @description All systems */
-            200: {
-                headers: {
-                    [name: string]: unknown;
-                };
-                content: {
-                    "application/json": {
-                        data?: components["schemas"]["System"][];
-                    };
-                };
-            };
-        };
-    };
-    getWorkspaceBySlug: {
-        parameters: {
-            query?: never;
-            header?: never;
-            path: {
-                workspaceSlug: string;
-            };
-            cookie?: never;
-        };
-        requestBody?: never;
-        responses: {
-            /** @description Workspace found */
-            200: {
-                headers: {
-                    [name: string]: unknown;
-                };
-                content: {
-                    "application/json": components["schemas"]["Workspace"];
-                };
-            };
-            /** @description Workspace not found */
-            404: {
-                headers: {
-                    [name: string]: unknown;
-                };
-                content: {
-                    "application/json": {
-                        error?: string;
-                    };
-                };
-            };
-            /** @description Internal server error */
-            500: {
-                headers: {
-                    [name: string]: unknown;
-                };
-                content: {
-                    "application/json": {
-                        error?: string;
-                    };
-                };
-            };
-        };
-    };
+  };
 }
 type WithRequired<T, K extends keyof T> = T & {
-    [P in K]-?: T[P];
+  [P in K]-?: T[P];
 };

--- a/e2e/api/schema.ts
+++ b/e2e/api/schema.ts
@@ -4,4438 +4,4396 @@
  */
 
 export interface paths {
-  "/api/v1/cloud-locations/{provider}": {
-    parameters: {
-      query?: never;
-      header?: never;
-      path?: never;
-      cookie?: never;
+    "/api/v1/cloud-locations/{provider}": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        /**
+         * Get all regions for a specific cloud provider
+         * @description Returns geographic data for all regions of a specific cloud provider
+         */
+        get: operations["getCloudProviderRegions"];
+        put?: never;
+        post?: never;
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
     };
-    /**
-     * Get all regions for a specific cloud provider
-     * @description Returns geographic data for all regions of a specific cloud provider
-     */
-    get: operations["getCloudProviderRegions"];
-    put?: never;
-    post?: never;
-    delete?: never;
-    options?: never;
-    head?: never;
-    patch?: never;
-    trace?: never;
-  };
-  "/v1/deployment-version-channels": {
-    parameters: {
-      query?: never;
-      header?: never;
-      path?: never;
-      cookie?: never;
+    "/v1/deployment-version-channels": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        get?: never;
+        put?: never;
+        /** Create a deployment version channel */
+        post: operations["createDeploymentVersionChannel"];
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
     };
-    get?: never;
-    put?: never;
-    /** Create a deployment version channel */
-    post: operations["createDeploymentVersionChannel"];
-    delete?: never;
-    options?: never;
-    head?: never;
-    patch?: never;
-    trace?: never;
-  };
-  "/v1/deployment-versions/{deploymentVersionId}": {
-    parameters: {
-      query?: never;
-      header?: never;
-      path?: never;
-      cookie?: never;
+    "/v1/deployment-versions/{deploymentVersionId}": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        get?: never;
+        put?: never;
+        post?: never;
+        delete?: never;
+        options?: never;
+        head?: never;
+        /** Updates a deployment version */
+        patch: operations["updateDeploymentVersion"];
+        trace?: never;
     };
-    get?: never;
-    put?: never;
-    post?: never;
-    delete?: never;
-    options?: never;
-    head?: never;
-    /** Updates a deployment version */
-    patch: operations["updateDeploymentVersion"];
-    trace?: never;
-  };
-  "/v1/deployment-versions": {
-    parameters: {
-      query?: never;
-      header?: never;
-      path?: never;
-      cookie?: never;
+    "/v1/deployment-versions": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        get?: never;
+        put?: never;
+        /** Upserts a deployment version */
+        post: operations["upsertDeploymentVersion"];
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
     };
-    get?: never;
-    put?: never;
-    /** Upserts a deployment version */
-    post: operations["upsertDeploymentVersion"];
-    delete?: never;
-    options?: never;
-    head?: never;
-    patch?: never;
-    trace?: never;
-  };
-  "/v1/deployments/{deploymentId}/deployment-version-channels/name/{name}": {
-    parameters: {
-      query?: never;
-      header?: never;
-      path?: never;
-      cookie?: never;
+    "/v1/deployments/{deploymentId}/deployment-version-channels/name/{name}": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        get?: never;
+        put?: never;
+        post?: never;
+        /** Delete a deployment version channel */
+        delete: operations["deleteDeploymentVersionChannel"];
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
     };
-    get?: never;
-    put?: never;
-    post?: never;
-    /** Delete a deployment version channel */
-    delete: operations["deleteDeploymentVersionChannel"];
-    options?: never;
-    head?: never;
-    patch?: never;
-    trace?: never;
-  };
-  "/v1/deployments/{deploymentId}": {
-    parameters: {
-      query?: never;
-      header?: never;
-      path?: never;
-      cookie?: never;
+    "/v1/deployments/{deploymentId}": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        /** Get a deployment */
+        get: operations["getDeployment"];
+        put?: never;
+        post?: never;
+        /** Delete a deployment */
+        delete: operations["deleteDeployment"];
+        options?: never;
+        head?: never;
+        /** Update a deployment */
+        patch: operations["updateDeployment"];
+        trace?: never;
     };
-    /** Get a deployment */
-    get: operations["getDeployment"];
-    put?: never;
-    post?: never;
-    /** Delete a deployment */
-    delete: operations["deleteDeployment"];
-    options?: never;
-    head?: never;
-    /** Update a deployment */
-    patch: operations["updateDeployment"];
-    trace?: never;
-  };
-  "/v1/deployments/{deploymentId}/release-channels/name/{name}": {
-    parameters: {
-      query?: never;
-      header?: never;
-      path?: never;
-      cookie?: never;
+    "/v1/deployments/{deploymentId}/release-channels/name/{name}": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        get?: never;
+        put?: never;
+        post?: never;
+        /** Delete a release channel */
+        delete: operations["deleteReleaseChannel"];
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
     };
-    get?: never;
-    put?: never;
-    post?: never;
-    /** Delete a release channel */
-    delete: operations["deleteReleaseChannel"];
-    options?: never;
-    head?: never;
-    patch?: never;
-    trace?: never;
-  };
-  "/v1/deployments/{deploymentId}/resources": {
-    parameters: {
-      query?: never;
-      header?: never;
-      path?: never;
-      cookie?: never;
+    "/v1/deployments/{deploymentId}/resources": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        /** Get resources for a deployment */
+        get: operations["getResourcesForDeployment"];
+        put?: never;
+        post?: never;
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
     };
-    /** Get resources for a deployment */
-    get: operations["getResourcesForDeployment"];
-    put?: never;
-    post?: never;
-    delete?: never;
-    options?: never;
-    head?: never;
-    patch?: never;
-    trace?: never;
-  };
-  "/v1/deployments/{deploymentId}/variables": {
-    parameters: {
-      query?: never;
-      header?: never;
-      path?: never;
-      cookie?: never;
+    "/v1/deployments/{deploymentId}/variables": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        /** Get all variables for a deployment */
+        get: operations["getDeploymentVariables"];
+        put?: never;
+        /** Create a new variable for a deployment */
+        post: operations["createDeploymentVariable"];
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
     };
-    /** Get all variables for a deployment */
-    get: operations["getDeploymentVariables"];
-    put?: never;
-    /** Create a new variable for a deployment */
-    post: operations["createDeploymentVariable"];
-    delete?: never;
-    options?: never;
-    head?: never;
-    patch?: never;
-    trace?: never;
-  };
-  "/v1/deployments": {
-    parameters: {
-      query?: never;
-      header?: never;
-      path?: never;
-      cookie?: never;
+    "/v1/deployments": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        get?: never;
+        put?: never;
+        /** Create a deployment */
+        post: operations["createDeployment"];
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
     };
-    get?: never;
-    put?: never;
-    /** Create a deployment */
-    post: operations["createDeployment"];
-    delete?: never;
-    options?: never;
-    head?: never;
-    patch?: never;
-    trace?: never;
-  };
-  "/v1/environments/{environmentId}": {
-    parameters: {
-      query?: never;
-      header?: never;
-      path?: never;
-      cookie?: never;
+    "/v1/environments/{environmentId}": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        /** Get an environment */
+        get: operations["getEnvironment"];
+        put?: never;
+        post?: never;
+        /** Delete an environment */
+        delete: operations["deleteEnvironment"];
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
     };
-    /** Get an environment */
-    get: operations["getEnvironment"];
-    put?: never;
-    post?: never;
-    /** Delete an environment */
-    delete: operations["deleteEnvironment"];
-    options?: never;
-    head?: never;
-    patch?: never;
-    trace?: never;
-  };
-  "/v1/environments/{environmentId}/resources": {
-    parameters: {
-      query?: never;
-      header?: never;
-      path?: never;
-      cookie?: never;
+    "/v1/environments/{environmentId}/resources": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        /** Get resources for an environment */
+        get: operations["getResourcesForEnvironment"];
+        put?: never;
+        post?: never;
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
     };
-    /** Get resources for an environment */
-    get: operations["getResourcesForEnvironment"];
-    put?: never;
-    post?: never;
-    delete?: never;
-    options?: never;
-    head?: never;
-    patch?: never;
-    trace?: never;
-  };
-  "/v1/environments": {
-    parameters: {
-      query?: never;
-      header?: never;
-      path?: never;
-      cookie?: never;
+    "/v1/environments": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        get?: never;
+        put?: never;
+        /** Create an environment */
+        post: operations["createEnvironment"];
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
     };
-    get?: never;
-    put?: never;
-    /** Create an environment */
-    post: operations["createEnvironment"];
-    delete?: never;
-    options?: never;
-    head?: never;
-    patch?: never;
-    trace?: never;
-  };
-  "/v1/job-agents/{agentId}/jobs/running": {
-    parameters: {
-      query?: never;
-      header?: never;
-      path?: never;
-      cookie?: never;
+    "/v1/job-agents/{agentId}/jobs/running": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        /** Get a agents running jobs */
+        get: operations["getAgentRunningJobs"];
+        put?: never;
+        post?: never;
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
     };
-    /** Get a agents running jobs */
-    get: operations["getAgentRunningJobs"];
-    put?: never;
-    post?: never;
-    delete?: never;
-    options?: never;
-    head?: never;
-    patch?: never;
-    trace?: never;
-  };
-  "/v1/job-agents/{agentId}/queue/acknowledge": {
-    parameters: {
-      query?: never;
-      header?: never;
-      path?: never;
-      cookie?: never;
+    "/v1/job-agents/{agentId}/queue/acknowledge": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        get?: never;
+        put?: never;
+        /**
+         * Acknowledge a job for an agent
+         * @description Marks a job as acknowledged by the agent
+         */
+        post: operations["acknowledgeAgentJob"];
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
     };
-    get?: never;
-    put?: never;
-    /**
-     * Acknowledge a job for an agent
-     * @description Marks a job as acknowledged by the agent
-     */
-    post: operations["acknowledgeAgentJob"];
-    delete?: never;
-    options?: never;
-    head?: never;
-    patch?: never;
-    trace?: never;
-  };
-  "/v1/job-agents/{agentId}/queue/next": {
-    parameters: {
-      query?: never;
-      header?: never;
-      path?: never;
-      cookie?: never;
+    "/v1/job-agents/{agentId}/queue/next": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        /** Get the next jobs */
+        get: operations["getNextJobs"];
+        put?: never;
+        post?: never;
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
     };
-    /** Get the next jobs */
-    get: operations["getNextJobs"];
-    put?: never;
-    post?: never;
-    delete?: never;
-    options?: never;
-    head?: never;
-    patch?: never;
-    trace?: never;
-  };
-  "/v1/job-agents/name": {
-    parameters: {
-      query?: never;
-      header?: never;
-      path?: never;
-      cookie?: never;
+    "/v1/job-agents/name": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        get?: never;
+        put?: never;
+        post?: never;
+        delete?: never;
+        options?: never;
+        head?: never;
+        /** Upserts the agent */
+        patch: operations["upsertJobAgent"];
+        trace?: never;
     };
-    get?: never;
-    put?: never;
-    post?: never;
-    delete?: never;
-    options?: never;
-    head?: never;
-    /** Upserts the agent */
-    patch: operations["upsertJobAgent"];
-    trace?: never;
-  };
-  "/v1/jobs/{jobId}/acknowledge": {
-    parameters: {
-      query?: never;
-      header?: never;
-      path?: never;
-      cookie?: never;
+    "/v1/jobs/{jobId}/acknowledge": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        get?: never;
+        put?: never;
+        /** Acknowledge a job */
+        post: operations["acknowledgeJob"];
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
     };
-    get?: never;
-    put?: never;
-    /** Acknowledge a job */
-    post: operations["acknowledgeJob"];
-    delete?: never;
-    options?: never;
-    head?: never;
-    patch?: never;
-    trace?: never;
-  };
-  "/v1/jobs/{jobId}": {
-    parameters: {
-      query?: never;
-      header?: never;
-      path?: never;
-      cookie?: never;
+    "/v1/jobs/{jobId}": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        /** Get a Job */
+        get: operations["getJob"];
+        put?: never;
+        post?: never;
+        delete?: never;
+        options?: never;
+        head?: never;
+        /** Update a job */
+        patch: operations["updateJob"];
+        trace?: never;
     };
-    /** Get a Job */
-    get: operations["getJob"];
-    put?: never;
-    post?: never;
-    delete?: never;
-    options?: never;
-    head?: never;
-    /** Update a job */
-    patch: operations["updateJob"];
-    trace?: never;
-  };
-  "/v1/policies/{policyId}": {
-    parameters: {
-      query?: never;
-      header?: never;
-      path?: never;
-      cookie?: never;
+    "/v1/policies/{policyId}": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        get?: never;
+        put?: never;
+        post?: never;
+        /** Delete a policy */
+        delete: operations["deletePolicy"];
+        options?: never;
+        head?: never;
+        /** Update a policy */
+        patch: operations["updatePolicy"];
+        trace?: never;
     };
-    get?: never;
-    put?: never;
-    post?: never;
-    /** Delete a policy */
-    delete: operations["deletePolicy"];
-    options?: never;
-    head?: never;
-    /** Update a policy */
-    patch: operations["updatePolicy"];
-    trace?: never;
-  };
-  "/v1/policies/{policyId}/release-targets": {
-    parameters: {
-      query?: never;
-      header?: never;
-      path?: never;
-      cookie?: never;
+    "/v1/policies/{policyId}/release-targets": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        /** Get release targets for a policy */
+        get: operations["getReleaseTargetsForPolicy"];
+        put?: never;
+        post?: never;
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
     };
-    /** Get release targets for a policy */
-    get: operations["getReleaseTargetsForPolicy"];
-    put?: never;
-    post?: never;
-    delete?: never;
-    options?: never;
-    head?: never;
-    patch?: never;
-    trace?: never;
-  };
-  "/v1/policies": {
-    parameters: {
-      query?: never;
-      header?: never;
-      path?: never;
-      cookie?: never;
+    "/v1/policies": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        get?: never;
+        put?: never;
+        /** Upsert a policy */
+        post: operations["upsertPolicy"];
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
     };
-    get?: never;
-    put?: never;
-    /** Upsert a policy */
-    post: operations["upsertPolicy"];
-    delete?: never;
-    options?: never;
-    head?: never;
-    patch?: never;
-    trace?: never;
-  };
-  "/v1/relationship/job-to-resource": {
-    parameters: {
-      query?: never;
-      header?: never;
-      path?: never;
-      cookie?: never;
+    "/v1/relationship/job-to-resource": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        get?: never;
+        put?: never;
+        /** Create a relationship between a job and a resource */
+        post: operations["createJobToResourceRelationship"];
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
     };
-    get?: never;
-    put?: never;
-    /** Create a relationship between a job and a resource */
-    post: operations["createJobToResourceRelationship"];
-    delete?: never;
-    options?: never;
-    head?: never;
-    patch?: never;
-    trace?: never;
-  };
-  "/v1/relationship/resource-to-resource": {
-    parameters: {
-      query?: never;
-      header?: never;
-      path?: never;
-      cookie?: never;
+    "/v1/relationship/resource-to-resource": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        get?: never;
+        put?: never;
+        /** Create a relationship between two resources */
+        post: operations["createResourceToResourceRelationship"];
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
     };
-    get?: never;
-    put?: never;
-    /** Create a relationship between two resources */
-    post: operations["createResourceToResourceRelationship"];
-    delete?: never;
-    options?: never;
-    head?: never;
-    patch?: never;
-    trace?: never;
-  };
-  "/v1/release-channels": {
-    parameters: {
-      query?: never;
-      header?: never;
-      path?: never;
-      cookie?: never;
+    "/v1/release-channels": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        get?: never;
+        put?: never;
+        /** Create a release channel */
+        post: operations["createReleaseChannel"];
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
     };
-    get?: never;
-    put?: never;
-    /** Create a release channel */
-    post: operations["createReleaseChannel"];
-    delete?: never;
-    options?: never;
-    head?: never;
-    patch?: never;
-    trace?: never;
-  };
-  "/v1/release-targets/{releaseTargetId}/releases": {
-    parameters: {
-      query?: never;
-      header?: never;
-      path?: never;
-      cookie?: never;
+    "/v1/release-targets/{releaseTargetId}/releases": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        /** Get the latest 100 releases for a release target */
+        get: operations["getReleaseTargetReleases"];
+        put?: never;
+        post?: never;
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
     };
-    /** Get the latest 100 releases for a release target */
-    get: operations["getReleaseTargetReleases"];
-    put?: never;
-    post?: never;
-    delete?: never;
-    options?: never;
-    head?: never;
-    patch?: never;
-    trace?: never;
-  };
-  "/v1/releases/{releaseId}": {
-    parameters: {
-      query?: never;
-      header?: never;
-      path?: never;
-      cookie?: never;
+    "/v1/releases/{releaseId}": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        get?: never;
+        put?: never;
+        post?: never;
+        delete?: never;
+        options?: never;
+        head?: never;
+        /** Updates a release */
+        patch: operations["updateRelease"];
+        trace?: never;
     };
-    get?: never;
-    put?: never;
-    post?: never;
-    delete?: never;
-    options?: never;
-    head?: never;
-    /** Updates a release */
-    patch: operations["updateRelease"];
-    trace?: never;
-  };
-  "/v1/releases": {
-    parameters: {
-      query?: never;
-      header?: never;
-      path?: never;
-      cookie?: never;
+    "/v1/releases": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        get?: never;
+        put?: never;
+        /** Upserts a release */
+        post: operations["upsertRelease"];
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
     };
-    get?: never;
-    put?: never;
-    /** Upserts a release */
-    post: operations["upsertRelease"];
-    delete?: never;
-    options?: never;
-    head?: never;
-    patch?: never;
-    trace?: never;
-  };
-  "/v1/resource-providers/{providerId}/set": {
-    parameters: {
-      query?: never;
-      header?: never;
-      path?: never;
-      cookie?: never;
+    "/v1/resource-providers/{providerId}/set": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        get?: never;
+        put?: never;
+        post?: never;
+        delete?: never;
+        options?: never;
+        head?: never;
+        /** Sets the resource for a provider. */
+        patch: operations["setResourceProvidersResources"];
+        trace?: never;
     };
-    get?: never;
-    put?: never;
-    post?: never;
-    delete?: never;
-    options?: never;
-    head?: never;
-    /** Sets the resource for a provider. */
-    patch: operations["setResourceProvidersResources"];
-    trace?: never;
-  };
-  "/v1/resource-relationship-rules/{ruleId}": {
-    parameters: {
-      query?: never;
-      header?: never;
-      path?: never;
-      cookie?: never;
+    "/v1/resource-relationship-rules/{ruleId}": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        get?: never;
+        put?: never;
+        post?: never;
+        delete?: never;
+        options?: never;
+        head?: never;
+        /** Update a resource relationship rule */
+        patch: operations["updateResourceRelationshipRule"];
+        trace?: never;
     };
-    get?: never;
-    put?: never;
-    post?: never;
-    delete?: never;
-    options?: never;
-    head?: never;
-    /** Update a resource relationship rule */
-    patch: operations["updateResourceRelationshipRule"];
-    trace?: never;
-  };
-  "/v1/resource-relationship-rules": {
-    parameters: {
-      query?: never;
-      header?: never;
-      path?: never;
-      cookie?: never;
+    "/v1/resource-relationship-rules": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        get?: never;
+        put?: never;
+        /** Create a resource relationship rule */
+        post: operations["createResourceRelationshipRule"];
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
     };
-    get?: never;
-    put?: never;
-    /** Create a resource relationship rule */
-    post: operations["createResourceRelationshipRule"];
-    delete?: never;
-    options?: never;
-    head?: never;
-    patch?: never;
-    trace?: never;
-  };
-  "/v1/resource-schemas": {
-    parameters: {
-      query?: never;
-      header?: never;
-      path?: never;
-      cookie?: never;
+    "/v1/resource-schemas": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        get?: never;
+        put?: never;
+        /** Create a resource schema */
+        post: operations["createResourceSchema"];
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
     };
-    get?: never;
-    put?: never;
-    /** Create a resource schema */
-    post: operations["createResourceSchema"];
-    delete?: never;
-    options?: never;
-    head?: never;
-    patch?: never;
-    trace?: never;
-  };
-  "/v1/resource-schemas/{schemaId}": {
-    parameters: {
-      query?: never;
-      header?: never;
-      path?: never;
-      cookie?: never;
+    "/v1/resource-schemas/{schemaId}": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        get?: never;
+        put?: never;
+        post?: never;
+        /** Delete a resource schema */
+        delete: operations["deleteResourceSchema"];
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
     };
-    get?: never;
-    put?: never;
-    post?: never;
-    /** Delete a resource schema */
-    delete: operations["deleteResourceSchema"];
-    options?: never;
-    head?: never;
-    patch?: never;
-    trace?: never;
-  };
-  "/v1/resources/{resourceId}": {
-    parameters: {
-      query?: never;
-      header?: never;
-      path?: never;
-      cookie?: never;
+    "/v1/resources/{resourceId}": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        /** Get a resource */
+        get: operations["getResource"];
+        put?: never;
+        post?: never;
+        /** Delete a resource */
+        delete: operations["deleteResource"];
+        options?: never;
+        head?: never;
+        /** Update a resource */
+        patch: operations["updateResource"];
+        trace?: never;
     };
-    /** Get a resource */
-    get: operations["getResource"];
-    put?: never;
-    post?: never;
-    /** Delete a resource */
-    delete: operations["deleteResource"];
-    options?: never;
-    head?: never;
-    /** Update a resource */
-    patch: operations["updateResource"];
-    trace?: never;
-  };
-  "/v1/resources/{resourceId}/release-targets": {
-    parameters: {
-      query?: never;
-      header?: never;
-      path?: never;
-      cookie?: never;
+    "/v1/resources/{resourceId}/release-targets": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        /** Get release targets for a resource */
+        get: operations["getReleaseTargets"];
+        put?: never;
+        post?: never;
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
     };
-    /** Get release targets for a resource */
-    get: operations["getReleaseTargets"];
-    put?: never;
-    post?: never;
-    delete?: never;
-    options?: never;
-    head?: never;
-    patch?: never;
-    trace?: never;
-  };
-  "/v1/resources": {
-    parameters: {
-      query?: never;
-      header?: never;
-      path?: never;
-      cookie?: never;
+    "/v1/resources": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        get?: never;
+        put?: never;
+        /** Create or update a resource */
+        post: operations["upsertResource"];
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
     };
-    get?: never;
-    put?: never;
-    /** Create or update a resource */
-    post: operations["upsertResource"];
-    delete?: never;
-    options?: never;
-    head?: never;
-    patch?: never;
-    trace?: never;
-  };
-  "/v1/systems/{systemId}/environments/{name}": {
-    parameters: {
-      query?: never;
-      header?: never;
-      path?: never;
-      cookie?: never;
+    "/v1/systems/{systemId}/environments/{name}": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        get?: never;
+        put?: never;
+        post?: never;
+        /** Delete an environment */
+        delete: operations["deleteEnvironmentByName"];
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
     };
-    get?: never;
-    put?: never;
-    post?: never;
-    /** Delete an environment */
-    delete: operations["deleteEnvironmentByName"];
-    options?: never;
-    head?: never;
-    patch?: never;
-    trace?: never;
-  };
-  "/v1/systems/{systemId}": {
-    parameters: {
-      query?: never;
-      header?: never;
-      path?: never;
-      cookie?: never;
+    "/v1/systems/{systemId}": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        /** Get a system */
+        get: operations["getSystem"];
+        put?: never;
+        post?: never;
+        /** Delete a system */
+        delete: operations["deleteSystem"];
+        options?: never;
+        head?: never;
+        /** Update a system */
+        patch: operations["updateSystem"];
+        trace?: never;
     };
-    /** Get a system */
-    get: operations["getSystem"];
-    put?: never;
-    post?: never;
-    /** Delete a system */
-    delete: operations["deleteSystem"];
-    options?: never;
-    head?: never;
-    /** Update a system */
-    patch: operations["updateSystem"];
-    trace?: never;
-  };
-  "/v1/systems": {
-    parameters: {
-      query?: never;
-      header?: never;
-      path?: never;
-      cookie?: never;
+    "/v1/systems": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        get?: never;
+        put?: never;
+        /** Create a system */
+        post: operations["createSystem"];
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
     };
-    get?: never;
-    put?: never;
-    /** Create a system */
-    post: operations["createSystem"];
-    delete?: never;
-    options?: never;
-    head?: never;
-    patch?: never;
-    trace?: never;
-  };
-  "/v1/workspaces/{workspaceId}/deployments": {
-    parameters: {
-      query?: never;
-      header?: never;
-      path: {
-        /** @description The ID of the workspace */
-        workspaceId: string;
-      };
-      cookie?: never;
+    "/v1/workspaces/{workspaceId}/deployments": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path: {
+                /** @description The ID of the workspace */
+                workspaceId: string;
+            };
+            cookie?: never;
+        };
+        /** List all deployments */
+        get: operations["listDeployments"];
+        put?: never;
+        post?: never;
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
     };
-    /** List all deployments */
-    get: operations["listDeployments"];
-    put?: never;
-    post?: never;
-    delete?: never;
-    options?: never;
-    head?: never;
-    patch?: never;
-    trace?: never;
-  };
-  "/v1/workspaces/{workspaceId}/environments": {
-    parameters: {
-      query?: never;
-      header?: never;
-      path: {
-        /** @description The ID of the workspace */
-        workspaceId: string;
-      };
-      cookie?: never;
+    "/v1/workspaces/{workspaceId}/environments": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path: {
+                /** @description The ID of the workspace */
+                workspaceId: string;
+            };
+            cookie?: never;
+        };
+        /** List all environments */
+        get: operations["listEnvironments"];
+        put?: never;
+        post?: never;
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
     };
-    /** List all environments */
-    get: operations["listEnvironments"];
-    put?: never;
-    post?: never;
-    delete?: never;
-    options?: never;
-    head?: never;
-    patch?: never;
-    trace?: never;
-  };
-  "/v1/workspaces/{workspaceId}/events/{action}": {
-    parameters: {
-      query?: never;
-      header?: never;
-      path: {
-        /** @description The ID of the workspace */
-        workspaceId: string;
-        action: string;
-      };
-      cookie?: never;
+    "/v1/workspaces/{workspaceId}/events/{action}": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path: {
+                /** @description The ID of the workspace */
+                workspaceId: string;
+                action: string;
+            };
+            cookie?: never;
+        };
+        /** Get events by action */
+        get: operations["getEventsByAction"];
+        put?: never;
+        post?: never;
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
     };
-    /** Get events by action */
-    get: operations["getEventsByAction"];
-    put?: never;
-    post?: never;
-    delete?: never;
-    options?: never;
-    head?: never;
-    patch?: never;
-    trace?: never;
-  };
-  "/v1/workspaces/{workspaceId}": {
-    parameters: {
-      query?: never;
-      header?: never;
-      path?: never;
-      cookie?: never;
+    "/v1/workspaces/{workspaceId}": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        /** Get a workspace */
+        get: operations["getWorkspace"];
+        put?: never;
+        post?: never;
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
     };
-    /** Get a workspace */
-    get: operations["getWorkspace"];
-    put?: never;
-    post?: never;
-    delete?: never;
-    options?: never;
-    head?: never;
-    patch?: never;
-    trace?: never;
-  };
-  "/v1/workspaces/{workspaceId}/policies/{name}": {
-    parameters: {
-      query?: never;
-      header?: never;
-      path?: never;
-      cookie?: never;
+    "/v1/workspaces/{workspaceId}/policies/{name}": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        get?: never;
+        put?: never;
+        post?: never;
+        /** Delete a policy by name */
+        delete: operations["deletePolicyByName"];
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
     };
-    get?: never;
-    put?: never;
-    post?: never;
-    /** Delete a policy by name */
-    delete: operations["deletePolicyByName"];
-    options?: never;
-    head?: never;
-    patch?: never;
-    trace?: never;
-  };
-  "/v1/workspaces/{workspaceId}/resource-providers/name/{name}": {
-    parameters: {
-      query?: never;
-      header?: never;
-      path?: never;
-      cookie?: never;
+    "/v1/workspaces/{workspaceId}/resource-providers/name/{name}": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        /** Upserts a resource provider. */
+        get: operations["upsertResourceProvider"];
+        put?: never;
+        post?: never;
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
     };
-    /** Upserts a resource provider. */
-    get: operations["upsertResourceProvider"];
-    put?: never;
-    post?: never;
-    delete?: never;
-    options?: never;
-    head?: never;
-    patch?: never;
-    trace?: never;
-  };
-  "/v1/workspaces/{workspaceId}/resources/identifier/{identifier}": {
-    parameters: {
-      query?: never;
-      header?: never;
-      path?: never;
-      cookie?: never;
+    "/v1/workspaces/{workspaceId}/resources/identifier/{identifier}": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        /** Get a resource by identifier */
+        get: operations["getResourceByIdentifier"];
+        put?: never;
+        post?: never;
+        /** Delete a resource by identifier */
+        delete: operations["deleteResourceByIdentifier"];
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
     };
-    /** Get a resource by identifier */
-    get: operations["getResourceByIdentifier"];
-    put?: never;
-    post?: never;
-    /** Delete a resource by identifier */
-    delete: operations["deleteResourceByIdentifier"];
-    options?: never;
-    head?: never;
-    patch?: never;
-    trace?: never;
-  };
-  "/v1/workspaces/{workspaceId}/resources/metadata-grouped-counts": {
-    parameters: {
-      query?: never;
-      header?: never;
-      path?: never;
-      cookie?: never;
+    "/v1/workspaces/{workspaceId}/resources/metadata-grouped-counts": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        get?: never;
+        put?: never;
+        /** Get grouped counts of resources */
+        post: operations["getGroupedCounts"];
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
     };
-    get?: never;
-    put?: never;
-    /** Get grouped counts of resources */
-    post: operations["getGroupedCounts"];
-    delete?: never;
-    options?: never;
-    head?: never;
-    patch?: never;
-    trace?: never;
-  };
-  "/v1/workspaces/{workspaceId}/resources": {
-    parameters: {
-      query?: never;
-      header?: never;
-      path: {
-        /** @description The ID of the workspace */
-        workspaceId: string;
-      };
-      cookie?: never;
+    "/v1/workspaces/{workspaceId}/resources": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path: {
+                /** @description The ID of the workspace */
+                workspaceId: string;
+            };
+            cookie?: never;
+        };
+        /** List all resources */
+        get: operations["listResources"];
+        put?: never;
+        post?: never;
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
     };
-    /** List all resources */
-    get: operations["listResources"];
-    put?: never;
-    post?: never;
-    delete?: never;
-    options?: never;
-    head?: never;
-    patch?: never;
-    trace?: never;
-  };
-  "/v1/workspaces/{workspaceId}/systems": {
-    parameters: {
-      query?: never;
-      header?: never;
-      path: {
-        /** @description The ID of the workspace */
-        workspaceId: string;
-      };
-      cookie?: never;
+    "/v1/workspaces/{workspaceId}/systems": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path: {
+                /** @description The ID of the workspace */
+                workspaceId: string;
+            };
+            cookie?: never;
+        };
+        /** List all systems */
+        get: operations["listSystems"];
+        put?: never;
+        post?: never;
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
     };
-    /** List all systems */
-    get: operations["listSystems"];
-    put?: never;
-    post?: never;
-    delete?: never;
-    options?: never;
-    head?: never;
-    patch?: never;
-    trace?: never;
-  };
-  "/v1/workspaces/slug/{workspaceSlug}": {
-    parameters: {
-      query?: never;
-      header?: never;
-      path?: never;
-      cookie?: never;
+    "/v1/workspaces/slug/{workspaceSlug}": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        /** Get a workspace by slug */
+        get: operations["getWorkspaceBySlug"];
+        put?: never;
+        post?: never;
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
     };
-    /** Get a workspace by slug */
-    get: operations["getWorkspaceBySlug"];
-    put?: never;
-    post?: never;
-    delete?: never;
-    options?: never;
-    head?: never;
-    patch?: never;
-    trace?: never;
-  };
 }
 export type webhooks = Record<string, never>;
 export interface components {
-  schemas: {
-    CloudRegionGeoData: {
-      /**
-       * @description Timezone of the region in UTC format
-       * @example UTC+1
-       */
-      timezone: string;
-      /**
-       * Format: float
-       * @description Latitude coordinate for the region
-       * @example 50.1109
-       */
-      latitude: number;
-      /**
-       * Format: float
-       * @description Longitude coordinate for the region
-       * @example 8.6821
-       */
-      longitude: number;
-    };
-    BaseVariableValue: {
-      resourceSelector?: {
-        [key: string]: unknown;
-      } | null;
-      default?: boolean;
-    };
-    DeploymentVariableDirectValue: components["schemas"]["BaseVariableValue"] & {
-      /** @enum {string} */
-      valueType: "direct";
-      value: string | number | boolean | Record<string, never> | unknown[];
-      sensitive?: boolean;
-    };
-    DeploymentVariableReferenceValue: components["schemas"]["BaseVariableValue"] & {
-      /** @enum {string} */
-      valueType: "reference";
-      reference: string;
-      path: string[];
-      defaultValue?:
-        | string
-        | number
-        | boolean
-        | Record<string, never>
-        | unknown[];
-    };
-    VariableValue:
-      | components["schemas"]["DeploymentVariableDirectValue"]
-      | components["schemas"]["DeploymentVariableReferenceValue"];
-    DeploymentVariableValue: components["schemas"]["VariableValue"] & {
-      /** Format: uuid */
-      id: string;
-    };
-    DeploymentVariable: {
-      /** Format: uuid */
-      id: string;
-      key: string;
-      description: string;
-      values: components["schemas"]["DeploymentVariableValue"][];
-      defaultValue?: components["schemas"]["DeploymentVariableValue"];
-      config: {
-        [key: string]: unknown;
-      };
-    };
-    JobWithTrigger: components["schemas"]["Job"] & {
-      release?: components["schemas"]["Release"];
-      version?: components["schemas"]["DeploymentVersion"];
-      deployment?: components["schemas"]["Deployment"];
-      runbook?: components["schemas"]["Runbook"];
-      resource?: components["schemas"]["ResourceWithVariablesAndMetadata"] & {
-        relationships?: {
-          [key: string]: components["schemas"]["Resource"];
+    schemas: {
+        CloudRegionGeoData: {
+            /**
+             * @description Timezone of the region in UTC format
+             * @example UTC+1
+             */
+            timezone: string;
+            /**
+             * Format: float
+             * @description Latitude coordinate for the region
+             * @example 50.1109
+             */
+            latitude: number;
+            /**
+             * Format: float
+             * @description Longitude coordinate for the region
+             * @example 8.6821
+             */
+            longitude: number;
         };
-      };
-      environment?: components["schemas"]["Environment"];
-      variables: components["schemas"]["VariableMap"];
-      approval?: {
-        id: string;
+        BaseVariableValue: {
+            resourceSelector?: {
+                [key: string]: unknown;
+            } | null;
+            default?: boolean;
+        };
+        DeploymentVariableDirectValue: components["schemas"]["BaseVariableValue"] & {
+            /** @enum {string} */
+            valueType: "direct";
+            value: string | number | boolean | Record<string, never> | unknown[];
+            sensitive?: boolean;
+        };
+        DeploymentVariableReferenceValue: components["schemas"]["BaseVariableValue"] & {
+            /** @enum {string} */
+            valueType: "reference";
+            reference: string;
+            path: string[];
+            defaultValue?: string | number | boolean | Record<string, never> | unknown[];
+        };
+        VariableValue: components["schemas"]["DeploymentVariableDirectValue"] | components["schemas"]["DeploymentVariableReferenceValue"];
+        DeploymentVariableValue: components["schemas"]["VariableValue"] & {
+            /** Format: uuid */
+            id: string;
+        };
+        DeploymentVariable: {
+            /** Format: uuid */
+            id: string;
+            key: string;
+            description: string;
+            values: components["schemas"]["DeploymentVariableValue"][];
+            defaultValue?: components["schemas"]["DeploymentVariableValue"];
+            config: {
+                [key: string]: unknown;
+            };
+        };
+        JobWithTrigger: components["schemas"]["Job"] & {
+            release?: components["schemas"]["Release"];
+            version?: components["schemas"]["DeploymentVersion"];
+            deployment?: components["schemas"]["Deployment"];
+            runbook?: components["schemas"]["Runbook"];
+            resource?: components["schemas"]["ResourceWithVariablesAndMetadata"] & {
+                relationships?: {
+                    [key: string]: components["schemas"]["Resource"];
+                };
+            };
+            environment?: components["schemas"]["Environment"];
+            variables: components["schemas"]["VariableMap"];
+            approval?: {
+                id: string;
+                /** @enum {string} */
+                status: "pending" | "approved" | "rejected";
+                /** @description Null when status is pending, contains approver details when approved or rejected */
+                approver?: {
+                    id: string;
+                    name: string;
+                } | null;
+            } | null;
+        };
+        Workspace: {
+            /**
+             * Format: uuid
+             * @description The workspace ID
+             */
+            id: string;
+            /** @description The name of the workspace */
+            name: string;
+            /** @description The slug of the workspace */
+            slug: string;
+            /**
+             * @description The email of the Google service account attached to the workspace
+             * @example ctrlplane@ctrlplane-workspace.iam.gserviceaccount.com
+             */
+            googleServiceAccountEmail?: string | null;
+            /**
+             * @description The ARN of the AWS role attached to the workspace
+             * @example arn:aws:iam::123456789012:role/ctrlplane-workspace-role
+             */
+            awsRoleArn?: string | null;
+        };
+        System: {
+            /**
+             * Format: uuid
+             * @description The system ID
+             */
+            id: string;
+            /**
+             * Format: uuid
+             * @description The workspace ID of the system
+             */
+            workspaceId: string;
+            /** @description The name of the system */
+            name: string;
+            /** @description The slug of the system */
+            slug: string;
+            /** @description The description of the system */
+            description?: string;
+        };
+        Deployment: {
+            /** Format: uuid */
+            id: string;
+            name: string;
+            slug: string;
+            description: string;
+            /** Format: uuid */
+            systemId: string;
+            /** Format: uuid */
+            jobAgentId?: string | null;
+            jobAgentConfig: {
+                [key: string]: unknown;
+            };
+            retryCount?: number;
+            timeout?: number | null;
+        };
+        /** @description Schema for updating a deployment (all fields optional) */
+        UpdateDeployment: {
+            [key: string]: unknown;
+        } & (WithRequired<components["schemas"]["Deployment"], "id"> & {
+            [key: string]: unknown;
+        });
+        Release: {
+            /** Format: uuid */
+            id: string;
+            name: string;
+            version: string;
+            config: {
+                [key: string]: unknown;
+            };
+            jobAgentConfig: {
+                [key: string]: unknown;
+            };
+            /** Format: uuid */
+            deploymentId: string;
+            /** Format: date-time */
+            createdAt: string;
+            metadata?: {
+                [key: string]: unknown;
+            };
+        };
+        DeploymentVersion: {
+            /** Format: uuid */
+            id: string;
+            name: string;
+            tag: string;
+            config: {
+                [key: string]: unknown;
+            };
+            jobAgentConfig: {
+                [key: string]: unknown;
+            };
+            /** Format: uuid */
+            deploymentId: string;
+            /** Format: date-time */
+            createdAt: string;
+            metadata?: {
+                [key: string]: string;
+            };
+            /** @enum {string} */
+            status?: "building" | "ready" | "failed";
+        };
+        Policy: {
+            /**
+             * Format: uuid
+             * @description The policy ID
+             */
+            id: string;
+            /**
+             * Format: uuid
+             * @description The system ID
+             */
+            systemId: string;
+            /** @description The name of the policy */
+            name: string;
+            /** @description The description of the policy */
+            description?: string | null;
+            /**
+             * @description The approval requirement of the policy
+             * @enum {string}
+             */
+            approvalRequirement: "manual" | "automatic";
+            /**
+             * @description If a policy depends on an environment, whether or not the policy requires all, some, or optional successful releases in the environment
+             * @enum {string}
+             */
+            successType: "some" | "all" | "optional";
+            /** @description If a policy depends on an environment, the minimum number of successful releases in the environment */
+            successMinimum: number;
+            /** @description The maximum number of concurrent releases in the environment */
+            concurrencyLimit?: number | null;
+            /** @description The duration of the rollout in milliseconds */
+            rolloutDuration: number;
+            /** @description The minimum interval between releases in milliseconds */
+            minimumReleaseInterval: number;
+            /**
+             * @description If a new release is created, whether it will wait for the current release to finish before starting, or cancel the current release
+             * @enum {string}
+             */
+            releaseSequencing: "wait" | "cancel";
+        };
+        Environment: {
+            /** Format: uuid */
+            id: string;
+            /** Format: uuid */
+            systemId: string;
+            name: string;
+            description?: string;
+            /** Format: uuid */
+            policyId?: string | null;
+            resourceSelector?: {
+                [key: string]: unknown;
+            } | null;
+            /**
+             * @description The directory path of the environment
+             * @default
+             * @example my/env/path
+             */
+            directory: string;
+            /** Format: date-time */
+            createdAt: string;
+            metadata?: {
+                [key: string]: string;
+            };
+            policy?: components["schemas"]["Policy"];
+        };
+        Runbook: {
+            /** Format: uuid */
+            id: string;
+            name: string;
+            /** Format: uuid */
+            systemId: string;
+            /** Format: uuid */
+            jobAgentId: string;
+        };
+        Resource: {
+            /** Format: uuid */
+            id: string;
+            name: string;
+            version: string;
+            kind: string;
+            identifier: string;
+            config: {
+                [key: string]: unknown;
+            };
+            metadata: {
+                [key: string]: unknown;
+            };
+            /** Format: date-time */
+            createdAt: string;
+            /** Format: date-time */
+            updatedAt: string;
+            /** Format: uuid */
+            workspaceId: string;
+            /** Format: uuid */
+            providerId?: string;
+        };
+        ResourceWithVariables: components["schemas"]["Resource"] & {
+            variables?: components["schemas"]["VariableMap"];
+        };
+        ResourceWithMetadata: components["schemas"]["Resource"] & {
+            metadata?: components["schemas"]["MetadataMap"];
+        };
+        ResourceWithVariablesAndMetadata: components["schemas"]["ResourceWithVariables"] & components["schemas"]["ResourceWithMetadata"];
+        CreateResource: {
+            identifier: string;
+            name: string;
+            version: string;
+            kind: string;
+            config: {
+                [key: string]: unknown;
+            };
+            metadata: {
+                [key: string]: string;
+            };
+            variables?: components["schemas"]["Variable"][];
+        };
         /** @enum {string} */
-        status: "pending" | "approved" | "rejected";
-        /** @description Null when status is pending, contains approver details when approved or rejected */
-        approver?: {
-          id: string;
-          name: string;
-        } | null;
-      } | null;
+        JobStatus: "successful" | "cancelled" | "skipped" | "in_progress" | "action_required" | "pending" | "failure" | "invalid_job_agent" | "invalid_integration" | "external_run_not_found";
+        Job: {
+            /** Format: uuid */
+            id: string;
+            status: components["schemas"]["JobStatus"];
+            /** @description External job identifier (e.g. GitHub workflow run ID) */
+            externalId?: string | null;
+            /** Format: date-time */
+            createdAt: string;
+            /** Format: date-time */
+            updatedAt: string;
+            /** Format: date-time */
+            startedAt?: string | null;
+            /** Format: date-time */
+            completedAt?: string | null;
+            /** Format: uuid */
+            jobAgentId?: string;
+            /** @description Configuration for the Job Agent */
+            jobAgentConfig: {
+                [key: string]: unknown;
+            };
+            message?: string;
+            reason?: string;
+        };
+        MetadataMap: {
+            [key: string]: string;
+        };
+        VariableMap: {
+            [key: string]: (string | boolean | number | Record<string, never> | unknown[]) | null;
+        };
+        ReferenceVariable: {
+            key: string;
+            reference: string;
+            path: string[];
+            defaultValue?: string | number | boolean | Record<string, never> | unknown[];
+        };
+        DirectVariable: {
+            key: string;
+            value: string | number | boolean | Record<string, never> | unknown[];
+            sensitive?: boolean;
+        };
+        Variable: components["schemas"]["DirectVariable"] | components["schemas"]["ReferenceVariable"];
+        PolicyTarget: {
+            deploymentSelector?: {
+                [key: string]: unknown;
+            } | null;
+            environmentSelector?: {
+                [key: string]: unknown;
+            } | null;
+            resourceSelector?: {
+                [key: string]: unknown;
+            } | null;
+        };
+        DenyWindow: {
+            timeZone: string;
+            rrule: {
+                [key: string]: unknown;
+            };
+            /** Format: date-time */
+            dtend?: string;
+        };
+        DeploymentVersionSelector: {
+            name: string;
+            deploymentVersionSelector: {
+                [key: string]: unknown;
+            };
+            description?: string;
+        };
+        VersionAnyApproval: {
+            requiredApprovalsCount: number;
+        };
+        VersionUserApproval: {
+            userId: string;
+        };
+        VersionRoleApproval: {
+            roleId: string;
+            requiredApprovalsCount: number;
+        };
+        Policy1: {
+            /** Format: uuid */
+            id: string;
+            name: string;
+            description?: string;
+            priority: number;
+            /** Format: date-time */
+            createdAt: string;
+            enabled: boolean;
+            /** Format: uuid */
+            workspaceId: string;
+            targets: components["schemas"]["PolicyTarget"][];
+            denyWindows: components["schemas"]["DenyWindow"][];
+            deploymentVersionSelector?: components["schemas"]["DeploymentVersionSelector"];
+            versionAnyApprovals?: components["schemas"]["VersionAnyApproval"];
+            versionUserApprovals: components["schemas"]["VersionUserApproval"][];
+            versionRoleApprovals: components["schemas"]["VersionRoleApproval"][];
+        };
+        UpdateResourceRelationshipRule: {
+            name?: string;
+            reference?: string;
+            dependencyType?: components["schemas"]["ResourceRelationshipRuleDependencyType"];
+            dependencyDescription?: string;
+            description?: string;
+            sourceKind?: string;
+            sourceVersion?: string;
+            targetKind?: string;
+            targetVersion?: string;
+            metadataKeysMatch?: string[];
+            targetMetadataEquals?: {
+                key: string;
+                value: string;
+            }[];
+        };
+        /** @enum {string} */
+        ResourceRelationshipRuleDependencyType: "depends_on" | "depends_indirectly_on" | "uses_at_runtime" | "created_after" | "provisioned_in" | "inherits_from";
+        ResourceRelationshipRule: {
+            /** Format: uuid */
+            id: string;
+            /** Format: uuid */
+            workspaceId: string;
+            name: string;
+            reference: string;
+            dependencyType: components["schemas"]["ResourceRelationshipRuleDependencyType"];
+            dependencyDescription?: string;
+            description?: string;
+            sourceKind: string;
+            sourceVersion: string;
+            targetKind?: string;
+            targetVersion?: string;
+            targetMetadataEquals?: {
+                key: string;
+                value: string;
+            }[];
+            metadataKeysMatches?: string[];
+        };
+        CreateResourceRelationshipRule: {
+            workspaceId: string;
+            name: string;
+            reference: string;
+            dependencyType: components["schemas"]["ResourceRelationshipRuleDependencyType"];
+            dependencyDescription?: string;
+            description?: string;
+            sourceKind: string;
+            sourceVersion: string;
+            targetKind: string;
+            targetVersion: string;
+            metadataKeysMatches?: string[];
+            targetMetadataEquals?: {
+                key: string;
+                value: string;
+            }[];
+        };
+        ReleaseTarget: {
+            /** Format: uuid */
+            id: string;
+            resource: components["schemas"]["Resource"];
+            environment: components["schemas"]["Environment"];
+            deployment: components["schemas"]["Deployment"];
+        };
+        Event: {
+            /** Format: uuid */
+            id: string;
+            action: string;
+            payload: {
+                [key: string]: unknown;
+            };
+            /** Format: date-time */
+            createdAt: string;
+        };
     };
-    Workspace: {
-      /**
-       * Format: uuid
-       * @description The workspace ID
-       */
-      id: string;
-      /** @description The name of the workspace */
-      name: string;
-      /** @description The slug of the workspace */
-      slug: string;
-      /**
-       * @description The email of the Google service account attached to the workspace
-       * @example ctrlplane@ctrlplane-workspace.iam.gserviceaccount.com
-       */
-      googleServiceAccountEmail?: string | null;
-      /**
-       * @description The ARN of the AWS role attached to the workspace
-       * @example arn:aws:iam::123456789012:role/ctrlplane-workspace-role
-       */
-      awsRoleArn?: string | null;
-    };
-    System: {
-      /**
-       * Format: uuid
-       * @description The system ID
-       */
-      id: string;
-      /**
-       * Format: uuid
-       * @description The workspace ID of the system
-       */
-      workspaceId: string;
-      /** @description The name of the system */
-      name: string;
-      /** @description The slug of the system */
-      slug: string;
-      /** @description The description of the system */
-      description?: string;
-    };
-    Deployment: {
-      /** Format: uuid */
-      id: string;
-      name: string;
-      slug: string;
-      description: string;
-      /** Format: uuid */
-      systemId: string;
-      /** Format: uuid */
-      jobAgentId?: string | null;
-      jobAgentConfig: {
-        [key: string]: unknown;
-      };
-      retryCount?: number;
-      timeout?: number | null;
-    };
-    /** @description Schema for updating a deployment (all fields optional) */
-    UpdateDeployment: {
-      [key: string]: unknown;
-    } & (WithRequired<components["schemas"]["Deployment"], "id"> & {
-      [key: string]: unknown;
-    });
-    Release: {
-      /** Format: uuid */
-      id: string;
-      name: string;
-      version: string;
-      config: {
-        [key: string]: unknown;
-      };
-      jobAgentConfig: {
-        [key: string]: unknown;
-      };
-      /** Format: uuid */
-      deploymentId: string;
-      /** Format: date-time */
-      createdAt: string;
-      metadata?: {
-        [key: string]: unknown;
-      };
-    };
-    DeploymentVersion: {
-      /** Format: uuid */
-      id: string;
-      name: string;
-      tag: string;
-      config: {
-        [key: string]: unknown;
-      };
-      jobAgentConfig: {
-        [key: string]: unknown;
-      };
-      /** Format: uuid */
-      deploymentId: string;
-      /** Format: date-time */
-      createdAt: string;
-      metadata?: {
-        [key: string]: string;
-      };
-      /** @enum {string} */
-      status?: "building" | "ready" | "failed";
-    };
-    Policy: {
-      /**
-       * Format: uuid
-       * @description The policy ID
-       */
-      id: string;
-      /**
-       * Format: uuid
-       * @description The system ID
-       */
-      systemId: string;
-      /** @description The name of the policy */
-      name: string;
-      /** @description The description of the policy */
-      description?: string | null;
-      /**
-       * @description The approval requirement of the policy
-       * @enum {string}
-       */
-      approvalRequirement: "manual" | "automatic";
-      /**
-       * @description If a policy depends on an environment, whether or not the policy requires all, some, or optional successful releases in the environment
-       * @enum {string}
-       */
-      successType: "some" | "all" | "optional";
-      /** @description If a policy depends on an environment, the minimum number of successful releases in the environment */
-      successMinimum: number;
-      /** @description The maximum number of concurrent releases in the environment */
-      concurrencyLimit?: number | null;
-      /** @description The duration of the rollout in milliseconds */
-      rolloutDuration: number;
-      /** @description The minimum interval between releases in milliseconds */
-      minimumReleaseInterval: number;
-      /**
-       * @description If a new release is created, whether it will wait for the current release to finish before starting, or cancel the current release
-       * @enum {string}
-       */
-      releaseSequencing: "wait" | "cancel";
-    };
-    Environment: {
-      /** Format: uuid */
-      id: string;
-      /** Format: uuid */
-      systemId: string;
-      name: string;
-      description?: string;
-      /** Format: uuid */
-      policyId?: string | null;
-      resourceSelector?: {
-        [key: string]: unknown;
-      } | null;
-      /**
-       * @description The directory path of the environment
-       * @default
-       * @example my/env/path
-       */
-      directory: string;
-      /** Format: date-time */
-      createdAt: string;
-      metadata?: {
-        [key: string]: string;
-      };
-      policy?: components["schemas"]["Policy"];
-    };
-    Runbook: {
-      /** Format: uuid */
-      id: string;
-      name: string;
-      /** Format: uuid */
-      systemId: string;
-      /** Format: uuid */
-      jobAgentId: string;
-    };
-    Resource: {
-      /** Format: uuid */
-      id: string;
-      name: string;
-      version: string;
-      kind: string;
-      identifier: string;
-      config: {
-        [key: string]: unknown;
-      };
-      metadata: {
-        [key: string]: unknown;
-      };
-      /** Format: date-time */
-      createdAt: string;
-      /** Format: date-time */
-      updatedAt: string;
-      /** Format: uuid */
-      workspaceId: string;
-      /** Format: uuid */
-      providerId?: string;
-    };
-    ResourceWithVariables: components["schemas"]["Resource"] & {
-      variables?: components["schemas"]["VariableMap"];
-    };
-    ResourceWithMetadata: components["schemas"]["Resource"] & {
-      metadata?: components["schemas"]["MetadataMap"];
-    };
-    ResourceWithVariablesAndMetadata: components["schemas"]["ResourceWithVariables"] &
-      components["schemas"]["ResourceWithMetadata"];
-    CreateResource: {
-      identifier: string;
-      name: string;
-      version: string;
-      kind: string;
-      config: {
-        [key: string]: unknown;
-      };
-      metadata: {
-        [key: string]: string;
-      };
-      variables?: components["schemas"]["Variable"][];
-    };
-    /** @enum {string} */
-    JobStatus:
-      | "successful"
-      | "cancelled"
-      | "skipped"
-      | "in_progress"
-      | "action_required"
-      | "pending"
-      | "failure"
-      | "invalid_job_agent"
-      | "invalid_integration"
-      | "external_run_not_found";
-    Job: {
-      /** Format: uuid */
-      id: string;
-      status: components["schemas"]["JobStatus"];
-      /** @description External job identifier (e.g. GitHub workflow run ID) */
-      externalId?: string | null;
-      /** Format: date-time */
-      createdAt: string;
-      /** Format: date-time */
-      updatedAt: string;
-      /** Format: date-time */
-      startedAt?: string | null;
-      /** Format: date-time */
-      completedAt?: string | null;
-      /** Format: uuid */
-      jobAgentId?: string;
-      /** @description Configuration for the Job Agent */
-      jobAgentConfig: {
-        [key: string]: unknown;
-      };
-      message?: string;
-      reason?: string;
-    };
-    MetadataMap: {
-      [key: string]: string;
-    };
-    VariableMap: {
-      [key: string]:
-        | (string | boolean | number | Record<string, never> | unknown[])
-        | null;
-    };
-    ReferenceVariable: {
-      key: string;
-      reference: string;
-      path: string[];
-      defaultValue?:
-        | string
-        | number
-        | boolean
-        | Record<string, never>
-        | unknown[];
-    };
-    DirectVariable: {
-      key: string;
-      value: string | number | boolean | Record<string, never> | unknown[];
-      sensitive?: boolean;
-    };
-    Variable:
-      | components["schemas"]["DirectVariable"]
-      | components["schemas"]["ReferenceVariable"];
-    PolicyTarget: {
-      deploymentSelector?: {
-        [key: string]: unknown;
-      } | null;
-      environmentSelector?: {
-        [key: string]: unknown;
-      } | null;
-      resourceSelector?: {
-        [key: string]: unknown;
-      } | null;
-    };
-    DenyWindow: {
-      timeZone: string;
-      rrule: {
-        [key: string]: unknown;
-      };
-      /** Format: date-time */
-      dtend?: string;
-    };
-    DeploymentVersionSelector: {
-      name: string;
-      deploymentVersionSelector: {
-        [key: string]: unknown;
-      };
-      description?: string;
-    };
-    VersionAnyApproval: {
-      requiredApprovalsCount: number;
-    };
-    VersionUserApproval: {
-      userId: string;
-    };
-    VersionRoleApproval: {
-      roleId: string;
-      requiredApprovalsCount: number;
-    };
-    Policy1: {
-      /** Format: uuid */
-      id: string;
-      name: string;
-      description?: string;
-      priority: number;
-      /** Format: date-time */
-      createdAt: string;
-      enabled: boolean;
-      /** Format: uuid */
-      workspaceId: string;
-      targets: components["schemas"]["PolicyTarget"][];
-      denyWindows: components["schemas"]["DenyWindow"][];
-      deploymentVersionSelector?: components["schemas"]["DeploymentVersionSelector"];
-      versionAnyApprovals?: components["schemas"]["VersionAnyApproval"][];
-      versionUserApprovals: components["schemas"]["VersionUserApproval"][];
-      versionRoleApprovals: components["schemas"]["VersionRoleApproval"][];
-    };
-    UpdateResourceRelationshipRule: {
-      name?: string;
-      reference?: string;
-      dependencyType?: components["schemas"]["ResourceRelationshipRuleDependencyType"];
-      dependencyDescription?: string;
-      description?: string;
-      sourceKind?: string;
-      sourceVersion?: string;
-      targetKind?: string;
-      targetVersion?: string;
-      metadataKeysMatch?: string[];
-      targetMetadataEquals?: {
-        key: string;
-        value: string;
-      }[];
-    };
-    /** @enum {string} */
-    ResourceRelationshipRuleDependencyType:
-      | "depends_on"
-      | "depends_indirectly_on"
-      | "uses_at_runtime"
-      | "created_after"
-      | "provisioned_in"
-      | "inherits_from";
-    ResourceRelationshipRule: {
-      /** Format: uuid */
-      id: string;
-      /** Format: uuid */
-      workspaceId: string;
-      name: string;
-      reference: string;
-      dependencyType: components["schemas"]["ResourceRelationshipRuleDependencyType"];
-      dependencyDescription?: string;
-      description?: string;
-      sourceKind: string;
-      sourceVersion: string;
-      targetKind?: string;
-      targetVersion?: string;
-      targetMetadataEquals?: {
-        key: string;
-        value: string;
-      }[];
-      metadataKeysMatches?: string[];
-    };
-    CreateResourceRelationshipRule: {
-      workspaceId: string;
-      name: string;
-      reference: string;
-      dependencyType: components["schemas"]["ResourceRelationshipRuleDependencyType"];
-      dependencyDescription?: string;
-      description?: string;
-      sourceKind: string;
-      sourceVersion: string;
-      targetKind: string;
-      targetVersion: string;
-      metadataKeysMatches?: string[];
-      targetMetadataEquals?: {
-        key: string;
-        value: string;
-      }[];
-    };
-    ReleaseTarget: {
-      /** Format: uuid */
-      id: string;
-      resource: components["schemas"]["Resource"];
-      environment: components["schemas"]["Environment"];
-      deployment: components["schemas"]["Deployment"];
-    };
-    Event: {
-      /** Format: uuid */
-      id: string;
-      action: string;
-      payload: {
-        [key: string]: unknown;
-      };
-      /** Format: date-time */
-      createdAt: string;
-    };
-  };
-  responses: never;
-  parameters: never;
-  requestBodies: never;
-  headers: never;
-  pathItems: never;
+    responses: never;
+    parameters: never;
+    requestBodies: never;
+    headers: never;
+    pathItems: never;
 }
 export type $defs = Record<string, never>;
 export interface operations {
-  getCloudProviderRegions: {
-    parameters: {
-      query?: never;
-      header?: never;
-      path: {
-        /** @description Cloud provider (aws, gcp, azure) */
-        provider: "aws" | "gcp" | "azure";
-      };
-      cookie?: never;
-    };
-    requestBody?: never;
-    responses: {
-      /** @description Successfully returned geographic data for cloud provider regions */
-      200: {
-        headers: {
-          [name: string]: unknown;
-        };
-        content: {
-          "application/json": {
-            [key: string]: components["schemas"]["CloudRegionGeoData"];
-          };
-        };
-      };
-      /** @description Cloud provider not found */
-      404: {
-        headers: {
-          [name: string]: unknown;
-        };
-        content: {
-          "application/json": {
-            /** @example Cloud provider 'unknown' not found */
-            error?: string;
-          };
-        };
-      };
-    };
-  };
-  createDeploymentVersionChannel: {
-    parameters: {
-      query?: never;
-      header?: never;
-      path?: never;
-      cookie?: never;
-    };
-    requestBody: {
-      content: {
-        "application/json": {
-          deploymentId: string;
-          name: string;
-          description?: string | null;
-          versionSelector: {
-            [key: string]: unknown;
-          };
-        };
-      };
-    };
-    responses: {
-      /** @description Deployment version channel created successfully */
-      200: {
-        headers: {
-          [name: string]: unknown;
-        };
-        content: {
-          "application/json": {
-            id: string;
-            deploymentId: string;
-            name: string;
-            description?: string | null;
-            /** Format: date-time */
-            createdAt: string;
-            versionSelector?: {
-              [key: string]: unknown;
+    getCloudProviderRegions: {
+        parameters: {
+            query?: never;
+            header?: never;
+            path: {
+                /** @description Cloud provider (aws, gcp, azure) */
+                provider: "aws" | "gcp" | "azure";
             };
-          };
-        };
-      };
-      /** @description Unauthorized */
-      401: {
-        headers: {
-          [name: string]: unknown;
-        };
-        content: {
-          "application/json": {
-            error: string;
-          };
-        };
-      };
-      /** @description Forbidden */
-      403: {
-        headers: {
-          [name: string]: unknown;
-        };
-        content: {
-          "application/json": {
-            error: string;
-          };
-        };
-      };
-      /** @description Deployment version channel already exists */
-      409: {
-        headers: {
-          [name: string]: unknown;
-        };
-        content: {
-          "application/json": {
-            error: string;
-            id: string;
-          };
-        };
-      };
-      /** @description Failed to create deployment version channel */
-      500: {
-        headers: {
-          [name: string]: unknown;
-        };
-        content: {
-          "application/json": {
-            error: string;
-          };
-        };
-      };
-    };
-  };
-  updateDeploymentVersion: {
-    parameters: {
-      query?: never;
-      header?: never;
-      path: {
-        /** @description The deployment version ID */
-        deploymentVersionId: string;
-      };
-      cookie?: never;
-    };
-    requestBody: {
-      content: {
-        "application/json": {
-          tag?: string;
-          deploymentId?: string;
-          /** Format: date-time */
-          createdAt?: string;
-          name?: string;
-          config?: {
-            [key: string]: unknown;
-          };
-          jobAgentConfig?: {
-            [key: string]: unknown;
-          };
-          /** @enum {string} */
-          status?: "ready" | "building" | "failed";
-          message?: string;
-          metadata?: {
-            [key: string]: string;
-          };
-        };
-      };
-    };
-    responses: {
-      /** @description OK */
-      200: {
-        headers: {
-          [name: string]: unknown;
-        };
-        content: {
-          "application/json": components["schemas"]["DeploymentVersion"];
-        };
-      };
-      /** @description Deployment version not found */
-      404: {
-        headers: {
-          [name: string]: unknown;
-        };
-        content: {
-          "application/json": {
-            error?: string;
-          };
-        };
-      };
-      /** @description Internal server error */
-      500: {
-        headers: {
-          [name: string]: unknown;
-        };
-        content: {
-          "application/json": {
-            error?: string;
-          };
-        };
-      };
-    };
-  };
-  upsertDeploymentVersion: {
-    parameters: {
-      query?: never;
-      header?: never;
-      path?: never;
-      cookie?: never;
-    };
-    requestBody: {
-      content: {
-        "application/json": {
-          tag: string;
-          deploymentId: string;
-          /** Format: date-time */
-          createdAt?: string;
-          name?: string;
-          config?: {
-            [key: string]: unknown;
-          };
-          jobAgentConfig?: {
-            [key: string]: unknown;
-          };
-          /** @enum {string} */
-          status?: "ready" | "building" | "failed";
-          message?: string;
-          metadata?: {
-            [key: string]: string;
-          };
-        };
-      };
-    };
-    responses: {
-      /** @description OK */
-      201: {
-        headers: {
-          [name: string]: unknown;
-        };
-        content: {
-          "application/json": components["schemas"]["DeploymentVersion"];
-        };
-      };
-      /** @description Internal server error */
-      500: {
-        headers: {
-          [name: string]: unknown;
-        };
-        content: {
-          "application/json": {
-            error?: string;
-          };
-        };
-      };
-    };
-  };
-  deleteDeploymentVersionChannel: {
-    parameters: {
-      query?: never;
-      header?: never;
-      path: {
-        deploymentId: string;
-        name: string;
-      };
-      cookie?: never;
-    };
-    requestBody?: never;
-    responses: {
-      /** @description Deployment version channel deleted */
-      200: {
-        headers: {
-          [name: string]: unknown;
-        };
-        content: {
-          "application/json": {
-            message: string;
-          };
-        };
-      };
-      /** @description Permission denied */
-      403: {
-        headers: {
-          [name: string]: unknown;
-        };
-        content: {
-          "application/json": {
-            error: string;
-          };
-        };
-      };
-      /** @description Deployment version channel not found */
-      404: {
-        headers: {
-          [name: string]: unknown;
-        };
-        content: {
-          "application/json": {
-            error: string;
-          };
-        };
-      };
-      /** @description Failed to delete deployment version channel */
-      500: {
-        headers: {
-          [name: string]: unknown;
-        };
-        content: {
-          "application/json": {
-            error: string;
-          };
-        };
-      };
-    };
-  };
-  getDeployment: {
-    parameters: {
-      query?: never;
-      header?: never;
-      path: {
-        deploymentId: string;
-      };
-      cookie?: never;
-    };
-    requestBody?: never;
-    responses: {
-      /** @description Deployment found */
-      200: {
-        headers: {
-          [name: string]: unknown;
-        };
-        content: {
-          "application/json": components["schemas"]["Deployment"];
-        };
-      };
-      /** @description Deployment not found */
-      404: {
-        headers: {
-          [name: string]: unknown;
-        };
-        content: {
-          "application/json": {
-            error: string;
-          };
-        };
-      };
-    };
-  };
-  deleteDeployment: {
-    parameters: {
-      query?: never;
-      header?: never;
-      path: {
-        deploymentId: string;
-      };
-      cookie?: never;
-    };
-    requestBody?: never;
-    responses: {
-      /** @description Deployment deleted */
-      200: {
-        headers: {
-          [name: string]: unknown;
-        };
-        content: {
-          "application/json": components["schemas"]["Deployment"];
-        };
-      };
-      /** @description Deployment not found */
-      404: {
-        headers: {
-          [name: string]: unknown;
-        };
-        content: {
-          "application/json": {
-            error: string;
-          };
-        };
-      };
-      /** @description Failed to delete deployment */
-      500: {
-        headers: {
-          [name: string]: unknown;
-        };
-        content: {
-          "application/json": {
-            error: string;
-          };
-        };
-      };
-    };
-  };
-  updateDeployment: {
-    parameters: {
-      query?: never;
-      header?: never;
-      path: {
-        deploymentId: string;
-      };
-      cookie?: never;
-    };
-    requestBody: {
-      content: {
-        "application/json": {
-          name?: string;
-          slug?: string;
-          description?: string;
-          /** Format: uuid */
-          systemId?: string;
-          /** Format: uuid */
-          jobAgentId?: string | null;
-          jobAgentConfig?: {
-            [key: string]: unknown;
-          };
-          retryCount?: number;
-          timeout?: number | null;
-          resourceSelector?: {
-            [key: string]: unknown;
-          } | null;
-        };
-      };
-    };
-    responses: {
-      /** @description Deployment updated */
-      200: {
-        headers: {
-          [name: string]: unknown;
-        };
-        content: {
-          "application/json": components["schemas"]["Deployment"];
-        };
-      };
-      /** @description Deployment not found */
-      404: {
-        headers: {
-          [name: string]: unknown;
-        };
-        content: {
-          "application/json": {
-            error: string;
-          };
-        };
-      };
-      /** @description Failed to update deployment */
-      500: {
-        headers: {
-          [name: string]: unknown;
-        };
-        content: {
-          "application/json": {
-            error: string;
-          };
-        };
-      };
-    };
-  };
-  deleteReleaseChannel: {
-    parameters: {
-      query?: never;
-      header?: never;
-      path: {
-        deploymentId: string;
-        name: string;
-      };
-      cookie?: never;
-    };
-    requestBody?: never;
-    responses: {
-      /** @description Release channel deleted */
-      200: {
-        headers: {
-          [name: string]: unknown;
-        };
-        content: {
-          "application/json": {
-            message: string;
-          };
-        };
-      };
-      /** @description Permission denied */
-      403: {
-        headers: {
-          [name: string]: unknown;
-        };
-        content: {
-          "application/json": {
-            error: string;
-          };
-        };
-      };
-      /** @description Release channel not found */
-      404: {
-        headers: {
-          [name: string]: unknown;
-        };
-        content: {
-          "application/json": {
-            error: string;
-          };
-        };
-      };
-      /** @description Failed to delete release channel */
-      500: {
-        headers: {
-          [name: string]: unknown;
-        };
-        content: {
-          "application/json": {
-            error: string;
-          };
-        };
-      };
-    };
-  };
-  getResourcesForDeployment: {
-    parameters: {
-      query?: never;
-      header?: never;
-      path: {
-        /** @description UUID of the deployment */
-        deploymentId: string;
-      };
-      cookie?: never;
-    };
-    requestBody?: never;
-    responses: {
-      /** @description OK */
-      200: {
-        headers: {
-          [name: string]: unknown;
-        };
-        content: {
-          "application/json": {
-            resources?: components["schemas"]["Resource"][];
-            count?: number;
-          };
-        };
-      };
-      /** @description Internal Server Error */
-      500: {
-        headers: {
-          [name: string]: unknown;
-        };
-        content: {
-          "application/json": {
-            error?: string;
-          };
-        };
-      };
-    };
-  };
-  getDeploymentVariables: {
-    parameters: {
-      query?: never;
-      header?: never;
-      path: {
-        deploymentId: string;
-      };
-      cookie?: never;
-    };
-    requestBody?: never;
-    responses: {
-      /** @description Variables fetched successfully */
-      200: {
-        headers: {
-          [name: string]: unknown;
-        };
-        content: {
-          "application/json": components["schemas"]["DeploymentVariable"][];
-        };
-      };
-      /** @description Deployment not found */
-      404: {
-        headers: {
-          [name: string]: unknown;
-        };
-        content: {
-          "application/json": {
-            error: string;
-          };
-        };
-      };
-      /** @description Failed to fetch variables */
-      500: {
-        headers: {
-          [name: string]: unknown;
-        };
-        content: {
-          "application/json": {
-            error: string;
-          };
-        };
-      };
-    };
-  };
-  createDeploymentVariable: {
-    parameters: {
-      query?: never;
-      header?: never;
-      path: {
-        deploymentId: string;
-      };
-      cookie?: never;
-    };
-    requestBody?: {
-      content: {
-        "application/json": {
-          key: string;
-          description?: string;
-          config: {
-            [key: string]: unknown;
-          };
-          values?: (components["schemas"]["VariableValue"] & {
-            resourceSelector?: {
-              [key: string]: unknown;
-            } | null;
-          })[];
-        };
-      };
-    };
-    responses: {
-      /** @description Variable created successfully */
-      200: {
-        headers: {
-          [name: string]: unknown;
-        };
-        content: {
-          "application/json": components["schemas"]["DeploymentVariable"];
-        };
-      };
-      /** @description Invalid request body */
-      400: {
-        headers: {
-          [name: string]: unknown;
-        };
-        content: {
-          "application/json": {
-            error: string;
-          };
-        };
-      };
-      /** @description Deployment not found */
-      404: {
-        headers: {
-          [name: string]: unknown;
-        };
-        content: {
-          "application/json": {
-            error: string;
-          };
-        };
-      };
-      /** @description Failed to create variable */
-      500: {
-        headers: {
-          [name: string]: unknown;
-        };
-        content: {
-          "application/json": {
-            error: string;
-          };
-        };
-      };
-    };
-  };
-  createDeployment: {
-    parameters: {
-      query?: never;
-      header?: never;
-      path?: never;
-      cookie?: never;
-    };
-    requestBody?: {
-      content: {
-        "application/json": {
-          /**
-           * Format: uuid
-           * @description The ID of the system to create the deployment for
-           * @example 123e4567-e89b-12d3-a456-426614174000
-           */
-          systemId: string;
-          /**
-           * @description The name of the deployment
-           * @example My Deployment
-           */
-          name: string;
-          /**
-           * @description The slug of the deployment
-           * @example my-deployment
-           */
-          slug: string;
-          /**
-           * @description The description of the deployment
-           * @example This is a deployment for my system
-           */
-          description?: string;
-          /**
-           * Format: uuid
-           * @description The ID of the job agent to use for the deployment
-           * @example 123e4567-e89b-12d3-a456-426614174000
-           */
-          jobAgentId?: string;
-          /**
-           * @description The configuration for the job agent
-           * @example {
-           *       "key": "value"
-           *     }
-           */
-          jobAgentConfig?: Record<string, never>;
-          /**
-           * @description The number of times to retry the deployment
-           * @example 3
-           */
-          retryCount?: number;
-          /**
-           * @description The timeout for the deployment
-           * @example 60
-           */
-          timeout?: number;
-          /**
-           * @description The resource selector for the deployment
-           * @example {
-           *       "key": "value"
-           *     }
-           */
-          resourceSelector?: {
-            [key: string]: unknown;
-          };
-        };
-      };
-    };
-    responses: {
-      /** @description Deployment updated */
-      200: {
-        headers: {
-          [name: string]: unknown;
-        };
-        content: {
-          "application/json": components["schemas"]["Deployment"];
-        };
-      };
-      /** @description Deployment created */
-      201: {
-        headers: {
-          [name: string]: unknown;
-        };
-        content: {
-          "application/json": components["schemas"]["Deployment"];
-        };
-      };
-      /** @description Deployment already exists */
-      409: {
-        headers: {
-          [name: string]: unknown;
-        };
-        content: {
-          "application/json": {
-            error: string;
-            /** Format: uuid */
-            id: string;
-          };
-        };
-      };
-      /** @description Failed to create deployment */
-      500: {
-        headers: {
-          [name: string]: unknown;
-        };
-        content: {
-          "application/json": {
-            error: string;
-          };
-        };
-      };
-    };
-  };
-  getEnvironment: {
-    parameters: {
-      query?: never;
-      header?: never;
-      path: {
-        /** @description UUID of the environment */
-        environmentId: string;
-      };
-      cookie?: never;
-    };
-    requestBody?: never;
-    responses: {
-      /** @description Successful response */
-      200: {
-        headers: {
-          [name: string]: unknown;
-        };
-        content: {
-          "application/json": components["schemas"]["Environment"];
-        };
-      };
-      /** @description Environment not found */
-      404: {
-        headers: {
-          [name: string]: unknown;
-        };
-        content: {
-          "application/json": {
-            /** @example Environment not found */
-            error: string;
-          };
-        };
-      };
-    };
-  };
-  deleteEnvironment: {
-    parameters: {
-      query?: never;
-      header?: never;
-      path: {
-        /** @description UUID of the environment */
-        environmentId: string;
-      };
-      cookie?: never;
-    };
-    requestBody?: never;
-    responses: {
-      /** @description Environment deleted successfully */
-      200: {
-        headers: {
-          [name: string]: unknown;
-        };
-        content?: never;
-      };
-    };
-  };
-  getResourcesForEnvironment: {
-    parameters: {
-      query?: never;
-      header?: never;
-      path: {
-        /** @description UUID of the environment */
-        environmentId: string;
-      };
-      cookie?: never;
-    };
-    requestBody?: never;
-    responses: {
-      /** @description OK */
-      200: {
-        headers: {
-          [name: string]: unknown;
-        };
-        content: {
-          "application/json": {
-            resources?: components["schemas"]["Resource"][];
-            count?: number;
-          };
-        };
-      };
-      /** @description Internal Server Error */
-      500: {
-        headers: {
-          [name: string]: unknown;
-        };
-        content: {
-          "application/json": {
-            error?: string;
-          };
-        };
-      };
-    };
-  };
-  createEnvironment: {
-    parameters: {
-      query?: never;
-      header?: never;
-      path?: never;
-      cookie?: never;
-    };
-    requestBody: {
-      content: {
-        "application/json": {
-          /**
-           * @description The directory path of the environment
-           * @default
-           * @example my/env/path
-           */
-          directory?: string;
-          systemId: string;
-          name: string;
-          description?: string;
-          resourceSelector?: {
-            [key: string]: unknown;
-          };
-          policyId?: string;
-          releaseChannels?: string[];
-          deploymentVersionChannels?: string[];
-          metadata?: {
-            [key: string]: string;
-          };
-        };
-      };
-    };
-    responses: {
-      /** @description Environment created successfully */
-      200: {
-        headers: {
-          [name: string]: unknown;
-        };
-        content: {
-          "application/json": components["schemas"]["Environment"];
-        };
-      };
-      /** @description Environment already exists */
-      409: {
-        headers: {
-          [name: string]: unknown;
-        };
-        content: {
-          "application/json": {
-            error?: string;
-            id?: string;
-          };
-        };
-      };
-      /** @description Failed to create environment */
-      500: {
-        headers: {
-          [name: string]: unknown;
-        };
-        content: {
-          "application/json": {
-            error: string;
-          };
-        };
-      };
-    };
-  };
-  getAgentRunningJobs: {
-    parameters: {
-      query?: never;
-      header?: never;
-      path: {
-        /** @description The execution ID */
-        agentId: string;
-      };
-      cookie?: never;
-    };
-    requestBody?: never;
-    responses: {
-      /** @description OK */
-      200: {
-        headers: {
-          [name: string]: unknown;
-        };
-        content: {
-          "application/json": {
-            jobs: components["schemas"]["Job"][];
-          };
-        };
-      };
-    };
-  };
-  acknowledgeAgentJob: {
-    parameters: {
-      query?: never;
-      header?: never;
-      path: {
-        /** @description The ID of the job agent */
-        agentId: string;
-      };
-      cookie?: never;
-    };
-    requestBody?: never;
-    responses: {
-      /** @description Successfully acknowledged job */
-      200: {
-        headers: {
-          [name: string]: unknown;
-        };
-        content: {
-          "application/json": {
-            job?: components["schemas"]["Job"];
-          };
-        };
-      };
-      /** @description Unauthorized */
-      401: {
-        headers: {
-          [name: string]: unknown;
-        };
-        content: {
-          "application/json": {
-            error?: string;
-          };
-        };
-      };
-      /** @description Workspace not found */
-      404: {
-        headers: {
-          [name: string]: unknown;
-        };
-        content: {
-          "application/json": {
-            error?: string;
-          };
-        };
-      };
-    };
-  };
-  getNextJobs: {
-    parameters: {
-      query?: never;
-      header?: never;
-      path: {
-        /** @description The agent ID */
-        agentId: string;
-      };
-      cookie?: never;
-    };
-    requestBody?: never;
-    responses: {
-      /** @description OK */
-      200: {
-        headers: {
-          [name: string]: unknown;
-        };
-        content: {
-          "application/json": {
-            jobs?: components["schemas"]["Job"][];
-          };
-        };
-      };
-    };
-  };
-  upsertJobAgent: {
-    parameters: {
-      query?: never;
-      header?: never;
-      path?: never;
-      cookie?: never;
-    };
-    requestBody: {
-      content: {
-        "application/json": {
-          workspaceId: string;
-          name: string;
-          type: string;
-        };
-      };
-    };
-    responses: {
-      /** @description Successfully retrieved or created the agent */
-      200: {
-        headers: {
-          [name: string]: unknown;
-        };
-        content: {
-          "application/json": {
-            id: string;
-            name: string;
-            workspaceId: string;
-          };
-        };
-      };
-      /** @description Internal server error */
-      500: {
-        headers: {
-          [name: string]: unknown;
-        };
-        content?: never;
-      };
-    };
-  };
-  acknowledgeJob: {
-    parameters: {
-      query?: never;
-      header?: never;
-      path: {
-        /** @description The job ID */
-        jobId: string;
-      };
-      cookie?: never;
-    };
-    requestBody?: never;
-    responses: {
-      /** @description OK */
-      200: {
-        headers: {
-          [name: string]: unknown;
-        };
-        content: {
-          "application/json": {
-            sucess: boolean;
-          };
-        };
-      };
-      /** @description Unauthorized */
-      401: {
-        headers: {
-          [name: string]: unknown;
-        };
-        content: {
-          "application/json": {
-            error: string;
-          };
-        };
-      };
-    };
-  };
-  getJob: {
-    parameters: {
-      query?: never;
-      header?: never;
-      path: {
-        /** @description The job ID */
-        jobId: string;
-      };
-      cookie?: never;
-    };
-    requestBody?: never;
-    responses: {
-      /** @description OK */
-      200: {
-        headers: {
-          [name: string]: unknown;
-        };
-        content: {
-          "application/json": components["schemas"]["JobWithTrigger"];
-        };
-      };
-      /** @description Not Found */
-      404: {
-        headers: {
-          [name: string]: unknown;
-        };
-        content: {
-          "application/json": {
-            /** @example Job not found. */
-            error?: string;
-          };
-        };
-      };
-    };
-  };
-  updateJob: {
-    parameters: {
-      query?: never;
-      header?: never;
-      path: {
-        /** @description The execution ID */
-        jobId: string;
-      };
-      cookie?: never;
-    };
-    requestBody: {
-      content: {
-        "application/json": {
-          status?: components["schemas"]["JobStatus"];
-          message?: string | null;
-          externalId?: string | null;
-        };
-      };
-    };
-    responses: {
-      /** @description OK */
-      200: {
-        headers: {
-          [name: string]: unknown;
-        };
-        content: {
-          "application/json": {
-            id: string;
-          };
-        };
-      };
-    };
-  };
-  deletePolicy: {
-    parameters: {
-      query?: never;
-      header?: never;
-      path: {
-        policyId: string;
-      };
-      cookie?: never;
-    };
-    requestBody?: never;
-    responses: {
-      /** @description OK */
-      200: {
-        headers: {
-          [name: string]: unknown;
-        };
-        content: {
-          "application/json": {
-            count?: number;
-          };
-        };
-      };
-      /** @description Internal Server Error */
-      500: {
-        headers: {
-          [name: string]: unknown;
-        };
-        content: {
-          "application/json": {
-            error?: string;
-          };
-        };
-      };
-    };
-  };
-  updatePolicy: {
-    parameters: {
-      query?: never;
-      header?: never;
-      path: {
-        policyId: string;
-      };
-      cookie?: never;
-    };
-    requestBody: {
-      content: {
-        "application/json": {
-          name?: string;
-          description?: string;
-          priority?: number;
-          enabled?: boolean;
-          workspaceId?: string;
-          targets?: components["schemas"]["PolicyTarget"][];
-          denyWindows?: {
-            timeZone: string;
-            rrule?: {
-              [key: string]: unknown;
-            };
-            /** Format: date-time */
-            dtend?: string;
-          }[];
-          deploymentVersionSelector?: components["schemas"]["DeploymentVersionSelector"];
-          versionAnyApprovals?: {
-            requiredApprovalsCount?: number;
-          }[];
-          versionUserApprovals?: components["schemas"]["VersionUserApproval"][];
-          versionRoleApprovals?: {
-            roleId: string;
-            requiredApprovalsCount?: number;
-          }[];
-        };
-      };
-    };
-    responses: {
-      /** @description OK */
-      200: {
-        headers: {
-          [name: string]: unknown;
-        };
-        content: {
-          "application/json": components["schemas"]["Policy"];
-        };
-      };
-      /** @description Policy not found */
-      404: {
-        headers: {
-          [name: string]: unknown;
-        };
-        content: {
-          "application/json": {
-            error?: string;
-          };
-        };
-      };
-      /** @description Internal Server Error */
-      500: {
-        headers: {
-          [name: string]: unknown;
-        };
-        content: {
-          "application/json": {
-            error?: string;
-          };
-        };
-      };
-    };
-  };
-  getReleaseTargetsForPolicy: {
-    parameters: {
-      query?: never;
-      header?: never;
-      path: {
-        /** @description UUID of the policy */
-        policyId: string;
-      };
-      cookie?: never;
-    };
-    requestBody?: never;
-    responses: {
-      /** @description OK */
-      200: {
-        headers: {
-          [name: string]: unknown;
-        };
-        content: {
-          "application/json": {
-            releaseTargets?: components["schemas"]["ReleaseTarget"][];
-            count?: number;
-          };
-        };
-      };
-      /** @description Internal Server Error */
-      500: {
-        headers: {
-          [name: string]: unknown;
-        };
-        content: {
-          "application/json": {
-            error?: string;
-          };
-        };
-      };
-    };
-  };
-  upsertPolicy: {
-    parameters: {
-      query?: never;
-      header?: never;
-      path?: never;
-      cookie?: never;
-    };
-    requestBody: {
-      content: {
-        "application/json": {
-          name: string;
-          description?: string;
-          priority?: number;
-          enabled?: boolean;
-          workspaceId: string;
-          targets: components["schemas"]["PolicyTarget"][];
-          denyWindows?: {
-            timeZone: string;
-            rrule?: {
-              [key: string]: unknown;
-            };
-            /** Format: date-time */
-            dtend?: string;
-          }[];
-          deploymentVersionSelector?: components["schemas"]["DeploymentVersionSelector"];
-          versionAnyApprovals?: {
-            requiredApprovalsCount?: number;
-          }[];
-          versionUserApprovals?: components["schemas"]["VersionUserApproval"][];
-          versionRoleApprovals?: {
-            roleId: string;
-            requiredApprovalsCount?: number;
-          }[];
-        };
-      };
-    };
-    responses: {
-      /** @description OK */
-      200: {
-        headers: {
-          [name: string]: unknown;
-        };
-        content: {
-          "application/json": components["schemas"]["Policy1"];
-        };
-      };
-      /** @description Internal Server Error */
-      500: {
-        headers: {
-          [name: string]: unknown;
-        };
-        content: {
-          "application/json": {
-            error?: string;
-          };
-        };
-      };
-    };
-  };
-  createJobToResourceRelationship: {
-    parameters: {
-      query?: never;
-      header?: never;
-      path?: never;
-      cookie?: never;
-    };
-    requestBody: {
-      content: {
-        "application/json": {
-          /**
-           * Format: uuid
-           * @description Unique identifier of the job
-           * @example 123e4567-e89b-12d3-a456-426614174000
-           */
-          jobId: string;
-          /**
-           * @description Unique identifier of the resource
-           * @example resource-123
-           */
-          resourceIdentifier: string;
-        };
-      };
-    };
-    responses: {
-      /** @description Relationship created successfully */
-      200: {
-        headers: {
-          [name: string]: unknown;
-        };
-        content: {
-          "application/json": {
-            /** @example Relationship created successfully */
-            message?: string;
-          };
-        };
-      };
-      /** @description Invalid request body */
-      400: {
-        headers: {
-          [name: string]: unknown;
-        };
-        content: {
-          "application/json": {
-            /** @example Invalid jobId format */
-            error?: string;
-          };
-        };
-      };
-      /** @description Job or resource not found */
-      404: {
-        headers: {
-          [name: string]: unknown;
-        };
-        content: {
-          "application/json": {
-            /** @example Job with specified ID not found */
-            error?: string;
-          };
-        };
-      };
-      /** @description Relationship already exists */
-      409: {
-        headers: {
-          [name: string]: unknown;
-        };
-        content: {
-          "application/json": {
-            /** @example Relationship between job and resource already exists */
-            error?: string;
-          };
-        };
-      };
-      /** @description Internal server error */
-      500: {
-        headers: {
-          [name: string]: unknown;
-        };
-        content: {
-          "application/json": {
-            /** @example Internal server error occurred */
-            error?: string;
-          };
-        };
-      };
-    };
-  };
-  createResourceToResourceRelationship: {
-    parameters: {
-      query?: never;
-      header?: never;
-      path?: never;
-      cookie?: never;
-    };
-    requestBody: {
-      content: {
-        "application/json": {
-          /**
-           * Format: uuid
-           * @description The workspace ID
-           * @example 123e4567-e89b-12d3-a456-426614174000
-           */
-          workspaceId: string;
-          /**
-           * @description The identifier of the resource to connect
-           * @example my-resource
-           */
-          fromIdentifier: string;
-          /**
-           * @description The identifier of the resource to connect to
-           * @example my-resource
-           */
-          toIdentifier: string;
-          /**
-           * @description The type of relationship
-           * @example depends_on
-           */
-          type: string;
-        };
-      };
-    };
-    responses: {
-      /** @description Relationship created */
-      200: {
-        headers: {
-          [name: string]: unknown;
-        };
-        content: {
-          "application/json": {
-            /** @example Relationship created successfully */
-            message?: string;
-          };
-        };
-      };
-      /** @description Invalid request body */
-      400: {
-        headers: {
-          [name: string]: unknown;
-        };
-        content: {
-          "application/json": {
-            error?: string;
-          };
-        };
-      };
-      /** @description Resource not found */
-      404: {
-        headers: {
-          [name: string]: unknown;
-        };
-        content: {
-          "application/json": {
-            error?: string;
-          };
-        };
-      };
-      /** @description Relationship already exists */
-      409: {
-        headers: {
-          [name: string]: unknown;
-        };
-        content: {
-          "application/json": {
-            error?: string;
-          };
-        };
-      };
-      /** @description Internal server error */
-      500: {
-        headers: {
-          [name: string]: unknown;
-        };
-        content: {
-          "application/json": {
-            error?: string;
-          };
-        };
-      };
-    };
-  };
-  createReleaseChannel: {
-    parameters: {
-      query?: never;
-      header?: never;
-      path?: never;
-      cookie?: never;
-    };
-    requestBody: {
-      content: {
-        "application/json": {
-          deploymentId: string;
-          name: string;
-          description?: string | null;
-          releaseSelector: {
-            [key: string]: unknown;
-          };
-        };
-      };
-    };
-    responses: {
-      /** @description Release channel created successfully */
-      200: {
-        headers: {
-          [name: string]: unknown;
-        };
-        content: {
-          "application/json": {
-            id: string;
-            deploymentId: string;
-            name: string;
-            description?: string | null;
-            /** Format: date-time */
-            createdAt: string;
-            releaseSelector?: {
-              [key: string]: unknown;
-            };
-          };
-        };
-      };
-      /** @description Unauthorized */
-      401: {
-        headers: {
-          [name: string]: unknown;
-        };
-        content: {
-          "application/json": {
-            error: string;
-          };
-        };
-      };
-      /** @description Forbidden */
-      403: {
-        headers: {
-          [name: string]: unknown;
-        };
-        content: {
-          "application/json": {
-            error: string;
-          };
-        };
-      };
-      /** @description Release channel already exists */
-      409: {
-        headers: {
-          [name: string]: unknown;
-        };
-        content: {
-          "application/json": {
-            error: string;
-            id: string;
-          };
-        };
-      };
-      /** @description Failed to create release channel */
-      500: {
-        headers: {
-          [name: string]: unknown;
-        };
-        content: {
-          "application/json": {
-            error: string;
-          };
-        };
-      };
-    };
-  };
-  getReleaseTargetReleases: {
-    parameters: {
-      query?: never;
-      header?: never;
-      path: {
-        releaseTargetId: string;
-      };
-      cookie?: never;
-    };
-    requestBody?: never;
-    responses: {
-      /** @description The latest 100 releases for the release target */
-      200: {
-        headers: {
-          [name: string]: unknown;
-        };
-        content: {
-          "application/json": {
-            deployment: components["schemas"]["Deployment"];
-            version: components["schemas"]["DeploymentVersion"];
-            variables: {
-              key: string;
-              value: string;
-            }[];
-          }[];
-        };
-      };
-      /** @description The release target was not found */
-      404: {
-        headers: {
-          [name: string]: unknown;
-        };
-        content: {
-          "application/json": {
-            error: string;
-          };
-        };
-      };
-      /** @description An internal server error occurred */
-      500: {
-        headers: {
-          [name: string]: unknown;
-        };
-        content: {
-          "application/json": {
-            error: string;
-          };
-        };
-      };
-    };
-  };
-  updateRelease: {
-    parameters: {
-      query?: never;
-      header?: never;
-      path: {
-        /** @description The release ID */
-        releaseId: string;
-      };
-      cookie?: never;
-    };
-    requestBody: {
-      content: {
-        "application/json": {
-          version?: string;
-          deploymentId?: string;
-          /** Format: date-time */
-          createdAt?: string;
-          name?: string;
-          config?: {
-            [key: string]: unknown;
-          };
-          jobAgentConfig?: {
-            [key: string]: unknown;
-          };
-          /** @enum {string} */
-          status?: "ready" | "building" | "failed";
-          message?: string;
-          metadata?: {
-            [key: string]: string;
-          };
-        };
-      };
-    };
-    responses: {
-      /** @description OK */
-      200: {
-        headers: {
-          [name: string]: unknown;
-        };
-        content: {
-          "application/json": components["schemas"]["Release"];
-        };
-      };
-    };
-  };
-  upsertRelease: {
-    parameters: {
-      query?: never;
-      header?: never;
-      path?: never;
-      cookie?: never;
-    };
-    requestBody: {
-      content: {
-        "application/json": {
-          version: string;
-          deploymentId: string;
-          /** Format: date-time */
-          createdAt?: string;
-          name?: string;
-          config?: {
-            [key: string]: unknown;
-          };
-          jobAgentConfig?: {
-            [key: string]: unknown;
-          };
-          /** @enum {string} */
-          status?: "ready" | "building" | "failed";
-          message?: string;
-          metadata?: {
-            [key: string]: string;
-          };
-        };
-      };
-    };
-    responses: {
-      /** @description OK */
-      200: {
-        headers: {
-          [name: string]: unknown;
-        };
-        content: {
-          "application/json": components["schemas"]["Release"];
-        };
-      };
-      /** @description Release already exists */
-      409: {
-        headers: {
-          [name: string]: unknown;
-        };
-        content: {
-          "application/json": {
-            error?: string;
-            id?: string;
-          };
-        };
-      };
-    };
-  };
-  setResourceProvidersResources: {
-    parameters: {
-      query?: never;
-      header?: never;
-      path: {
-        /** @description UUID of the scanner */
-        providerId: string;
-      };
-      cookie?: never;
-    };
-    requestBody: {
-      content: {
-        "application/json": {
-          resources: components["schemas"]["CreateResource"][];
-        };
-      };
-    };
-    responses: {
-      /** @description Successfully updated the deployment resources */
-      200: {
-        headers: {
-          [name: string]: unknown;
-        };
-        content: {
-          "application/json": {
-            resources?: {
-              ignored?: {
-                identifier?: string;
-                name?: string;
-                version?: string;
-                kind?: string;
-                workspaceId?: string;
-              }[];
-              inserted?: {
-                id?: string;
-                name?: string;
-                version?: string;
-                kind?: string;
-                config?: {
-                  [key: string]: unknown;
+            cookie?: never;
+        };
+        requestBody?: never;
+        responses: {
+            /** @description Successfully returned geographic data for cloud provider regions */
+            200: {
+                headers: {
+                    [name: string]: unknown;
                 };
-              }[];
-              updated?: {
-                id?: string;
-                name?: string;
-                version?: string;
-                kind?: string;
-                config?: {
-                  [key: string]: unknown;
+                content: {
+                    "application/json": {
+                        [key: string]: components["schemas"]["CloudRegionGeoData"];
+                    };
                 };
-              }[];
-              deleted?: {
-                id?: string;
-                name?: string;
-                version?: string;
-                kind?: string;
-                config?: {
-                  [key: string]: unknown;
-                };
-              }[];
             };
-          };
+            /** @description Cloud provider not found */
+            404: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": {
+                        /** @example Cloud provider 'unknown' not found */
+                        error?: string;
+                    };
+                };
+            };
         };
-      };
-      /** @description Invalid request */
-      400: {
-        headers: {
-          [name: string]: unknown;
-        };
-        content?: never;
-      };
-      /** @description Deployment resources not found */
-      404: {
-        headers: {
-          [name: string]: unknown;
-        };
-        content: {
-          "application/json": {
-            error?: string;
-          };
-        };
-      };
-      /** @description Internal server error */
-      500: {
-        headers: {
-          [name: string]: unknown;
-        };
-        content?: never;
-      };
     };
-  };
-  updateResourceRelationshipRule: {
-    parameters: {
-      query?: never;
-      header?: never;
-      path: {
-        ruleId: string;
-      };
-      cookie?: never;
+    createDeploymentVersionChannel: {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        requestBody: {
+            content: {
+                "application/json": {
+                    deploymentId: string;
+                    name: string;
+                    description?: string | null;
+                    versionSelector: {
+                        [key: string]: unknown;
+                    };
+                };
+            };
+        };
+        responses: {
+            /** @description Deployment version channel created successfully */
+            200: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": {
+                        id: string;
+                        deploymentId: string;
+                        name: string;
+                        description?: string | null;
+                        /** Format: date-time */
+                        createdAt: string;
+                        versionSelector?: {
+                            [key: string]: unknown;
+                        };
+                    };
+                };
+            };
+            /** @description Unauthorized */
+            401: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": {
+                        error: string;
+                    };
+                };
+            };
+            /** @description Forbidden */
+            403: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": {
+                        error: string;
+                    };
+                };
+            };
+            /** @description Deployment version channel already exists */
+            409: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": {
+                        error: string;
+                        id: string;
+                    };
+                };
+            };
+            /** @description Failed to create deployment version channel */
+            500: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": {
+                        error: string;
+                    };
+                };
+            };
+        };
     };
-    requestBody?: {
-      content: {
-        "application/json": components["schemas"]["UpdateResourceRelationshipRule"];
-      };
+    updateDeploymentVersion: {
+        parameters: {
+            query?: never;
+            header?: never;
+            path: {
+                /** @description The deployment version ID */
+                deploymentVersionId: string;
+            };
+            cookie?: never;
+        };
+        requestBody: {
+            content: {
+                "application/json": {
+                    tag?: string;
+                    deploymentId?: string;
+                    /** Format: date-time */
+                    createdAt?: string;
+                    name?: string;
+                    config?: {
+                        [key: string]: unknown;
+                    };
+                    jobAgentConfig?: {
+                        [key: string]: unknown;
+                    };
+                    /** @enum {string} */
+                    status?: "ready" | "building" | "failed";
+                    message?: string;
+                    metadata?: {
+                        [key: string]: string;
+                    };
+                };
+            };
+        };
+        responses: {
+            /** @description OK */
+            200: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["DeploymentVersion"];
+                };
+            };
+            /** @description Deployment version not found */
+            404: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": {
+                        error?: string;
+                    };
+                };
+            };
+            /** @description Internal server error */
+            500: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": {
+                        error?: string;
+                    };
+                };
+            };
+        };
     };
-    responses: {
-      /** @description The updated resource relationship rule */
-      200: {
-        headers: {
-          [name: string]: unknown;
+    upsertDeploymentVersion: {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
         };
-        content: {
-          "application/json": components["schemas"]["ResourceRelationshipRule"];
+        requestBody: {
+            content: {
+                "application/json": {
+                    tag: string;
+                    deploymentId: string;
+                    /** Format: date-time */
+                    createdAt?: string;
+                    name?: string;
+                    config?: {
+                        [key: string]: unknown;
+                    };
+                    jobAgentConfig?: {
+                        [key: string]: unknown;
+                    };
+                    /** @enum {string} */
+                    status?: "ready" | "building" | "failed";
+                    message?: string;
+                    metadata?: {
+                        [key: string]: string;
+                    };
+                };
+            };
         };
-      };
-      /** @description The resource relationship rule was not found */
-      404: {
-        headers: {
-          [name: string]: unknown;
+        responses: {
+            /** @description OK */
+            201: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["DeploymentVersion"];
+                };
+            };
+            /** @description Internal server error */
+            500: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": {
+                        error?: string;
+                    };
+                };
+            };
         };
-        content: {
-          "application/json": {
-            error: string;
-          };
-        };
-      };
-      /** @description An error occurred while updating the resource relationship rule */
-      500: {
-        headers: {
-          [name: string]: unknown;
-        };
-        content: {
-          "application/json": {
-            error: string;
-          };
-        };
-      };
     };
-  };
-  createResourceRelationshipRule: {
-    parameters: {
-      query?: never;
-      header?: never;
-      path?: never;
-      cookie?: never;
+    deleteDeploymentVersionChannel: {
+        parameters: {
+            query?: never;
+            header?: never;
+            path: {
+                deploymentId: string;
+                name: string;
+            };
+            cookie?: never;
+        };
+        requestBody?: never;
+        responses: {
+            /** @description Deployment version channel deleted */
+            200: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": {
+                        message: string;
+                    };
+                };
+            };
+            /** @description Permission denied */
+            403: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": {
+                        error: string;
+                    };
+                };
+            };
+            /** @description Deployment version channel not found */
+            404: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": {
+                        error: string;
+                    };
+                };
+            };
+            /** @description Failed to delete deployment version channel */
+            500: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": {
+                        error: string;
+                    };
+                };
+            };
+        };
     };
-    requestBody: {
-      content: {
-        "application/json": components["schemas"]["CreateResourceRelationshipRule"];
-      };
+    getDeployment: {
+        parameters: {
+            query?: never;
+            header?: never;
+            path: {
+                deploymentId: string;
+            };
+            cookie?: never;
+        };
+        requestBody?: never;
+        responses: {
+            /** @description Deployment found */
+            200: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["Deployment"];
+                };
+            };
+            /** @description Deployment not found */
+            404: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": {
+                        error: string;
+                    };
+                };
+            };
+        };
     };
-    responses: {
-      /** @description Resource relationship rule created successfully */
-      200: {
-        headers: {
-          [name: string]: unknown;
+    deleteDeployment: {
+        parameters: {
+            query?: never;
+            header?: never;
+            path: {
+                deploymentId: string;
+            };
+            cookie?: never;
         };
-        content: {
-          "application/json": components["schemas"]["ResourceRelationshipRule"];
+        requestBody?: never;
+        responses: {
+            /** @description Deployment deleted */
+            200: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["Deployment"];
+                };
+            };
+            /** @description Deployment not found */
+            404: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": {
+                        error: string;
+                    };
+                };
+            };
+            /** @description Failed to delete deployment */
+            500: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": {
+                        error: string;
+                    };
+                };
+            };
         };
-      };
-      /** @description Resource relationship rule already exists */
-      409: {
-        headers: {
-          [name: string]: unknown;
-        };
-        content: {
-          "application/json": {
-            error?: string;
-          };
-        };
-      };
-      /** @description Failed to create resource relationship rule */
-      500: {
-        headers: {
-          [name: string]: unknown;
-        };
-        content: {
-          "application/json": {
-            error?: string;
-          };
-        };
-      };
     };
-  };
-  createResourceSchema: {
-    parameters: {
-      query?: never;
-      header?: never;
-      path?: never;
-      cookie?: never;
+    updateDeployment: {
+        parameters: {
+            query?: never;
+            header?: never;
+            path: {
+                deploymentId: string;
+            };
+            cookie?: never;
+        };
+        requestBody: {
+            content: {
+                "application/json": {
+                    name?: string;
+                    slug?: string;
+                    description?: string;
+                    /** Format: uuid */
+                    systemId?: string;
+                    /** Format: uuid */
+                    jobAgentId?: string | null;
+                    jobAgentConfig?: {
+                        [key: string]: unknown;
+                    };
+                    retryCount?: number;
+                    timeout?: number | null;
+                    resourceSelector?: {
+                        [key: string]: unknown;
+                    } | null;
+                };
+            };
+        };
+        responses: {
+            /** @description Deployment updated */
+            200: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["Deployment"];
+                };
+            };
+            /** @description Deployment not found */
+            404: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": {
+                        error: string;
+                    };
+                };
+            };
+            /** @description Failed to update deployment */
+            500: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": {
+                        error: string;
+                    };
+                };
+            };
+        };
     };
-    requestBody: {
-      content: {
-        "application/json": {
-          /**
-           * Format: uuid
-           * @description The ID of the workspace
-           */
-          workspaceId: string;
-          /** @description Version of the schema */
-          version: string;
-          /** @description Kind of resource this schema is for */
-          kind: string;
-          /** @description The JSON schema definition */
-          jsonSchema: Record<string, never>;
+    deleteReleaseChannel: {
+        parameters: {
+            query?: never;
+            header?: never;
+            path: {
+                deploymentId: string;
+                name: string;
+            };
+            cookie?: never;
         };
-      };
+        requestBody?: never;
+        responses: {
+            /** @description Release channel deleted */
+            200: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": {
+                        message: string;
+                    };
+                };
+            };
+            /** @description Permission denied */
+            403: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": {
+                        error: string;
+                    };
+                };
+            };
+            /** @description Release channel not found */
+            404: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": {
+                        error: string;
+                    };
+                };
+            };
+            /** @description Failed to delete release channel */
+            500: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": {
+                        error: string;
+                    };
+                };
+            };
+        };
     };
-    responses: {
-      /** @description Resource schema created successfully */
-      201: {
-        headers: {
-          [name: string]: unknown;
+    getResourcesForDeployment: {
+        parameters: {
+            query?: never;
+            header?: never;
+            path: {
+                /** @description UUID of the deployment */
+                deploymentId: string;
+            };
+            cookie?: never;
         };
-        content: {
-          "application/json": {
-            /** Format: uuid */
-            id?: string;
-            /** Format: uuid */
-            workspaceId?: string;
-            version?: string;
-            kind?: string;
-            jsonSchema?: Record<string, never>;
-          };
+        requestBody?: never;
+        responses: {
+            /** @description OK */
+            200: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": {
+                        resources?: components["schemas"]["Resource"][];
+                        count?: number;
+                    };
+                };
+            };
+            /** @description Internal Server Error */
+            500: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": {
+                        error?: string;
+                    };
+                };
+            };
         };
-      };
-      /** @description Invalid request body */
-      400: {
-        headers: {
-          [name: string]: unknown;
-        };
-        content: {
-          "application/json": {
-            error?: string;
-          };
-        };
-      };
-      /** @description Schema already exists for this version and kind */
-      409: {
-        headers: {
-          [name: string]: unknown;
-        };
-        content: {
-          "application/json": {
-            error?: string;
-            /** Format: uuid */
-            id?: string;
-          };
-        };
-      };
     };
-  };
-  deleteResourceSchema: {
-    parameters: {
-      query?: never;
-      header?: never;
-      path: {
-        /** @description UUID of the schema to delete */
-        schemaId: string;
-      };
-      cookie?: never;
+    getDeploymentVariables: {
+        parameters: {
+            query?: never;
+            header?: never;
+            path: {
+                deploymentId: string;
+            };
+            cookie?: never;
+        };
+        requestBody?: never;
+        responses: {
+            /** @description Variables fetched successfully */
+            200: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["DeploymentVariable"][];
+                };
+            };
+            /** @description Deployment not found */
+            404: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": {
+                        error: string;
+                    };
+                };
+            };
+            /** @description Failed to fetch variables */
+            500: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": {
+                        error: string;
+                    };
+                };
+            };
+        };
     };
-    requestBody?: never;
-    responses: {
-      /** @description Schema deleted successfully */
-      200: {
-        headers: {
-          [name: string]: unknown;
+    createDeploymentVariable: {
+        parameters: {
+            query?: never;
+            header?: never;
+            path: {
+                deploymentId: string;
+            };
+            cookie?: never;
         };
-        content: {
-          "application/json": {
-            /** Format: uuid */
-            id?: string;
-          };
+        requestBody?: {
+            content: {
+                "application/json": {
+                    key: string;
+                    description?: string;
+                    config: {
+                        [key: string]: unknown;
+                    };
+                    values?: components["schemas"]["VariableValue"][];
+                };
+            };
         };
-      };
-      /** @description Schema not found */
-      404: {
-        headers: {
-          [name: string]: unknown;
+        responses: {
+            /** @description Variable created successfully */
+            200: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["DeploymentVariable"];
+                };
+            };
+            /** @description Invalid request body */
+            400: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": {
+                        error: string;
+                    };
+                };
+            };
+            /** @description Deployment not found */
+            404: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": {
+                        error: string;
+                    };
+                };
+            };
+            /** @description Failed to create variable */
+            500: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": {
+                        error: string;
+                    };
+                };
+            };
         };
-        content: {
-          "application/json": {
-            /** @example Schema not found */
-            error?: string;
-          };
-        };
-      };
     };
-  };
-  getResource: {
-    parameters: {
-      query?: never;
-      header?: never;
-      path: {
-        /** @description The resource ID */
-        resourceId: string;
-      };
-      cookie?: never;
+    createDeployment: {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        requestBody?: {
+            content: {
+                "application/json": {
+                    /**
+                     * Format: uuid
+                     * @description The ID of the system to create the deployment for
+                     * @example 123e4567-e89b-12d3-a456-426614174000
+                     */
+                    systemId: string;
+                    /**
+                     * @description The name of the deployment
+                     * @example My Deployment
+                     */
+                    name: string;
+                    /**
+                     * @description The slug of the deployment
+                     * @example my-deployment
+                     */
+                    slug: string;
+                    /**
+                     * @description The description of the deployment
+                     * @example This is a deployment for my system
+                     */
+                    description?: string;
+                    /**
+                     * Format: uuid
+                     * @description The ID of the job agent to use for the deployment
+                     * @example 123e4567-e89b-12d3-a456-426614174000
+                     */
+                    jobAgentId?: string;
+                    /**
+                     * @description The configuration for the job agent
+                     * @example {
+                     *       "key": "value"
+                     *     }
+                     */
+                    jobAgentConfig?: Record<string, never>;
+                    /**
+                     * @description The number of times to retry the deployment
+                     * @example 3
+                     */
+                    retryCount?: number;
+                    /**
+                     * @description The timeout for the deployment
+                     * @example 60
+                     */
+                    timeout?: number;
+                    /**
+                     * @description The resource selector for the deployment
+                     * @example {
+                     *       "key": "value"
+                     *     }
+                     */
+                    resourceSelector?: {
+                        [key: string]: unknown;
+                    };
+                };
+            };
+        };
+        responses: {
+            /** @description Deployment updated */
+            200: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["Deployment"];
+                };
+            };
+            /** @description Deployment created */
+            201: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["Deployment"];
+                };
+            };
+            /** @description Deployment already exists */
+            409: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": {
+                        error: string;
+                        /** Format: uuid */
+                        id: string;
+                    };
+                };
+            };
+            /** @description Failed to create deployment */
+            500: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": {
+                        error: string;
+                    };
+                };
+            };
+        };
     };
-    requestBody?: never;
-    responses: {
-      /** @description OK */
-      200: {
-        headers: {
-          [name: string]: unknown;
+    getEnvironment: {
+        parameters: {
+            query?: never;
+            header?: never;
+            path: {
+                /** @description UUID of the environment */
+                environmentId: string;
+            };
+            cookie?: never;
         };
-        content: {
-          "application/json": components["schemas"]["ResourceWithVariablesAndMetadata"];
+        requestBody?: never;
+        responses: {
+            /** @description Successful response */
+            200: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["Environment"];
+                };
+            };
+            /** @description Environment not found */
+            404: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": {
+                        /** @example Environment not found */
+                        error: string;
+                    };
+                };
+            };
         };
-      };
-      /** @description Unauthorized */
-      401: {
-        headers: {
-          [name: string]: unknown;
-        };
-        content?: never;
-      };
-      /** @description Permission denied */
-      403: {
-        headers: {
-          [name: string]: unknown;
-        };
-        content?: never;
-      };
-      /** @description Resource not found */
-      404: {
-        headers: {
-          [name: string]: unknown;
-        };
-        content: {
-          "application/json": {
-            /** @example Resource not found */
-            error: string;
-          };
-        };
-      };
     };
-  };
-  deleteResource: {
-    parameters: {
-      query?: never;
-      header?: never;
-      path: {
-        /** @description The resource ID */
-        resourceId: string;
-      };
-      cookie?: never;
+    deleteEnvironment: {
+        parameters: {
+            query?: never;
+            header?: never;
+            path: {
+                /** @description UUID of the environment */
+                environmentId: string;
+            };
+            cookie?: never;
+        };
+        requestBody?: never;
+        responses: {
+            /** @description Environment deleted successfully */
+            200: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content?: never;
+            };
+        };
     };
-    requestBody?: never;
-    responses: {
-      /** @description Resource deleted successfully */
-      200: {
-        headers: {
-          [name: string]: unknown;
+    getResourcesForEnvironment: {
+        parameters: {
+            query?: never;
+            header?: never;
+            path: {
+                /** @description UUID of the environment */
+                environmentId: string;
+            };
+            cookie?: never;
         };
-        content: {
-          "application/json": {
-            success: boolean;
-          };
+        requestBody?: never;
+        responses: {
+            /** @description OK */
+            200: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": {
+                        resources?: components["schemas"]["Resource"][];
+                        count?: number;
+                    };
+                };
+            };
+            /** @description Internal Server Error */
+            500: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": {
+                        error?: string;
+                    };
+                };
+            };
         };
-      };
-      /** @description Unauthorized */
-      401: {
-        headers: {
-          [name: string]: unknown;
-        };
-        content?: never;
-      };
-      /** @description Permission denied */
-      403: {
-        headers: {
-          [name: string]: unknown;
-        };
-        content?: never;
-      };
-      /** @description Resource not found */
-      404: {
-        headers: {
-          [name: string]: unknown;
-        };
-        content: {
-          "application/json": {
-            error: string;
-          };
-        };
-      };
     };
-  };
-  updateResource: {
-    parameters: {
-      query?: never;
-      header?: never;
-      path: {
-        resourceId: string;
-      };
-      cookie?: never;
+    createEnvironment: {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        requestBody: {
+            content: {
+                "application/json": {
+                    /**
+                     * @description The directory path of the environment
+                     * @default
+                     * @example my/env/path
+                     */
+                    directory?: string;
+                    systemId: string;
+                    name: string;
+                    description?: string;
+                    resourceSelector?: {
+                        [key: string]: unknown;
+                    };
+                    policyId?: string;
+                    releaseChannels?: string[];
+                    deploymentVersionChannels?: string[];
+                    metadata?: {
+                        [key: string]: string;
+                    };
+                };
+            };
+        };
+        responses: {
+            /** @description Environment created successfully */
+            200: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["Environment"];
+                };
+            };
+            /** @description Environment already exists */
+            409: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": {
+                        error?: string;
+                        id?: string;
+                    };
+                };
+            };
+            /** @description Failed to create environment */
+            500: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": {
+                        error: string;
+                    };
+                };
+            };
+        };
     };
-    requestBody: {
-      content: {
-        "application/json": {
-          name?: string;
-          version?: string;
-          kind?: string;
-          identifier?: string;
-          workspaceId?: string;
-          metadata?: components["schemas"]["MetadataMap"];
-          variables?: components["schemas"]["DirectVariable"][];
+    getAgentRunningJobs: {
+        parameters: {
+            query?: never;
+            header?: never;
+            path: {
+                /** @description The execution ID */
+                agentId: string;
+            };
+            cookie?: never;
         };
-      };
+        requestBody?: never;
+        responses: {
+            /** @description OK */
+            200: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": {
+                        jobs: components["schemas"]["Job"][];
+                    };
+                };
+            };
+        };
     };
-    responses: {
-      /** @description Resource updated successfully */
-      200: {
-        headers: {
-          [name: string]: unknown;
+    acknowledgeAgentJob: {
+        parameters: {
+            query?: never;
+            header?: never;
+            path: {
+                /** @description The ID of the job agent */
+                agentId: string;
+            };
+            cookie?: never;
         };
-        content: {
-          "application/json": components["schemas"]["ResourceWithVariablesAndMetadata"];
+        requestBody?: never;
+        responses: {
+            /** @description Successfully acknowledged job */
+            200: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": {
+                        job?: components["schemas"]["Job"];
+                    };
+                };
+            };
+            /** @description Unauthorized */
+            401: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": {
+                        error?: string;
+                    };
+                };
+            };
+            /** @description Workspace not found */
+            404: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": {
+                        error?: string;
+                    };
+                };
+            };
         };
-      };
-      /** @description Unauthorized */
-      401: {
-        headers: {
-          [name: string]: unknown;
-        };
-        content?: never;
-      };
-      /** @description Permission denied */
-      403: {
-        headers: {
-          [name: string]: unknown;
-        };
-        content?: never;
-      };
-      /** @description Resource not found */
-      404: {
-        headers: {
-          [name: string]: unknown;
-        };
-        content: {
-          "application/json": {
-            error: string;
-          };
-        };
-      };
     };
-  };
-  getReleaseTargets: {
-    parameters: {
-      query?: never;
-      header?: never;
-      path: {
-        /** @description The resource ID */
-        resourceId: string;
-      };
-      cookie?: never;
+    getNextJobs: {
+        parameters: {
+            query?: never;
+            header?: never;
+            path: {
+                /** @description The agent ID */
+                agentId: string;
+            };
+            cookie?: never;
+        };
+        requestBody?: never;
+        responses: {
+            /** @description OK */
+            200: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": {
+                        jobs?: components["schemas"]["Job"][];
+                    };
+                };
+            };
+        };
     };
-    requestBody?: never;
-    responses: {
-      /** @description OK */
-      200: {
-        headers: {
-          [name: string]: unknown;
+    upsertJobAgent: {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
         };
-        content: {
-          "application/json": components["schemas"]["ReleaseTarget"][];
+        requestBody: {
+            content: {
+                "application/json": {
+                    workspaceId: string;
+                    name: string;
+                    type: string;
+                };
+            };
         };
-      };
+        responses: {
+            /** @description Successfully retrieved or created the agent */
+            200: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": {
+                        id: string;
+                        name: string;
+                        workspaceId: string;
+                    };
+                };
+            };
+            /** @description Internal server error */
+            500: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content?: never;
+            };
+        };
     };
-  };
-  upsertResource: {
-    parameters: {
-      query?: never;
-      header?: never;
-      path?: never;
-      cookie?: never;
+    acknowledgeJob: {
+        parameters: {
+            query?: never;
+            header?: never;
+            path: {
+                /** @description The job ID */
+                jobId: string;
+            };
+            cookie?: never;
+        };
+        requestBody?: never;
+        responses: {
+            /** @description OK */
+            200: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": {
+                        sucess: boolean;
+                    };
+                };
+            };
+            /** @description Unauthorized */
+            401: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": {
+                        error: string;
+                    };
+                };
+            };
+        };
     };
-    requestBody: {
-      content: {
-        "application/json": {
-          /** Format: uuid */
-          workspaceId: string;
-          name: string;
-          kind: string;
-          identifier: string;
-          version: string;
-          config: Record<string, never>;
-          metadata?: {
-            [key: string]: string;
-          };
-          variables?: components["schemas"]["Variable"][];
+    getJob: {
+        parameters: {
+            query?: never;
+            header?: never;
+            path: {
+                /** @description The job ID */
+                jobId: string;
+            };
+            cookie?: never;
         };
-      };
+        requestBody?: never;
+        responses: {
+            /** @description OK */
+            200: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["JobWithTrigger"];
+                };
+            };
+            /** @description Not Found */
+            404: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": {
+                        /** @example Job not found. */
+                        error?: string;
+                    };
+                };
+            };
+        };
     };
-    responses: {
-      /** @description The created or updated resource */
-      200: {
-        headers: {
-          [name: string]: unknown;
+    updateJob: {
+        parameters: {
+            query?: never;
+            header?: never;
+            path: {
+                /** @description The execution ID */
+                jobId: string;
+            };
+            cookie?: never;
         };
-        content: {
-          "application/json": components["schemas"]["Resource"];
+        requestBody: {
+            content: {
+                "application/json": {
+                    status?: components["schemas"]["JobStatus"];
+                    message?: string | null;
+                    externalId?: string | null;
+                };
+            };
         };
-      };
+        responses: {
+            /** @description OK */
+            200: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": {
+                        id: string;
+                    };
+                };
+            };
+        };
     };
-  };
-  deleteEnvironmentByName: {
-    parameters: {
-      query?: never;
-      header?: never;
-      path: {
-        /** @description UUID of the system */
-        systemId: string;
-        /** @description Name of the environment */
-        name: string;
-      };
-      cookie?: never;
+    deletePolicy: {
+        parameters: {
+            query?: never;
+            header?: never;
+            path: {
+                policyId: string;
+            };
+            cookie?: never;
+        };
+        requestBody?: never;
+        responses: {
+            /** @description OK */
+            200: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": {
+                        count?: number;
+                    };
+                };
+            };
+            /** @description Internal Server Error */
+            500: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": {
+                        error?: string;
+                    };
+                };
+            };
+        };
     };
-    requestBody?: never;
-    responses: {
-      /** @description Environment deleted successfully */
-      200: {
-        headers: {
-          [name: string]: unknown;
+    updatePolicy: {
+        parameters: {
+            query?: never;
+            header?: never;
+            path: {
+                policyId: string;
+            };
+            cookie?: never;
         };
-        content?: never;
-      };
+        requestBody: {
+            content: {
+                "application/json": {
+                    name?: string;
+                    description?: string;
+                    priority?: number;
+                    enabled?: boolean;
+                    workspaceId?: string;
+                    targets?: components["schemas"]["PolicyTarget"][];
+                    denyWindows?: {
+                        timeZone: string;
+                        rrule?: {
+                            [key: string]: unknown;
+                        };
+                        /** Format: date-time */
+                        dtend?: string;
+                    }[];
+                    deploymentVersionSelector?: components["schemas"]["DeploymentVersionSelector"];
+                    versionAnyApprovals?: {
+                        requiredApprovalsCount?: number;
+                    }[];
+                    versionUserApprovals?: components["schemas"]["VersionUserApproval"][];
+                    versionRoleApprovals?: {
+                        roleId: string;
+                        requiredApprovalsCount?: number;
+                    }[];
+                };
+            };
+        };
+        responses: {
+            /** @description OK */
+            200: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["Policy"];
+                };
+            };
+            /** @description Policy not found */
+            404: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": {
+                        error?: string;
+                    };
+                };
+            };
+            /** @description Internal Server Error */
+            500: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": {
+                        error?: string;
+                    };
+                };
+            };
+        };
     };
-  };
-  getSystem: {
-    parameters: {
-      query?: never;
-      header?: never;
-      path: {
-        /** @description UUID of the system */
-        systemId: string;
-      };
-      cookie?: never;
+    getReleaseTargetsForPolicy: {
+        parameters: {
+            query?: never;
+            header?: never;
+            path: {
+                /** @description UUID of the policy */
+                policyId: string;
+            };
+            cookie?: never;
+        };
+        requestBody?: never;
+        responses: {
+            /** @description OK */
+            200: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": {
+                        releaseTargets?: components["schemas"]["ReleaseTarget"][];
+                        count?: number;
+                    };
+                };
+            };
+            /** @description Internal Server Error */
+            500: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": {
+                        error?: string;
+                    };
+                };
+            };
+        };
     };
-    requestBody?: never;
-    responses: {
-      /** @description System retrieved successfully */
-      200: {
-        headers: {
-          [name: string]: unknown;
+    upsertPolicy: {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
         };
-        content: {
-          "application/json": components["schemas"]["System"] & {
-            environments?: components["schemas"]["Environment"][];
-            deployments?: components["schemas"]["Deployment"][];
-          };
+        requestBody: {
+            content: {
+                "application/json": {
+                    name: string;
+                    description?: string;
+                    priority?: number;
+                    enabled?: boolean;
+                    workspaceId: string;
+                    targets: components["schemas"]["PolicyTarget"][];
+                    denyWindows?: {
+                        timeZone: string;
+                        rrule?: {
+                            [key: string]: unknown;
+                        };
+                        /** Format: date-time */
+                        dtend?: string;
+                    }[];
+                    deploymentVersionSelector?: components["schemas"]["DeploymentVersionSelector"];
+                    versionAnyApprovals?: components["schemas"]["VersionAnyApproval"];
+                    versionUserApprovals?: components["schemas"]["VersionUserApproval"][];
+                    versionRoleApprovals?: components["schemas"]["VersionRoleApproval"][];
+                };
+            };
         };
-      };
+        responses: {
+            /** @description OK */
+            200: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["Policy1"];
+                };
+            };
+            /** @description Internal Server Error */
+            500: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": {
+                        error?: string;
+                    };
+                };
+            };
+        };
     };
-  };
-  deleteSystem: {
-    parameters: {
-      query?: never;
-      header?: never;
-      path: {
-        systemId: string;
-      };
-      cookie?: never;
+    createJobToResourceRelationship: {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        requestBody: {
+            content: {
+                "application/json": {
+                    /**
+                     * Format: uuid
+                     * @description Unique identifier of the job
+                     * @example 123e4567-e89b-12d3-a456-426614174000
+                     */
+                    jobId: string;
+                    /**
+                     * @description Unique identifier of the resource
+                     * @example resource-123
+                     */
+                    resourceIdentifier: string;
+                };
+            };
+        };
+        responses: {
+            /** @description Relationship created successfully */
+            200: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": {
+                        /** @example Relationship created successfully */
+                        message?: string;
+                    };
+                };
+            };
+            /** @description Invalid request body */
+            400: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": {
+                        /** @example Invalid jobId format */
+                        error?: string;
+                    };
+                };
+            };
+            /** @description Job or resource not found */
+            404: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": {
+                        /** @example Job with specified ID not found */
+                        error?: string;
+                    };
+                };
+            };
+            /** @description Relationship already exists */
+            409: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": {
+                        /** @example Relationship between job and resource already exists */
+                        error?: string;
+                    };
+                };
+            };
+            /** @description Internal server error */
+            500: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": {
+                        /** @example Internal server error occurred */
+                        error?: string;
+                    };
+                };
+            };
+        };
     };
-    requestBody?: never;
-    responses: {
-      /** @description System deleted successfully */
-      200: {
-        headers: {
-          [name: string]: unknown;
+    createResourceToResourceRelationship: {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
         };
-        content: {
-          "application/json": {
-            /** @example System deleted */
-            message?: string;
-          };
+        requestBody: {
+            content: {
+                "application/json": {
+                    /**
+                     * Format: uuid
+                     * @description The workspace ID
+                     * @example 123e4567-e89b-12d3-a456-426614174000
+                     */
+                    workspaceId: string;
+                    /**
+                     * @description The identifier of the resource to connect
+                     * @example my-resource
+                     */
+                    fromIdentifier: string;
+                    /**
+                     * @description The identifier of the resource to connect to
+                     * @example my-resource
+                     */
+                    toIdentifier: string;
+                    /**
+                     * @description The type of relationship
+                     * @example depends_on
+                     */
+                    type: string;
+                };
+            };
         };
-      };
-      /** @description System not found */
-      404: {
-        headers: {
-          [name: string]: unknown;
+        responses: {
+            /** @description Relationship created */
+            200: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": {
+                        /** @example Relationship created successfully */
+                        message?: string;
+                    };
+                };
+            };
+            /** @description Invalid request body */
+            400: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": {
+                        error?: string;
+                    };
+                };
+            };
+            /** @description Resource not found */
+            404: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": {
+                        error?: string;
+                    };
+                };
+            };
+            /** @description Relationship already exists */
+            409: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": {
+                        error?: string;
+                    };
+                };
+            };
+            /** @description Internal server error */
+            500: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": {
+                        error?: string;
+                    };
+                };
+            };
         };
-        content: {
-          "application/json": {
-            /** @example System not found */
-            error?: string;
-          };
-        };
-      };
-      /** @description Internal server error */
-      500: {
-        headers: {
-          [name: string]: unknown;
-        };
-        content: {
-          "application/json": {
-            /** @example Internal server error */
-            error?: string;
-          };
-        };
-      };
     };
-  };
-  updateSystem: {
-    parameters: {
-      query?: never;
-      header?: never;
-      path: {
-        /** @description UUID of the system */
-        systemId: string;
-      };
-      cookie?: never;
+    createReleaseChannel: {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        requestBody: {
+            content: {
+                "application/json": {
+                    deploymentId: string;
+                    name: string;
+                    description?: string | null;
+                    releaseSelector: {
+                        [key: string]: unknown;
+                    };
+                };
+            };
+        };
+        responses: {
+            /** @description Release channel created successfully */
+            200: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": {
+                        id: string;
+                        deploymentId: string;
+                        name: string;
+                        description?: string | null;
+                        /** Format: date-time */
+                        createdAt: string;
+                        releaseSelector?: {
+                            [key: string]: unknown;
+                        };
+                    };
+                };
+            };
+            /** @description Unauthorized */
+            401: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": {
+                        error: string;
+                    };
+                };
+            };
+            /** @description Forbidden */
+            403: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": {
+                        error: string;
+                    };
+                };
+            };
+            /** @description Release channel already exists */
+            409: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": {
+                        error: string;
+                        id: string;
+                    };
+                };
+            };
+            /** @description Failed to create release channel */
+            500: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": {
+                        error: string;
+                    };
+                };
+            };
+        };
     };
-    requestBody: {
-      content: {
-        "application/json": {
-          /** @description Name of the system */
-          name?: string;
-          /** @description Slug of the system */
-          slug?: string;
-          /** @description Description of the system */
-          description?: string;
-          /**
-           * Format: uuid
-           * @description UUID of the workspace
-           */
-          workspaceId?: string;
+    getReleaseTargetReleases: {
+        parameters: {
+            query?: never;
+            header?: never;
+            path: {
+                releaseTargetId: string;
+            };
+            cookie?: never;
         };
-      };
+        requestBody?: never;
+        responses: {
+            /** @description The latest 100 releases for the release target */
+            200: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": {
+                        deployment: components["schemas"]["Deployment"];
+                        version: components["schemas"]["DeploymentVersion"];
+                        variables: {
+                            key: string;
+                            value: string;
+                        }[];
+                    }[];
+                };
+            };
+            /** @description The release target was not found */
+            404: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": {
+                        error: string;
+                    };
+                };
+            };
+            /** @description An internal server error occurred */
+            500: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": {
+                        error: string;
+                    };
+                };
+            };
+        };
     };
-    responses: {
-      /** @description System updated successfully */
-      200: {
-        headers: {
-          [name: string]: unknown;
+    updateRelease: {
+        parameters: {
+            query?: never;
+            header?: never;
+            path: {
+                /** @description The release ID */
+                releaseId: string;
+            };
+            cookie?: never;
         };
-        content: {
-          "application/json": components["schemas"]["System"];
+        requestBody: {
+            content: {
+                "application/json": {
+                    version?: string;
+                    deploymentId?: string;
+                    /** Format: date-time */
+                    createdAt?: string;
+                    name?: string;
+                    config?: {
+                        [key: string]: unknown;
+                    };
+                    jobAgentConfig?: {
+                        [key: string]: unknown;
+                    };
+                    /** @enum {string} */
+                    status?: "ready" | "building" | "failed";
+                    message?: string;
+                    metadata?: {
+                        [key: string]: string;
+                    };
+                };
+            };
         };
-      };
-      /** @description System not found */
-      404: {
-        headers: {
-          [name: string]: unknown;
+        responses: {
+            /** @description OK */
+            200: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["Release"];
+                };
+            };
         };
-        content: {
-          "application/json": {
-            /** @example System not found */
-            error?: string;
-          };
-        };
-      };
-      /** @description Internal server error */
-      500: {
-        headers: {
-          [name: string]: unknown;
-        };
-        content: {
-          "application/json": {
-            /** @example Internal server error */
-            error?: string;
-          };
-        };
-      };
     };
-  };
-  createSystem: {
-    parameters: {
-      query?: never;
-      header?: never;
-      path?: never;
-      cookie?: never;
+    upsertRelease: {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        requestBody: {
+            content: {
+                "application/json": {
+                    version: string;
+                    deploymentId: string;
+                    /** Format: date-time */
+                    createdAt?: string;
+                    name?: string;
+                    config?: {
+                        [key: string]: unknown;
+                    };
+                    jobAgentConfig?: {
+                        [key: string]: unknown;
+                    };
+                    /** @enum {string} */
+                    status?: "ready" | "building" | "failed";
+                    message?: string;
+                    metadata?: {
+                        [key: string]: string;
+                    };
+                };
+            };
+        };
+        responses: {
+            /** @description OK */
+            200: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["Release"];
+                };
+            };
+            /** @description Release already exists */
+            409: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": {
+                        error?: string;
+                        id?: string;
+                    };
+                };
+            };
+        };
     };
-    requestBody?: {
-      content: {
-        "application/json": {
-          /**
-           * Format: uuid
-           * @description The workspace ID of the system
-           */
-          workspaceId: string;
-          /** @description The name of the system */
-          name: string;
-          /** @description The slug of the system */
-          slug: string;
-          /** @description The description of the system */
-          description?: string;
+    setResourceProvidersResources: {
+        parameters: {
+            query?: never;
+            header?: never;
+            path: {
+                /** @description UUID of the scanner */
+                providerId: string;
+            };
+            cookie?: never;
         };
-      };
+        requestBody: {
+            content: {
+                "application/json": {
+                    resources: components["schemas"]["CreateResource"][];
+                };
+            };
+        };
+        responses: {
+            /** @description Successfully updated the deployment resources */
+            200: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": {
+                        resources?: {
+                            ignored?: {
+                                identifier?: string;
+                                name?: string;
+                                version?: string;
+                                kind?: string;
+                                workspaceId?: string;
+                            }[];
+                            inserted?: {
+                                id?: string;
+                                name?: string;
+                                version?: string;
+                                kind?: string;
+                                config?: {
+                                    [key: string]: unknown;
+                                };
+                            }[];
+                            updated?: {
+                                id?: string;
+                                name?: string;
+                                version?: string;
+                                kind?: string;
+                                config?: {
+                                    [key: string]: unknown;
+                                };
+                            }[];
+                            deleted?: {
+                                id?: string;
+                                name?: string;
+                                version?: string;
+                                kind?: string;
+                                config?: {
+                                    [key: string]: unknown;
+                                };
+                            }[];
+                        };
+                    };
+                };
+            };
+            /** @description Invalid request */
+            400: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content?: never;
+            };
+            /** @description Deployment resources not found */
+            404: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": {
+                        error?: string;
+                    };
+                };
+            };
+            /** @description Internal server error */
+            500: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content?: never;
+            };
+        };
     };
-    responses: {
-      /** @description System updated successfully */
-      200: {
-        headers: {
-          [name: string]: unknown;
-        };
-        content: {
-          "application/json": components["schemas"]["System"];
-        };
-      };
-      /** @description System created successfully */
-      201: {
-        headers: {
-          [name: string]: unknown;
-        };
-        content: {
-          "application/json": components["schemas"]["System"];
-        };
-      };
-      /** @description Bad request */
-      400: {
-        headers: {
-          [name: string]: unknown;
-        };
-        content: {
-          "application/json": {
-            error?: {
-              /** @enum {string} */
-              code: "invalid_type" | "invalid_literal" | "custom";
-              message: string;
-              path: (string | number)[];
-            }[];
-          };
-        };
-      };
-      /** @description Internal server error */
-      500: {
-        headers: {
-          [name: string]: unknown;
-        };
-        content: {
-          "application/json": {
-            /** @example Internal Server Error */
-            error?: string;
-          };
-        };
-      };
-    };
-  };
-  listDeployments: {
-    parameters: {
-      query?: never;
-      header?: never;
-      path: {
-        /** @description The ID of the workspace */
-        workspaceId: string;
-      };
-      cookie?: never;
-    };
-    requestBody?: never;
-    responses: {
-      /** @description All deployments */
-      200: {
-        headers: {
-          [name: string]: unknown;
-        };
-        content: {
-          "application/json": {
-            data?: components["schemas"]["Deployment"][];
-          };
-        };
-      };
-    };
-  };
-  listEnvironments: {
-    parameters: {
-      query?: never;
-      header?: never;
-      path: {
-        /** @description The ID of the workspace */
-        workspaceId: string;
-      };
-      cookie?: never;
-    };
-    requestBody?: never;
-    responses: {
-      /** @description All environments */
-      200: {
-        headers: {
-          [name: string]: unknown;
-        };
-        content: {
-          "application/json": {
-            data?: components["schemas"]["Environment"][];
-          };
-        };
-      };
-    };
-  };
-  getEventsByAction: {
-    parameters: {
-      query?: never;
-      header?: never;
-      path: {
-        /** @description The ID of the workspace */
-        workspaceId: string;
-        action: string;
-      };
-      cookie?: never;
-    };
-    requestBody?: never;
-    responses: {
-      /** @description Events */
-      200: {
-        headers: {
-          [name: string]: unknown;
-        };
-        content: {
-          "application/json": components["schemas"]["Event"][];
-        };
-      };
-      /** @description Workspace not found */
-      404: {
-        headers: {
-          [name: string]: unknown;
-        };
-        content: {
-          "application/json": {
-            error: string;
-          };
-        };
-      };
-      /** @description Internal server error */
-      500: {
-        headers: {
-          [name: string]: unknown;
-        };
-        content: {
-          "application/json": {
-            error: string;
-          };
-        };
-      };
-    };
-  };
-  getWorkspace: {
-    parameters: {
-      query?: never;
-      header?: never;
-      path: {
-        workspaceId: string;
-      };
-      cookie?: never;
-    };
-    requestBody?: never;
-    responses: {
-      /** @description Workspace found */
-      200: {
-        headers: {
-          [name: string]: unknown;
-        };
-        content: {
-          "application/json": components["schemas"]["Workspace"];
-        };
-      };
-      /** @description Workspace not found */
-      404: {
-        headers: {
-          [name: string]: unknown;
-        };
-        content: {
-          "application/json": {
-            error?: string;
-          };
-        };
-      };
-      /** @description Internal server error */
-      500: {
-        headers: {
-          [name: string]: unknown;
-        };
-        content: {
-          "application/json": {
-            error?: string;
-          };
-        };
-      };
-    };
-  };
-  deletePolicyByName: {
-    parameters: {
-      query?: never;
-      header?: never;
-      path: {
-        /** @description ID of the workspace */
-        workspaceId: string;
-        /** @description Name of the policy */
-        name: string;
-      };
-      cookie?: never;
-    };
-    requestBody?: never;
-    responses: {
-      /** @description Successfully deleted the policy */
-      200: {
-        headers: {
-          [name: string]: unknown;
-        };
-        content: {
-          "application/json": {
-            /** @example true */
-            success?: boolean;
-          };
-        };
-      };
-      /** @description Unauthorized */
-      401: {
-        headers: {
-          [name: string]: unknown;
-        };
-        content?: never;
-      };
-      /** @description Permission denied */
-      403: {
-        headers: {
-          [name: string]: unknown;
-        };
-        content?: never;
-      };
-      /** @description Policy not found */
-      404: {
-        headers: {
-          [name: string]: unknown;
-        };
-        content: {
-          "application/json": {
-            /** @example Policy not found */
-            error?: string;
-          };
-        };
-      };
-      /** @description Internal server error */
-      500: {
-        headers: {
-          [name: string]: unknown;
-        };
-        content?: never;
-      };
-    };
-  };
-  upsertResourceProvider: {
-    parameters: {
-      query?: never;
-      header?: never;
-      path: {
-        /** @description Name of the workspace */
-        workspaceId: string;
-        /** @description Name of the resource provider */
-        name: string;
-      };
-      cookie?: never;
-    };
-    requestBody?: never;
-    responses: {
-      /** @description Successfully retrieved or created the resource provider */
-      200: {
-        headers: {
-          [name: string]: unknown;
-        };
-        content: {
-          "application/json": {
-            id: string;
-            name: string;
-            workspaceId: string;
-          };
-        };
-      };
-      /** @description Unauthorized */
-      401: {
-        headers: {
-          [name: string]: unknown;
-        };
-        content?: never;
-      };
-      /** @description Permission denied */
-      403: {
-        headers: {
-          [name: string]: unknown;
-        };
-        content?: never;
-      };
-      /** @description Workspace not found */
-      404: {
-        headers: {
-          [name: string]: unknown;
-        };
-        content?: never;
-      };
-      /** @description Internal server error */
-      500: {
-        headers: {
-          [name: string]: unknown;
-        };
-        content?: never;
-      };
-    };
-  };
-  getResourceByIdentifier: {
-    parameters: {
-      query?: never;
-      header?: never;
-      path: {
-        /** @description ID of the workspace */
-        workspaceId: string;
-        /** @description Identifier of the resource */
-        identifier: string;
-      };
-      cookie?: never;
-    };
-    requestBody?: never;
-    responses: {
-      /** @description Successfully retrieved the resource */
-      200: {
-        headers: {
-          [name: string]: unknown;
-        };
-        content: {
-          "application/json": components["schemas"]["ResourceWithVariablesAndMetadata"] & {
-            relationships?: {
-              [key: string]: {
+    updateResourceRelationshipRule: {
+        parameters: {
+            query?: never;
+            header?: never;
+            path: {
                 ruleId: string;
-                type: string;
-                reference: string;
-                target: components["schemas"]["Resource"];
-              };
             };
-          };
+            cookie?: never;
         };
-      };
-      /** @description Unauthorized */
-      401: {
-        headers: {
-          [name: string]: unknown;
+        requestBody?: {
+            content: {
+                "application/json": components["schemas"]["UpdateResourceRelationshipRule"];
+            };
         };
-        content?: never;
-      };
-      /** @description Permission denied */
-      403: {
-        headers: {
-          [name: string]: unknown;
+        responses: {
+            /** @description The updated resource relationship rule */
+            200: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["ResourceRelationshipRule"];
+                };
+            };
+            /** @description The resource relationship rule was not found */
+            404: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": {
+                        error: string;
+                    };
+                };
+            };
+            /** @description An error occurred while updating the resource relationship rule */
+            500: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": {
+                        error: string;
+                    };
+                };
+            };
         };
-        content?: never;
-      };
-      /** @description Resource not found */
-      404: {
-        headers: {
-          [name: string]: unknown;
-        };
-        content: {
-          "application/json": {
-            /** @example Resource not found */
-            error?: string;
-          };
-        };
-      };
-      /** @description Internal server error */
-      500: {
-        headers: {
-          [name: string]: unknown;
-        };
-        content?: never;
-      };
     };
-  };
-  deleteResourceByIdentifier: {
-    parameters: {
-      query?: never;
-      header?: never;
-      path: {
-        /** @description ID of the workspace */
-        workspaceId: string;
-        /** @description Identifier of the resource */
-        identifier: string;
-      };
-      cookie?: never;
+    createResourceRelationshipRule: {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        requestBody: {
+            content: {
+                "application/json": components["schemas"]["CreateResourceRelationshipRule"];
+            };
+        };
+        responses: {
+            /** @description Resource relationship rule created successfully */
+            200: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["ResourceRelationshipRule"];
+                };
+            };
+            /** @description Resource relationship rule already exists */
+            409: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": {
+                        error?: string;
+                    };
+                };
+            };
+            /** @description Failed to create resource relationship rule */
+            500: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": {
+                        error?: string;
+                    };
+                };
+            };
+        };
     };
-    requestBody?: never;
-    responses: {
-      /** @description Successfully deleted the resource */
-      200: {
-        headers: {
-          [name: string]: unknown;
+    createResourceSchema: {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
         };
-        content: {
-          "application/json": {
-            /** @example true */
-            success?: boolean;
-          };
+        requestBody: {
+            content: {
+                "application/json": {
+                    /**
+                     * Format: uuid
+                     * @description The ID of the workspace
+                     */
+                    workspaceId: string;
+                    /** @description Version of the schema */
+                    version: string;
+                    /** @description Kind of resource this schema is for */
+                    kind: string;
+                    /** @description The JSON schema definition */
+                    jsonSchema: Record<string, never>;
+                };
+            };
         };
-      };
-      /** @description Unauthorized */
-      401: {
-        headers: {
-          [name: string]: unknown;
+        responses: {
+            /** @description Resource schema created successfully */
+            201: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": {
+                        /** Format: uuid */
+                        id?: string;
+                        /** Format: uuid */
+                        workspaceId?: string;
+                        version?: string;
+                        kind?: string;
+                        jsonSchema?: Record<string, never>;
+                    };
+                };
+            };
+            /** @description Invalid request body */
+            400: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": {
+                        error?: string;
+                    };
+                };
+            };
+            /** @description Schema already exists for this version and kind */
+            409: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": {
+                        error?: string;
+                        /** Format: uuid */
+                        id?: string;
+                    };
+                };
+            };
         };
-        content?: never;
-      };
-      /** @description Permission denied */
-      403: {
-        headers: {
-          [name: string]: unknown;
-        };
-        content?: never;
-      };
-      /** @description Resource not found */
-      404: {
-        headers: {
-          [name: string]: unknown;
-        };
-        content: {
-          "application/json": {
-            /** @example Resource not found */
-            error?: string;
-          };
-        };
-      };
-      /** @description Internal server error */
-      500: {
-        headers: {
-          [name: string]: unknown;
-        };
-        content?: never;
-      };
     };
-  };
-  getGroupedCounts: {
-    parameters: {
-      query?: never;
-      header?: never;
-      path: {
-        /** @description ID of the workspace */
-        workspaceId: string;
-      };
-      cookie?: never;
+    deleteResourceSchema: {
+        parameters: {
+            query?: never;
+            header?: never;
+            path: {
+                /** @description UUID of the schema to delete */
+                schemaId: string;
+            };
+            cookie?: never;
+        };
+        requestBody?: never;
+        responses: {
+            /** @description Schema deleted successfully */
+            200: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": {
+                        /** Format: uuid */
+                        id?: string;
+                    };
+                };
+            };
+            /** @description Schema not found */
+            404: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": {
+                        /** @example Schema not found */
+                        error?: string;
+                    };
+                };
+            };
+        };
     };
-    requestBody: {
-      content: {
-        "application/json": {
-          metadataKeys: string[];
-          allowNullCombinations: boolean;
+    getResource: {
+        parameters: {
+            query?: never;
+            header?: never;
+            path: {
+                /** @description The resource ID */
+                resourceId: string;
+            };
+            cookie?: never;
         };
-      };
+        requestBody?: never;
+        responses: {
+            /** @description OK */
+            200: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["ResourceWithVariablesAndMetadata"];
+                };
+            };
+            /** @description Unauthorized */
+            401: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content?: never;
+            };
+            /** @description Permission denied */
+            403: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content?: never;
+            };
+            /** @description Resource not found */
+            404: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": {
+                        /** @example Resource not found */
+                        error: string;
+                    };
+                };
+            };
+        };
     };
-    responses: {
-      /** @description Success */
-      200: {
-        headers: {
-          [name: string]: unknown;
+    deleteResource: {
+        parameters: {
+            query?: never;
+            header?: never;
+            path: {
+                /** @description The resource ID */
+                resourceId: string;
+            };
+            cookie?: never;
         };
-        content: {
-          "application/json": {
-            keys: string[];
-            combinations: {
-              metadata: {
-                [key: string]: string;
-              };
-              resources: number;
-            }[];
-          };
+        requestBody?: never;
+        responses: {
+            /** @description Resource deleted successfully */
+            200: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": {
+                        success: boolean;
+                    };
+                };
+            };
+            /** @description Unauthorized */
+            401: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content?: never;
+            };
+            /** @description Permission denied */
+            403: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content?: never;
+            };
+            /** @description Resource not found */
+            404: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": {
+                        error: string;
+                    };
+                };
+            };
         };
-      };
     };
-  };
-  listResources: {
-    parameters: {
-      query?: never;
-      header?: never;
-      path: {
-        /** @description The ID of the workspace */
-        workspaceId: string;
-      };
-      cookie?: never;
+    updateResource: {
+        parameters: {
+            query?: never;
+            header?: never;
+            path: {
+                resourceId: string;
+            };
+            cookie?: never;
+        };
+        requestBody: {
+            content: {
+                "application/json": {
+                    name?: string;
+                    version?: string;
+                    kind?: string;
+                    identifier?: string;
+                    workspaceId?: string;
+                    metadata?: components["schemas"]["MetadataMap"];
+                    variables?: components["schemas"]["DirectVariable"][];
+                };
+            };
+        };
+        responses: {
+            /** @description Resource updated successfully */
+            200: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["ResourceWithVariablesAndMetadata"];
+                };
+            };
+            /** @description Unauthorized */
+            401: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content?: never;
+            };
+            /** @description Permission denied */
+            403: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content?: never;
+            };
+            /** @description Resource not found */
+            404: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": {
+                        error: string;
+                    };
+                };
+            };
+        };
     };
-    requestBody?: never;
-    responses: {
-      /** @description All resources */
-      200: {
-        headers: {
-          [name: string]: unknown;
+    getReleaseTargets: {
+        parameters: {
+            query?: never;
+            header?: never;
+            path: {
+                /** @description The resource ID */
+                resourceId: string;
+            };
+            cookie?: never;
         };
-        content: {
-          "application/json": {
-            resources?: components["schemas"]["Resource"][];
-          };
+        requestBody?: never;
+        responses: {
+            /** @description OK */
+            200: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["ReleaseTarget"][];
+                };
+            };
         };
-      };
     };
-  };
-  listSystems: {
-    parameters: {
-      query?: never;
-      header?: never;
-      path: {
-        /** @description The ID of the workspace */
-        workspaceId: string;
-      };
-      cookie?: never;
+    upsertResource: {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        requestBody: {
+            content: {
+                "application/json": {
+                    /** Format: uuid */
+                    workspaceId: string;
+                    name: string;
+                    kind: string;
+                    identifier: string;
+                    version: string;
+                    config: Record<string, never>;
+                    metadata?: {
+                        [key: string]: string;
+                    };
+                    variables?: components["schemas"]["Variable"][];
+                };
+            };
+        };
+        responses: {
+            /** @description The created or updated resource */
+            200: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["Resource"];
+                };
+            };
+        };
     };
-    requestBody?: never;
-    responses: {
-      /** @description All systems */
-      200: {
-        headers: {
-          [name: string]: unknown;
+    deleteEnvironmentByName: {
+        parameters: {
+            query?: never;
+            header?: never;
+            path: {
+                /** @description UUID of the system */
+                systemId: string;
+                /** @description Name of the environment */
+                name: string;
+            };
+            cookie?: never;
         };
-        content: {
-          "application/json": {
-            data?: components["schemas"]["System"][];
-          };
+        requestBody?: never;
+        responses: {
+            /** @description Environment deleted successfully */
+            200: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content?: never;
+            };
         };
-      };
     };
-  };
-  getWorkspaceBySlug: {
-    parameters: {
-      query?: never;
-      header?: never;
-      path: {
-        workspaceSlug: string;
-      };
-      cookie?: never;
+    getSystem: {
+        parameters: {
+            query?: never;
+            header?: never;
+            path: {
+                /** @description UUID of the system */
+                systemId: string;
+            };
+            cookie?: never;
+        };
+        requestBody?: never;
+        responses: {
+            /** @description System retrieved successfully */
+            200: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["System"] & {
+                        environments?: components["schemas"]["Environment"][];
+                        deployments?: components["schemas"]["Deployment"][];
+                    };
+                };
+            };
+        };
     };
-    requestBody?: never;
-    responses: {
-      /** @description Workspace found */
-      200: {
-        headers: {
-          [name: string]: unknown;
+    deleteSystem: {
+        parameters: {
+            query?: never;
+            header?: never;
+            path: {
+                systemId: string;
+            };
+            cookie?: never;
         };
-        content: {
-          "application/json": components["schemas"]["Workspace"];
+        requestBody?: never;
+        responses: {
+            /** @description System deleted successfully */
+            200: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": {
+                        /** @example System deleted */
+                        message?: string;
+                    };
+                };
+            };
+            /** @description System not found */
+            404: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": {
+                        /** @example System not found */
+                        error?: string;
+                    };
+                };
+            };
+            /** @description Internal server error */
+            500: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": {
+                        /** @example Internal server error */
+                        error?: string;
+                    };
+                };
+            };
         };
-      };
-      /** @description Workspace not found */
-      404: {
-        headers: {
-          [name: string]: unknown;
-        };
-        content: {
-          "application/json": {
-            error?: string;
-          };
-        };
-      };
-      /** @description Internal server error */
-      500: {
-        headers: {
-          [name: string]: unknown;
-        };
-        content: {
-          "application/json": {
-            error?: string;
-          };
-        };
-      };
     };
-  };
+    updateSystem: {
+        parameters: {
+            query?: never;
+            header?: never;
+            path: {
+                /** @description UUID of the system */
+                systemId: string;
+            };
+            cookie?: never;
+        };
+        requestBody: {
+            content: {
+                "application/json": {
+                    /** @description Name of the system */
+                    name?: string;
+                    /** @description Slug of the system */
+                    slug?: string;
+                    /** @description Description of the system */
+                    description?: string;
+                    /**
+                     * Format: uuid
+                     * @description UUID of the workspace
+                     */
+                    workspaceId?: string;
+                };
+            };
+        };
+        responses: {
+            /** @description System updated successfully */
+            200: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["System"];
+                };
+            };
+            /** @description System not found */
+            404: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": {
+                        /** @example System not found */
+                        error?: string;
+                    };
+                };
+            };
+            /** @description Internal server error */
+            500: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": {
+                        /** @example Internal server error */
+                        error?: string;
+                    };
+                };
+            };
+        };
+    };
+    createSystem: {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        requestBody?: {
+            content: {
+                "application/json": {
+                    /**
+                     * Format: uuid
+                     * @description The workspace ID of the system
+                     */
+                    workspaceId: string;
+                    /** @description The name of the system */
+                    name: string;
+                    /** @description The slug of the system */
+                    slug: string;
+                    /** @description The description of the system */
+                    description?: string;
+                };
+            };
+        };
+        responses: {
+            /** @description System updated successfully */
+            200: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["System"];
+                };
+            };
+            /** @description System created successfully */
+            201: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["System"];
+                };
+            };
+            /** @description Bad request */
+            400: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": {
+                        error?: {
+                            /** @enum {string} */
+                            code: "invalid_type" | "invalid_literal" | "custom";
+                            message: string;
+                            path: (string | number)[];
+                        }[];
+                    };
+                };
+            };
+            /** @description Internal server error */
+            500: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": {
+                        /** @example Internal Server Error */
+                        error?: string;
+                    };
+                };
+            };
+        };
+    };
+    listDeployments: {
+        parameters: {
+            query?: never;
+            header?: never;
+            path: {
+                /** @description The ID of the workspace */
+                workspaceId: string;
+            };
+            cookie?: never;
+        };
+        requestBody?: never;
+        responses: {
+            /** @description All deployments */
+            200: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": {
+                        data?: components["schemas"]["Deployment"][];
+                    };
+                };
+            };
+        };
+    };
+    listEnvironments: {
+        parameters: {
+            query?: never;
+            header?: never;
+            path: {
+                /** @description The ID of the workspace */
+                workspaceId: string;
+            };
+            cookie?: never;
+        };
+        requestBody?: never;
+        responses: {
+            /** @description All environments */
+            200: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": {
+                        data?: components["schemas"]["Environment"][];
+                    };
+                };
+            };
+        };
+    };
+    getEventsByAction: {
+        parameters: {
+            query?: never;
+            header?: never;
+            path: {
+                /** @description The ID of the workspace */
+                workspaceId: string;
+                action: string;
+            };
+            cookie?: never;
+        };
+        requestBody?: never;
+        responses: {
+            /** @description Events */
+            200: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["Event"][];
+                };
+            };
+            /** @description Workspace not found */
+            404: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": {
+                        error: string;
+                    };
+                };
+            };
+            /** @description Internal server error */
+            500: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": {
+                        error: string;
+                    };
+                };
+            };
+        };
+    };
+    getWorkspace: {
+        parameters: {
+            query?: never;
+            header?: never;
+            path: {
+                workspaceId: string;
+            };
+            cookie?: never;
+        };
+        requestBody?: never;
+        responses: {
+            /** @description Workspace found */
+            200: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["Workspace"];
+                };
+            };
+            /** @description Workspace not found */
+            404: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": {
+                        error?: string;
+                    };
+                };
+            };
+            /** @description Internal server error */
+            500: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": {
+                        error?: string;
+                    };
+                };
+            };
+        };
+    };
+    deletePolicyByName: {
+        parameters: {
+            query?: never;
+            header?: never;
+            path: {
+                /** @description ID of the workspace */
+                workspaceId: string;
+                /** @description Name of the policy */
+                name: string;
+            };
+            cookie?: never;
+        };
+        requestBody?: never;
+        responses: {
+            /** @description Successfully deleted the policy */
+            200: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": {
+                        /** @example true */
+                        success?: boolean;
+                    };
+                };
+            };
+            /** @description Unauthorized */
+            401: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content?: never;
+            };
+            /** @description Permission denied */
+            403: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content?: never;
+            };
+            /** @description Policy not found */
+            404: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": {
+                        /** @example Policy not found */
+                        error?: string;
+                    };
+                };
+            };
+            /** @description Internal server error */
+            500: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content?: never;
+            };
+        };
+    };
+    upsertResourceProvider: {
+        parameters: {
+            query?: never;
+            header?: never;
+            path: {
+                /** @description Name of the workspace */
+                workspaceId: string;
+                /** @description Name of the resource provider */
+                name: string;
+            };
+            cookie?: never;
+        };
+        requestBody?: never;
+        responses: {
+            /** @description Successfully retrieved or created the resource provider */
+            200: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": {
+                        id: string;
+                        name: string;
+                        workspaceId: string;
+                    };
+                };
+            };
+            /** @description Unauthorized */
+            401: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content?: never;
+            };
+            /** @description Permission denied */
+            403: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content?: never;
+            };
+            /** @description Workspace not found */
+            404: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content?: never;
+            };
+            /** @description Internal server error */
+            500: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content?: never;
+            };
+        };
+    };
+    getResourceByIdentifier: {
+        parameters: {
+            query?: never;
+            header?: never;
+            path: {
+                /** @description ID of the workspace */
+                workspaceId: string;
+                /** @description Identifier of the resource */
+                identifier: string;
+            };
+            cookie?: never;
+        };
+        requestBody?: never;
+        responses: {
+            /** @description Successfully retrieved the resource */
+            200: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["ResourceWithVariablesAndMetadata"] & {
+                        relationships?: {
+                            [key: string]: {
+                                ruleId: string;
+                                type: string;
+                                reference: string;
+                                target: components["schemas"]["Resource"];
+                            };
+                        };
+                    };
+                };
+            };
+            /** @description Unauthorized */
+            401: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content?: never;
+            };
+            /** @description Permission denied */
+            403: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content?: never;
+            };
+            /** @description Resource not found */
+            404: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": {
+                        /** @example Resource not found */
+                        error?: string;
+                    };
+                };
+            };
+            /** @description Internal server error */
+            500: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content?: never;
+            };
+        };
+    };
+    deleteResourceByIdentifier: {
+        parameters: {
+            query?: never;
+            header?: never;
+            path: {
+                /** @description ID of the workspace */
+                workspaceId: string;
+                /** @description Identifier of the resource */
+                identifier: string;
+            };
+            cookie?: never;
+        };
+        requestBody?: never;
+        responses: {
+            /** @description Successfully deleted the resource */
+            200: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": {
+                        /** @example true */
+                        success?: boolean;
+                    };
+                };
+            };
+            /** @description Unauthorized */
+            401: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content?: never;
+            };
+            /** @description Permission denied */
+            403: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content?: never;
+            };
+            /** @description Resource not found */
+            404: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": {
+                        /** @example Resource not found */
+                        error?: string;
+                    };
+                };
+            };
+            /** @description Internal server error */
+            500: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content?: never;
+            };
+        };
+    };
+    getGroupedCounts: {
+        parameters: {
+            query?: never;
+            header?: never;
+            path: {
+                /** @description ID of the workspace */
+                workspaceId: string;
+            };
+            cookie?: never;
+        };
+        requestBody: {
+            content: {
+                "application/json": {
+                    metadataKeys: string[];
+                    allowNullCombinations: boolean;
+                };
+            };
+        };
+        responses: {
+            /** @description Success */
+            200: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": {
+                        keys: string[];
+                        combinations: {
+                            metadata: {
+                                [key: string]: string;
+                            };
+                            resources: number;
+                        }[];
+                    };
+                };
+            };
+        };
+    };
+    listResources: {
+        parameters: {
+            query?: never;
+            header?: never;
+            path: {
+                /** @description The ID of the workspace */
+                workspaceId: string;
+            };
+            cookie?: never;
+        };
+        requestBody?: never;
+        responses: {
+            /** @description All resources */
+            200: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": {
+                        resources?: components["schemas"]["Resource"][];
+                    };
+                };
+            };
+        };
+    };
+    listSystems: {
+        parameters: {
+            query?: never;
+            header?: never;
+            path: {
+                /** @description The ID of the workspace */
+                workspaceId: string;
+            };
+            cookie?: never;
+        };
+        requestBody?: never;
+        responses: {
+            /** @description All systems */
+            200: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": {
+                        data?: components["schemas"]["System"][];
+                    };
+                };
+            };
+        };
+    };
+    getWorkspaceBySlug: {
+        parameters: {
+            query?: never;
+            header?: never;
+            path: {
+                workspaceSlug: string;
+            };
+            cookie?: never;
+        };
+        requestBody?: never;
+        responses: {
+            /** @description Workspace found */
+            200: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["Workspace"];
+                };
+            };
+            /** @description Workspace not found */
+            404: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": {
+                        error?: string;
+                    };
+                };
+            };
+            /** @description Internal server error */
+            500: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": {
+                        error?: string;
+                    };
+                };
+            };
+        };
+    };
 }
 type WithRequired<T, K extends keyof T> = T & {
-  [P in K]-?: T[P];
+    [P in K]-?: T[P];
 };

--- a/e2e/api/yaml-loader.ts
+++ b/e2e/api/yaml-loader.ts
@@ -47,6 +47,7 @@ export interface TestYamlFile {
       config: Record<string, any>;
       values?: Array<{
         value: any;
+        valueType?: "direct" | "reference";
         sensitive?: boolean;
         resourceSelector?: any;
         default?: boolean;
@@ -110,6 +111,7 @@ export interface TestEntities {
       values?: Array<{
         id: string;
         value: any;
+        valueType?: "direct" | "reference";
         sensitive?: boolean;
         resourceSelector?: any;
         default?: boolean;

--- a/e2e/api/yaml-loader.ts
+++ b/e2e/api/yaml-loader.ts
@@ -4,8 +4,8 @@ import { faker } from "@faker-js/faker";
 import { compile } from "handlebars";
 import yaml from "js-yaml";
 
-import { ApiClient } from "./index";
 import { WorkspaceFixture } from "../tests/auth.setup";
+import { ApiClient } from "./index";
 
 // YAML structure used to create test entities
 export interface TestYamlFile {
@@ -211,9 +211,9 @@ export class EntitiesBuilder {
 
       if (resourceResponse.response.status !== 200) {
         throw new Error(
-          `Failed to create resource: ${
-            JSON.stringify(resourceResponse.error)
-          }`,
+          `Failed to create resource: ${JSON.stringify(
+            resourceResponse.error,
+          )}`,
         );
       }
     }
@@ -281,9 +281,9 @@ export class EntitiesBuilder {
 
       if (deploymentResponse.response.status !== 201) {
         throw new Error(
-          `Failed to create deployment: ${
-            JSON.stringify(deploymentResponse.error)
-          }`,
+          `Failed to create deployment: ${JSON.stringify(
+            deploymentResponse.error,
+          )}`,
         );
       }
       this.result.deployments.push({
@@ -304,18 +304,16 @@ export class EntitiesBuilder {
     for (const deployment of this.data.deployments) {
       if (deployment.versions && deployment.versions.length > 0) {
         console.log(
-          `Adding deployment versions: ${deployment.name} -> ${
-            deployment.versions.map((v) => v.tag).join(", ")
-          }`,
+          `Adding deployment versions: ${deployment.name} -> ${deployment.versions
+            .map((v) => v.tag)
+            .join(", ")}`,
         );
 
         const deploymentResult = this.result.deployments.find(
           (d) => d.name === deployment.name,
         );
         if (!deploymentResult) {
-          throw new Error(
-            `Deployment ${deployment.name} not found in result`,
-          );
+          throw new Error(`Deployment ${deployment.name} not found in result`);
         }
 
         for (const version of deployment.versions) {
@@ -331,9 +329,9 @@ export class EntitiesBuilder {
 
           if (versionResponse.response.status !== 201) {
             throw new Error(
-              `Failed to create deployment version: ${
-                JSON.stringify(versionResponse.error)
-              }`,
+              `Failed to create deployment version: ${JSON.stringify(
+                versionResponse.error,
+              )}`,
             );
           }
 
@@ -356,18 +354,16 @@ export class EntitiesBuilder {
     for (const deployment of this.data.deployments) {
       if (deployment.variables && deployment.variables.length > 0) {
         console.log(
-          `Adding deployment variables: ${deployment.name} -> ${
-            deployment.variables.map((v) => v.key).join(", ")
-          }`,
+          `Adding deployment variables: ${deployment.name} -> ${deployment.variables
+            .map((v) => v.key)
+            .join(", ")}`,
         );
 
         const deploymentResult = this.result.deployments.find(
           (d) => d.name === deployment.name,
         );
         if (!deploymentResult) {
-          throw new Error(
-            `Deployment ${deployment.name} not found in result`,
-          );
+          throw new Error(`Deployment ${deployment.name} not found in result`);
         }
 
         for (const variable of deployment.variables) {
@@ -383,9 +379,9 @@ export class EntitiesBuilder {
 
           if (variableResponse.response.status !== 201) {
             throw new Error(
-              `Failed to create deployment variable: ${
-                JSON.stringify(variableResponse.error)
-              }`,
+              `Failed to create deployment variable: ${JSON.stringify(
+                variableResponse.error,
+              )}`,
             );
           }
 

--- a/e2e/tests/api/deployment-remove-event.spec.ts
+++ b/e2e/tests/api/deployment-remove-event.spec.ts
@@ -16,15 +16,11 @@ test.describe("Deployment remove event", () => {
   });
 
   test.afterAll(async ({ api, workspace }) => {
-    await cleanupImportedEntities(api, builder.result, workspace.id);
+    await cleanupImportedEntities(api, builder.cache, workspace.id);
   });
 
-  test("deleting a resource should trigger a deployment remove event", async ({
-    api,
-    workspace,
-    page,
-  }) => {
-    const system = builder.result.system!;
+  test("deleting a resource should trigger a deployment remove event", async ({api,workspace,page,}) => {
+    const system = builder.cache.system!;
     const systemPrefix = system.slug.split("-")[0]!;
     const environmentCreateResponse = await api.POST("/v1/environments", {
       body: {
@@ -105,12 +101,8 @@ test.describe("Deployment remove event", () => {
     expect(matchedEvent).toBeDefined();
   });
 
-  test("deleting an environment should trigger a deployment remove event", async ({
-    api,
-    workspace,
-    page,
-  }) => {
-    const system = builder.result.system!;
+  test("deleting an environment should trigger a deployment remove event", async ({api,workspace,page,}) => {
+    const system = builder.cache.system!;
     const systemPrefix = system.slug.split("-")[0]!;
     const environmentCreateResponse = await api.POST("/v1/environments", {
       body: {
@@ -193,12 +185,8 @@ test.describe("Deployment remove event", () => {
     expect(matchedEvent).toBeDefined();
   });
 
-  test("unmatching a resource from an environment via resource update should trigger a deployment remove event", async ({
-    api,
-    workspace,
-    page,
-  }) => {
-    const system = builder.result.system!;
+  test("unmatching a resource from an environment via resource update should trigger a deployment remove event", async ({api,workspace,page,}) => {
+    const system = builder.cache.system!;
     const systemPrefix = system.slug.split("-")[0]!;
     const environmentCreateResponse = await api.POST("/v1/environments", {
       body: {
@@ -282,12 +270,8 @@ test.describe("Deployment remove event", () => {
     expect(matchedEvent).toBeDefined();
   });
 
-  test("unmatching a resource from an environment via env selector update should trigger a deployment remove event", async ({
-    api,
-    workspace,
-    page,
-  }) => {
-    const system = builder.result.system!;
+  test("unmatching a resource from an environment via env selector update should trigger a deployment remove event", async ({api,workspace,page,}) => {
+    const system = builder.cache.system!;
     const systemPrefix = system.slug.split("-")[0]!;
     const environmentCreateResponse = await api.POST("/v1/environments", {
       body: {
@@ -368,12 +352,8 @@ test.describe("Deployment remove event", () => {
     expect(matchedEvent).toBeDefined();
   });
 
-  test("updating a deployment's resource selector should trigger a deployment remove event if resource is unmatched", async ({
-    api,
-    workspace,
-    page,
-  }) => {
-    const system = builder.result.system!;
+  test("updating a deployment's resource selector should trigger a deployment remove event if resource is unmatched", async ({api,workspace,page,}) => {
+    const system = builder.cache.system!;
     const systemPrefix = system.slug.split("-")[0]!;
     const environmentCreateResponse = await api.POST("/v1/environments", {
       body: {

--- a/e2e/tests/api/deployment-remove-event.spec.ts
+++ b/e2e/tests/api/deployment-remove-event.spec.ts
@@ -19,7 +19,11 @@ test.describe("Deployment remove event", () => {
     await cleanupImportedEntities(api, builder.result, workspace.id);
   });
 
-  test("deleting a resource should trigger a deployment remove event", async ({ api, workspace, page }) => {
+  test("deleting a resource should trigger a deployment remove event", async ({
+    api,
+    workspace,
+    page,
+  }) => {
     const system = builder.result.system!;
     const systemPrefix = system.slug.split("-")[0]!;
     const environmentCreateResponse = await api.POST("/v1/environments", {
@@ -101,7 +105,11 @@ test.describe("Deployment remove event", () => {
     expect(matchedEvent).toBeDefined();
   });
 
-  test("deleting an environment should trigger a deployment remove event", async ({ api, workspace, page }) => {
+  test("deleting an environment should trigger a deployment remove event", async ({
+    api,
+    workspace,
+    page,
+  }) => {
     const system = builder.result.system!;
     const systemPrefix = system.slug.split("-")[0]!;
     const environmentCreateResponse = await api.POST("/v1/environments", {
@@ -185,7 +193,11 @@ test.describe("Deployment remove event", () => {
     expect(matchedEvent).toBeDefined();
   });
 
-  test("unmatching a resource from an environment via resource update should trigger a deployment remove event", async ({ api, workspace, page }) => {
+  test("unmatching a resource from an environment via resource update should trigger a deployment remove event", async ({
+    api,
+    workspace,
+    page,
+  }) => {
     const system = builder.result.system!;
     const systemPrefix = system.slug.split("-")[0]!;
     const environmentCreateResponse = await api.POST("/v1/environments", {
@@ -270,7 +282,11 @@ test.describe("Deployment remove event", () => {
     expect(matchedEvent).toBeDefined();
   });
 
-  test("unmatching a resource from an environment via env selector update should trigger a deployment remove event", async ({ api, workspace, page }) => {
+  test("unmatching a resource from an environment via env selector update should trigger a deployment remove event", async ({
+    api,
+    workspace,
+    page,
+  }) => {
     const system = builder.result.system!;
     const systemPrefix = system.slug.split("-")[0]!;
     const environmentCreateResponse = await api.POST("/v1/environments", {
@@ -352,7 +368,11 @@ test.describe("Deployment remove event", () => {
     expect(matchedEvent).toBeDefined();
   });
 
-  test("updating a deployment's resource selector should trigger a deployment remove event if resource is unmatched", async ({ api, workspace, page }) => {
+  test("updating a deployment's resource selector should trigger a deployment remove event if resource is unmatched", async ({
+    api,
+    workspace,
+    page,
+  }) => {
     const system = builder.result.system!;
     const systemPrefix = system.slug.split("-")[0]!;
     const environmentCreateResponse = await api.POST("/v1/environments", {

--- a/e2e/tests/api/deployment-remove-event.spec.ts
+++ b/e2e/tests/api/deployment-remove-event.spec.ts
@@ -19,7 +19,11 @@ test.describe("Deployment remove event", () => {
     await cleanupImportedEntities(api, builder.cache, workspace.id);
   });
 
-  test("deleting a resource should trigger a deployment remove event", async ({api,workspace,page,}) => {
+  test("deleting a resource should trigger a deployment remove event", async ({
+    api,
+    workspace,
+    page,
+  }) => {
     const system = builder.cache.system!;
     const systemPrefix = system.slug.split("-")[0]!;
     const environmentCreateResponse = await api.POST("/v1/environments", {
@@ -101,7 +105,11 @@ test.describe("Deployment remove event", () => {
     expect(matchedEvent).toBeDefined();
   });
 
-  test("deleting an environment should trigger a deployment remove event", async ({api,workspace,page,}) => {
+  test("deleting an environment should trigger a deployment remove event", async ({
+    api,
+    workspace,
+    page,
+  }) => {
     const system = builder.cache.system!;
     const systemPrefix = system.slug.split("-")[0]!;
     const environmentCreateResponse = await api.POST("/v1/environments", {
@@ -185,7 +193,11 @@ test.describe("Deployment remove event", () => {
     expect(matchedEvent).toBeDefined();
   });
 
-  test("unmatching a resource from an environment via resource update should trigger a deployment remove event", async ({api,workspace,page,}) => {
+  test("unmatching a resource from an environment via resource update should trigger a deployment remove event", async ({
+    api,
+    workspace,
+    page,
+  }) => {
     const system = builder.cache.system!;
     const systemPrefix = system.slug.split("-")[0]!;
     const environmentCreateResponse = await api.POST("/v1/environments", {
@@ -270,7 +282,11 @@ test.describe("Deployment remove event", () => {
     expect(matchedEvent).toBeDefined();
   });
 
-  test("unmatching a resource from an environment via env selector update should trigger a deployment remove event", async ({api,workspace,page,}) => {
+  test("unmatching a resource from an environment via env selector update should trigger a deployment remove event", async ({
+    api,
+    workspace,
+    page,
+  }) => {
     const system = builder.cache.system!;
     const systemPrefix = system.slug.split("-")[0]!;
     const environmentCreateResponse = await api.POST("/v1/environments", {
@@ -352,7 +368,11 @@ test.describe("Deployment remove event", () => {
     expect(matchedEvent).toBeDefined();
   });
 
-  test("updating a deployment's resource selector should trigger a deployment remove event if resource is unmatched", async ({api,workspace,page,}) => {
+  test("updating a deployment's resource selector should trigger a deployment remove event if resource is unmatched", async ({
+    api,
+    workspace,
+    page,
+  }) => {
     const system = builder.cache.system!;
     const systemPrefix = system.slug.split("-")[0]!;
     const environmentCreateResponse = await api.POST("/v1/environments", {

--- a/e2e/tests/api/deployment-remove-event.spec.ts
+++ b/e2e/tests/api/deployment-remove-event.spec.ts
@@ -2,36 +2,25 @@ import path from "path";
 import { faker } from "@faker-js/faker";
 import { expect } from "@playwright/test";
 
-import {
-  cleanupImportedEntities,
-  ImportedEntities,
-  importEntitiesFromYaml,
-} from "../../api";
+import { cleanupImportedEntities, EntitiesBuilder } from "../../api";
 import { test } from "../fixtures";
 
 const yamlPath = path.join(__dirname, "deployment-remove-event.spec.yaml");
 
 test.describe("Deployment remove event", () => {
-  let importedEntities: ImportedEntities;
+  let builder: EntitiesBuilder;
 
   test.beforeAll(async ({ api, workspace }) => {
-    importedEntities = await importEntitiesFromYaml(
-      api,
-      workspace.id,
-      yamlPath,
-    );
+    builder = new EntitiesBuilder(api, workspace, yamlPath);
+    await builder.createSystem();
   });
 
   test.afterAll(async ({ api, workspace }) => {
-    await cleanupImportedEntities(api, importedEntities, workspace.id);
+    await cleanupImportedEntities(api, builder.result, workspace.id);
   });
 
-  test("deleting a resource should trigger a deployment remove event", async ({
-    api,
-    workspace,
-    page,
-  }) => {
-    const system = importedEntities.system!;
+  test("deleting a resource should trigger a deployment remove event", async ({ api, workspace, page }) => {
+    const system = builder.result.system!;
     const systemPrefix = system.slug.split("-")[0]!;
     const environmentCreateResponse = await api.POST("/v1/environments", {
       body: {
@@ -112,12 +101,8 @@ test.describe("Deployment remove event", () => {
     expect(matchedEvent).toBeDefined();
   });
 
-  test("deleting an environment should trigger a deployment remove event", async ({
-    api,
-    workspace,
-    page,
-  }) => {
-    const system = importedEntities.system!;
+  test("deleting an environment should trigger a deployment remove event", async ({ api, workspace, page }) => {
+    const system = builder.result.system!;
     const systemPrefix = system.slug.split("-")[0]!;
     const environmentCreateResponse = await api.POST("/v1/environments", {
       body: {
@@ -200,12 +185,8 @@ test.describe("Deployment remove event", () => {
     expect(matchedEvent).toBeDefined();
   });
 
-  test("unmatching a resource from an environment via resource update should trigger a deployment remove event", async ({
-    api,
-    workspace,
-    page,
-  }) => {
-    const system = importedEntities.system!;
+  test("unmatching a resource from an environment via resource update should trigger a deployment remove event", async ({ api, workspace, page }) => {
+    const system = builder.result.system!;
     const systemPrefix = system.slug.split("-")[0]!;
     const environmentCreateResponse = await api.POST("/v1/environments", {
       body: {
@@ -289,12 +270,8 @@ test.describe("Deployment remove event", () => {
     expect(matchedEvent).toBeDefined();
   });
 
-  test("unmatching a resource from an environment via env selector update should trigger a deployment remove event", async ({
-    api,
-    workspace,
-    page,
-  }) => {
-    const system = importedEntities.system!;
+  test("unmatching a resource from an environment via env selector update should trigger a deployment remove event", async ({ api, workspace, page }) => {
+    const system = builder.result.system!;
     const systemPrefix = system.slug.split("-")[0]!;
     const environmentCreateResponse = await api.POST("/v1/environments", {
       body: {
@@ -375,12 +352,8 @@ test.describe("Deployment remove event", () => {
     expect(matchedEvent).toBeDefined();
   });
 
-  test("updating a deployment's resource selector should trigger a deployment remove event if resource is unmatched", async ({
-    api,
-    workspace,
-    page,
-  }) => {
-    const system = importedEntities.system!;
+  test("updating a deployment's resource selector should trigger a deployment remove event if resource is unmatched", async ({ api, workspace, page }) => {
+    const system = builder.result.system!;
     const systemPrefix = system.slug.split("-")[0]!;
     const environmentCreateResponse = await api.POST("/v1/environments", {
       body: {

--- a/e2e/tests/api/deployment-remove-event.spec.ts
+++ b/e2e/tests/api/deployment-remove-event.spec.ts
@@ -19,11 +19,7 @@ test.describe("Deployment remove event", () => {
     await cleanupImportedEntities(api, builder.cache, workspace.id);
   });
 
-  test("deleting a resource should trigger a deployment remove event", async ({
-    api,
-    workspace,
-    page,
-  }) => {
+  test("deleting a resource should trigger a deployment remove event", async ({ api, workspace, page }) => {
     const system = builder.cache.system!;
     const systemPrefix = system.slug.split("-")[0]!;
     const environmentCreateResponse = await api.POST("/v1/environments", {
@@ -105,11 +101,7 @@ test.describe("Deployment remove event", () => {
     expect(matchedEvent).toBeDefined();
   });
 
-  test("deleting an environment should trigger a deployment remove event", async ({
-    api,
-    workspace,
-    page,
-  }) => {
+  test("deleting an environment should trigger a deployment remove event", async ({ api, workspace, page }) => {
     const system = builder.cache.system!;
     const systemPrefix = system.slug.split("-")[0]!;
     const environmentCreateResponse = await api.POST("/v1/environments", {
@@ -193,11 +185,7 @@ test.describe("Deployment remove event", () => {
     expect(matchedEvent).toBeDefined();
   });
 
-  test("unmatching a resource from an environment via resource update should trigger a deployment remove event", async ({
-    api,
-    workspace,
-    page,
-  }) => {
+  test("unmatching a resource from an environment via resource update should trigger a deployment remove event", async ({ api, workspace, page }) => {
     const system = builder.cache.system!;
     const systemPrefix = system.slug.split("-")[0]!;
     const environmentCreateResponse = await api.POST("/v1/environments", {
@@ -282,11 +270,7 @@ test.describe("Deployment remove event", () => {
     expect(matchedEvent).toBeDefined();
   });
 
-  test("unmatching a resource from an environment via env selector update should trigger a deployment remove event", async ({
-    api,
-    workspace,
-    page,
-  }) => {
+  test("unmatching a resource from an environment via env selector update should trigger a deployment remove event", async ({ api, workspace, page }) => {
     const system = builder.cache.system!;
     const systemPrefix = system.slug.split("-")[0]!;
     const environmentCreateResponse = await api.POST("/v1/environments", {
@@ -368,11 +352,7 @@ test.describe("Deployment remove event", () => {
     expect(matchedEvent).toBeDefined();
   });
 
-  test("updating a deployment's resource selector should trigger a deployment remove event if resource is unmatched", async ({
-    api,
-    workspace,
-    page,
-  }) => {
+  test("updating a deployment's resource selector should trigger a deployment remove event if resource is unmatched", async ({ api, workspace, page }) => {
     const system = builder.cache.system!;
     const systemPrefix = system.slug.split("-")[0]!;
     const environmentCreateResponse = await api.POST("/v1/environments", {

--- a/e2e/tests/api/deployment-remove-event.spec.ts
+++ b/e2e/tests/api/deployment-remove-event.spec.ts
@@ -19,7 +19,11 @@ test.describe("Deployment remove event", () => {
     await cleanupImportedEntities(api, builder.cache, workspace.id);
   });
 
-  test("deleting a resource should trigger a deployment remove event", async ({ api, workspace, page }) => {
+  test("deleting a resource should trigger a deployment remove event", async ({
+    api,
+    workspace,
+    page,
+  }) => {
     const system = builder.cache.system!;
     const systemPrefix = system.slug.split("-")[0]!;
     const environmentCreateResponse = await api.POST("/v1/environments", {
@@ -101,7 +105,11 @@ test.describe("Deployment remove event", () => {
     expect(matchedEvent).toBeDefined();
   });
 
-  test("deleting an environment should trigger a deployment remove event", async ({ api, workspace, page }) => {
+  test("deleting an environment should trigger a deployment remove event", async ({
+    api,
+    workspace,
+    page,
+  }) => {
     const system = builder.cache.system!;
     const systemPrefix = system.slug.split("-")[0]!;
     const environmentCreateResponse = await api.POST("/v1/environments", {
@@ -185,7 +193,11 @@ test.describe("Deployment remove event", () => {
     expect(matchedEvent).toBeDefined();
   });
 
-  test("unmatching a resource from an environment via resource update should trigger a deployment remove event", async ({ api, workspace, page }) => {
+  test("unmatching a resource from an environment via resource update should trigger a deployment remove event", async ({
+    api,
+    workspace,
+    page,
+  }) => {
     const system = builder.cache.system!;
     const systemPrefix = system.slug.split("-")[0]!;
     const environmentCreateResponse = await api.POST("/v1/environments", {
@@ -270,7 +282,11 @@ test.describe("Deployment remove event", () => {
     expect(matchedEvent).toBeDefined();
   });
 
-  test("unmatching a resource from an environment via env selector update should trigger a deployment remove event", async ({ api, workspace, page }) => {
+  test("unmatching a resource from an environment via env selector update should trigger a deployment remove event", async ({
+    api,
+    workspace,
+    page,
+  }) => {
     const system = builder.cache.system!;
     const systemPrefix = system.slug.split("-")[0]!;
     const environmentCreateResponse = await api.POST("/v1/environments", {
@@ -352,7 +368,11 @@ test.describe("Deployment remove event", () => {
     expect(matchedEvent).toBeDefined();
   });
 
-  test("updating a deployment's resource selector should trigger a deployment remove event if resource is unmatched", async ({ api, workspace, page }) => {
+  test("updating a deployment's resource selector should trigger a deployment remove event if resource is unmatched", async ({
+    api,
+    workspace,
+    page,
+  }) => {
     const system = builder.cache.system!;
     const systemPrefix = system.slug.split("-")[0]!;
     const environmentCreateResponse = await api.POST("/v1/environments", {

--- a/e2e/tests/api/deployment-variable.spec.ts
+++ b/e2e/tests/api/deployment-variable.spec.ts
@@ -4,15 +4,15 @@ import { expect } from "@playwright/test";
 
 import {
   cleanupImportedEntities,
-  ImportedEntities,
   importEntitiesFromYaml,
+  TestEntities,
 } from "../../api";
 import { test } from "../fixtures";
 
 const yamlPath = path.join(__dirname, "deployment-variable.spec.yaml");
 
 test.describe("Deployment Variables API", () => {
-  let importedEntities: ImportedEntities;
+  let importedEntities: TestEntities;
 
   test.beforeAll(async ({ api, workspace }) => {
     importedEntities = await importEntitiesFromYaml(
@@ -129,21 +129,17 @@ test.describe("Deployment Variables API", () => {
 
     const receivedValues = receivedVariable.values;
     expect(receivedValues.length).toBe(2);
-    const receivedValueA =
-      receivedValues[0]!.valueType === "direct"
-        ? receivedValues[0]!.value
-        : receivedValues[0]!.defaultValue;
-    const receivedValueB =
-      receivedValues[1]!.valueType === "direct"
-        ? receivedValues[1]!.value
-        : receivedValues[1]!.defaultValue;
+    const receivedValueA = receivedValues[0]!.valueType === "direct"
+      ? receivedValues[0]!.value
+      : receivedValues[0]!.defaultValue;
+    const receivedValueB = receivedValues[1]!.valueType === "direct"
+      ? receivedValues[1]!.value
+      : receivedValues[1]!.defaultValue;
     expect(receivedValueA).toBe(valueA);
     expect(receivedValueB).toBe(valueB);
   });
 
-  test("should create a deployment variable with values and default value", async ({
-    api,
-  }) => {
+  test("should create a deployment variable with values and default value", async ({api,}) => {
     const importedDeployment = importedEntities.deployments[0]!;
     const key = faker.string.alphanumeric(10);
 
@@ -198,28 +194,23 @@ test.describe("Deployment Variables API", () => {
 
     const receivedValues = receivedVariable.values;
     expect(receivedValues.length).toBe(2);
-    const receivedValueA =
-      receivedValues[0]!.valueType === "direct"
-        ? receivedValues[0]!.value
-        : receivedValues[0]!.defaultValue;
-    const receivedValueB =
-      receivedValues[1]!.valueType === "direct"
-        ? receivedValues[1]!.value
-        : receivedValues[1]!.defaultValue;
+    const receivedValueA = receivedValues[0]!.valueType === "direct"
+      ? receivedValues[0]!.value
+      : receivedValues[0]!.defaultValue;
+    const receivedValueB = receivedValues[1]!.valueType === "direct"
+      ? receivedValues[1]!.value
+      : receivedValues[1]!.defaultValue;
     expect(receivedValueA).toBe(valueA);
     expect(receivedValueB).toBe(valueB);
 
-    const receivedDefaultValue =
-      receivedValues[1]!.valueType === "direct"
-        ? receivedValues[1]!.value
-        : receivedValues[1]!.defaultValue;
+    const receivedDefaultValue = receivedValues[1]!.valueType === "direct"
+      ? receivedValues[1]!.value
+      : receivedValues[1]!.defaultValue;
 
     expect(receivedDefaultValue).toBe(valueB);
   });
 
-  test("shoudl fail if more than one default value is provided", async ({
-    api,
-  }) => {
+  test("shoudl fail if more than one default value is provided", async ({api,}) => {
     const importedDeployment = importedEntities.deployments[0]!;
     const key = faker.string.alphanumeric(10);
 

--- a/e2e/tests/api/deployment-variable.spec.ts
+++ b/e2e/tests/api/deployment-variable.spec.ts
@@ -123,17 +123,21 @@ test.describe("Deployment Variables API", () => {
 
     const receivedValues = receivedVariable.values;
     expect(receivedValues.length).toBe(2);
-    const receivedValueA = receivedValues[0]!.valueType === "direct"
-      ? receivedValues[0]!.value
-      : receivedValues[0]!.defaultValue;
-    const receivedValueB = receivedValues[1]!.valueType === "direct"
-      ? receivedValues[1]!.value
-      : receivedValues[1]!.defaultValue;
+    const receivedValueA =
+      receivedValues[0]!.valueType === "direct"
+        ? receivedValues[0]!.value
+        : receivedValues[0]!.defaultValue;
+    const receivedValueB =
+      receivedValues[1]!.valueType === "direct"
+        ? receivedValues[1]!.value
+        : receivedValues[1]!.defaultValue;
     expect(receivedValueA).toBe(valueA);
     expect(receivedValueB).toBe(valueB);
   });
 
-  test("should create a deployment variable with values and default value", async ({api,}) => {
+  test("should create a deployment variable with values and default value", async ({
+    api,
+  }) => {
     const importedDeployment = builder.cache.deployments[0]!;
     const key = faker.string.alphanumeric(10);
 
@@ -188,23 +192,28 @@ test.describe("Deployment Variables API", () => {
 
     const receivedValues = receivedVariable.values;
     expect(receivedValues.length).toBe(2);
-    const receivedValueA = receivedValues[0]!.valueType === "direct"
-      ? receivedValues[0]!.value
-      : receivedValues[0]!.defaultValue;
-    const receivedValueB = receivedValues[1]!.valueType === "direct"
-      ? receivedValues[1]!.value
-      : receivedValues[1]!.defaultValue;
+    const receivedValueA =
+      receivedValues[0]!.valueType === "direct"
+        ? receivedValues[0]!.value
+        : receivedValues[0]!.defaultValue;
+    const receivedValueB =
+      receivedValues[1]!.valueType === "direct"
+        ? receivedValues[1]!.value
+        : receivedValues[1]!.defaultValue;
     expect(receivedValueA).toBe(valueA);
     expect(receivedValueB).toBe(valueB);
 
-    const receivedDefaultValue = receivedValues[1]!.valueType === "direct"
-      ? receivedValues[1]!.value
-      : receivedValues[1]!.defaultValue;
+    const receivedDefaultValue =
+      receivedValues[1]!.valueType === "direct"
+        ? receivedValues[1]!.value
+        : receivedValues[1]!.defaultValue;
 
     expect(receivedDefaultValue).toBe(valueB);
   });
 
-  test("shoudl fail if more than one default value is provided", async ({api,}) => {
+  test("shoudl fail if more than one default value is provided", async ({
+    api,
+  }) => {
     const importedDeployment = builder.cache.deployments[0]!;
     const key = faker.string.alphanumeric(10);
 

--- a/e2e/tests/api/deployment-variable.spec.ts
+++ b/e2e/tests/api/deployment-variable.spec.ts
@@ -18,11 +18,11 @@ test.describe("Deployment Variables API", () => {
   });
 
   test.afterAll(async ({ api, workspace }) => {
-    await cleanupImportedEntities(api, builder.result, workspace.id);
+    await cleanupImportedEntities(api, builder.cache, workspace.id);
   });
 
   test("should create a deployment variable", async ({ api }) => {
-    const importedDeployment = builder.result.deployments[0]!;
+    const importedDeployment = builder.cache.deployments[0]!;
     const key = faker.string.alphanumeric(10);
 
     const variableCreateResponse = await api.POST(
@@ -69,7 +69,7 @@ test.describe("Deployment Variables API", () => {
   });
 
   test("should create a deployment variable with values", async ({ api }) => {
-    const importedDeployment = builder.result.deployments[0]!;
+    const importedDeployment = builder.cache.deployments[0]!;
     const key = faker.string.alphanumeric(10);
 
     const valueA = faker.string.alphanumeric(10);
@@ -123,22 +123,18 @@ test.describe("Deployment Variables API", () => {
 
     const receivedValues = receivedVariable.values;
     expect(receivedValues.length).toBe(2);
-    const receivedValueA =
-      receivedValues[0]!.valueType === "direct"
-        ? receivedValues[0]!.value
-        : receivedValues[0]!.defaultValue;
-    const receivedValueB =
-      receivedValues[1]!.valueType === "direct"
-        ? receivedValues[1]!.value
-        : receivedValues[1]!.defaultValue;
+    const receivedValueA = receivedValues[0]!.valueType === "direct"
+      ? receivedValues[0]!.value
+      : receivedValues[0]!.defaultValue;
+    const receivedValueB = receivedValues[1]!.valueType === "direct"
+      ? receivedValues[1]!.value
+      : receivedValues[1]!.defaultValue;
     expect(receivedValueA).toBe(valueA);
     expect(receivedValueB).toBe(valueB);
   });
 
-  test("should create a deployment variable with values and default value", async ({
-    api,
-  }) => {
-    const importedDeployment = builder.result.deployments[0]!;
+  test("should create a deployment variable with values and default value", async ({api,}) => {
+    const importedDeployment = builder.cache.deployments[0]!;
     const key = faker.string.alphanumeric(10);
 
     const valueA = faker.string.alphanumeric(10);
@@ -192,29 +188,24 @@ test.describe("Deployment Variables API", () => {
 
     const receivedValues = receivedVariable.values;
     expect(receivedValues.length).toBe(2);
-    const receivedValueA =
-      receivedValues[0]!.valueType === "direct"
-        ? receivedValues[0]!.value
-        : receivedValues[0]!.defaultValue;
-    const receivedValueB =
-      receivedValues[1]!.valueType === "direct"
-        ? receivedValues[1]!.value
-        : receivedValues[1]!.defaultValue;
+    const receivedValueA = receivedValues[0]!.valueType === "direct"
+      ? receivedValues[0]!.value
+      : receivedValues[0]!.defaultValue;
+    const receivedValueB = receivedValues[1]!.valueType === "direct"
+      ? receivedValues[1]!.value
+      : receivedValues[1]!.defaultValue;
     expect(receivedValueA).toBe(valueA);
     expect(receivedValueB).toBe(valueB);
 
-    const receivedDefaultValue =
-      receivedValues[1]!.valueType === "direct"
-        ? receivedValues[1]!.value
-        : receivedValues[1]!.defaultValue;
+    const receivedDefaultValue = receivedValues[1]!.valueType === "direct"
+      ? receivedValues[1]!.value
+      : receivedValues[1]!.defaultValue;
 
     expect(receivedDefaultValue).toBe(valueB);
   });
 
-  test("shoudl fail if more than one default value is provided", async ({
-    api,
-  }) => {
-    const importedDeployment = builder.result.deployments[0]!;
+  test("shoudl fail if more than one default value is provided", async ({api,}) => {
+    const importedDeployment = builder.cache.deployments[0]!;
     const key = faker.string.alphanumeric(10);
 
     const valueA = faker.string.alphanumeric(10);

--- a/e2e/tests/api/deployment-variable.spec.ts
+++ b/e2e/tests/api/deployment-variable.spec.ts
@@ -123,17 +123,21 @@ test.describe("Deployment Variables API", () => {
 
     const receivedValues = receivedVariable.values;
     expect(receivedValues.length).toBe(2);
-    const receivedValueA = receivedValues[0]!.valueType === "direct"
-      ? receivedValues[0]!.value
-      : receivedValues[0]!.defaultValue;
-    const receivedValueB = receivedValues[1]!.valueType === "direct"
-      ? receivedValues[1]!.value
-      : receivedValues[1]!.defaultValue;
+    const receivedValueA =
+      receivedValues[0]!.valueType === "direct"
+        ? receivedValues[0]!.value
+        : receivedValues[0]!.defaultValue;
+    const receivedValueB =
+      receivedValues[1]!.valueType === "direct"
+        ? receivedValues[1]!.value
+        : receivedValues[1]!.defaultValue;
     expect(receivedValueA).toBe(valueA);
     expect(receivedValueB).toBe(valueB);
   });
 
-  test("should create a deployment variable with values and default value", async ({ api }) => {
+  test("should create a deployment variable with values and default value", async ({
+    api,
+  }) => {
     const importedDeployment = builder.result.deployments[0]!;
     const key = faker.string.alphanumeric(10);
 
@@ -188,23 +192,28 @@ test.describe("Deployment Variables API", () => {
 
     const receivedValues = receivedVariable.values;
     expect(receivedValues.length).toBe(2);
-    const receivedValueA = receivedValues[0]!.valueType === "direct"
-      ? receivedValues[0]!.value
-      : receivedValues[0]!.defaultValue;
-    const receivedValueB = receivedValues[1]!.valueType === "direct"
-      ? receivedValues[1]!.value
-      : receivedValues[1]!.defaultValue;
+    const receivedValueA =
+      receivedValues[0]!.valueType === "direct"
+        ? receivedValues[0]!.value
+        : receivedValues[0]!.defaultValue;
+    const receivedValueB =
+      receivedValues[1]!.valueType === "direct"
+        ? receivedValues[1]!.value
+        : receivedValues[1]!.defaultValue;
     expect(receivedValueA).toBe(valueA);
     expect(receivedValueB).toBe(valueB);
 
-    const receivedDefaultValue = receivedValues[1]!.valueType === "direct"
-      ? receivedValues[1]!.value
-      : receivedValues[1]!.defaultValue;
+    const receivedDefaultValue =
+      receivedValues[1]!.valueType === "direct"
+        ? receivedValues[1]!.value
+        : receivedValues[1]!.defaultValue;
 
     expect(receivedDefaultValue).toBe(valueB);
   });
 
-  test("shoudl fail if more than one default value is provided", async ({ api }) => {
+  test("shoudl fail if more than one default value is provided", async ({
+    api,
+  }) => {
     const importedDeployment = builder.result.deployments[0]!;
     const key = faker.string.alphanumeric(10);
 

--- a/e2e/tests/api/deployment-version.spec.ts
+++ b/e2e/tests/api/deployment-version.spec.ts
@@ -4,15 +4,15 @@ import { expect } from "@playwright/test";
 
 import {
   cleanupImportedEntities,
-  ImportedEntities,
   importEntitiesFromYaml,
+  TestEntities,
 } from "../../api";
 import { test } from "../fixtures";
 
 const yamlPath = path.join(__dirname, "deployment-version.spec.yaml");
 
 test.describe("Deployment Versions API", () => {
-  let importedEntities: ImportedEntities;
+  let importedEntities: TestEntities;
 
   test.beforeAll(async ({ api, workspace }) => {
     importedEntities = await importEntitiesFromYaml(
@@ -56,9 +56,7 @@ test.describe("Deployment Versions API", () => {
     expect(deploymentVersion.status).toBe("ready");
   });
 
-  test("name should default to version tag if name not provided", async ({
-    api,
-  }) => {
+  test("name should default to version tag if name not provided", async ({api,}) => {
     const versionTag = faker.string.alphanumeric(10);
 
     const deploymentVersionResponse = await api.POST(
@@ -79,9 +77,7 @@ test.describe("Deployment Versions API", () => {
     expect(deploymentVersion.name).toBe(versionTag);
   });
 
-  test("should create a deployment version in building status", async ({
-    api,
-  }) => {
+  test("should create a deployment version in building status", async ({api,}) => {
     const versionTag = faker.string.alphanumeric(10);
 
     const deploymentVersionResponse = await api.POST(
@@ -144,8 +140,9 @@ test.describe("Deployment Versions API", () => {
     expect(updatedDeploymentVersionResponse.response.status).toBe(200);
     const updatedDeploymentVersion = updatedDeploymentVersionResponse.data;
     expect(updatedDeploymentVersion).toBeDefined();
-    if (!updatedDeploymentVersion)
+    if (!updatedDeploymentVersion) {
       throw new Error("Deployment version not found");
+    }
 
     expect(updatedDeploymentVersion.name).toBe(newVersionName);
     expect(updatedDeploymentVersion.tag).toBe(newVersionTag);
@@ -186,8 +183,9 @@ test.describe("Deployment Versions API", () => {
     expect(updatedDeploymentVersionResponse.response.status).toBe(200);
     const updatedDeploymentVersion = updatedDeploymentVersionResponse.data;
     expect(updatedDeploymentVersion).toBeDefined();
-    if (!updatedDeploymentVersion)
+    if (!updatedDeploymentVersion) {
       throw new Error("Deployment version not found");
+    }
 
     expect(updatedDeploymentVersion.status).toBe("ready");
   });
@@ -226,8 +224,9 @@ test.describe("Deployment Versions API", () => {
     expect(updatedDeploymentVersionResponse.response.status).toBe(200);
     const updatedDeploymentVersion = updatedDeploymentVersionResponse.data;
     expect(updatedDeploymentVersion).toBeDefined();
-    if (!updatedDeploymentVersion)
+    if (!updatedDeploymentVersion) {
       throw new Error("Deployment version not found");
+    }
 
     expect(updatedDeploymentVersion.status).toBe("failed");
   });

--- a/e2e/tests/api/deployment-version.spec.ts
+++ b/e2e/tests/api/deployment-version.spec.ts
@@ -17,7 +17,7 @@ test.describe("Deployment Versions API", () => {
   });
 
   test.afterAll(async ({ api, workspace }) => {
-    await cleanupImportedEntities(api, builder.result, workspace.id);
+    await cleanupImportedEntities(api, builder.cache, workspace.id);
   });
 
   test("should create a deployment version", async ({ api }) => {
@@ -30,7 +30,7 @@ test.describe("Deployment Versions API", () => {
         body: {
           name: versionName,
           tag: versionTag,
-          deploymentId: builder.result.deployments[0].id,
+          deploymentId: builder.cache.deployments[0].id,
           metadata: { enabled: "true" },
         },
       },
@@ -44,15 +44,13 @@ test.describe("Deployment Versions API", () => {
     expect(deploymentVersion.name).toBe(versionName);
     expect(deploymentVersion.tag).toBe(versionTag);
     expect(deploymentVersion.deploymentId).toBe(
-      builder.result.deployments[0].id,
+      builder.cache.deployments[0].id,
     );
     expect(deploymentVersion.metadata).toEqual({ enabled: "true" });
     expect(deploymentVersion.status).toBe("ready");
   });
 
-  test("name should default to version tag if name not provided", async ({
-    api,
-  }) => {
+  test("name should default to version tag if name not provided", async ({ api }) => {
     const versionTag = faker.string.alphanumeric(10);
 
     const deploymentVersionResponse = await api.POST(
@@ -60,7 +58,7 @@ test.describe("Deployment Versions API", () => {
       {
         body: {
           tag: versionTag,
-          deploymentId: builder.result.deployments[0].id,
+          deploymentId: builder.cache.deployments[0].id,
         },
       },
     );
@@ -73,9 +71,7 @@ test.describe("Deployment Versions API", () => {
     expect(deploymentVersion.name).toBe(versionTag);
   });
 
-  test("should create a deployment version in building status", async ({
-    api,
-  }) => {
+  test("should create a deployment version in building status", async ({ api }) => {
     const versionTag = faker.string.alphanumeric(10);
 
     const deploymentVersionResponse = await api.POST(
@@ -83,7 +79,7 @@ test.describe("Deployment Versions API", () => {
       {
         body: {
           tag: versionTag,
-          deploymentId: builder.result.deployments[0].id,
+          deploymentId: builder.cache.deployments[0].id,
           status: "building",
         },
       },
@@ -106,7 +102,7 @@ test.describe("Deployment Versions API", () => {
       {
         body: {
           tag: versionTag,
-          deploymentId: builder.result.deployments[0].id,
+          deploymentId: builder.cache.deployments[0].id,
           name: versionName,
           metadata: { enabled: "true" },
         },
@@ -153,7 +149,7 @@ test.describe("Deployment Versions API", () => {
       {
         body: {
           tag: faker.string.alphanumeric(10),
-          deploymentId: builder.result.deployments[0].id,
+          deploymentId: builder.cache.deployments[0].id,
           status: "building",
         },
       },
@@ -194,7 +190,7 @@ test.describe("Deployment Versions API", () => {
       {
         body: {
           tag: faker.string.alphanumeric(10),
-          deploymentId: builder.result.deployments[0].id,
+          deploymentId: builder.cache.deployments[0].id,
           status: "building",
         },
       },

--- a/e2e/tests/api/deployment-version.spec.ts
+++ b/e2e/tests/api/deployment-version.spec.ts
@@ -50,7 +50,9 @@ test.describe("Deployment Versions API", () => {
     expect(deploymentVersion.status).toBe("ready");
   });
 
-  test("name should default to version tag if name not provided", async ({ api }) => {
+  test("name should default to version tag if name not provided", async ({
+    api,
+  }) => {
     const versionTag = faker.string.alphanumeric(10);
 
     const deploymentVersionResponse = await api.POST(
@@ -71,7 +73,9 @@ test.describe("Deployment Versions API", () => {
     expect(deploymentVersion.name).toBe(versionTag);
   });
 
-  test("should create a deployment version in building status", async ({ api }) => {
+  test("should create a deployment version in building status", async ({
+    api,
+  }) => {
     const versionTag = faker.string.alphanumeric(10);
 
     const deploymentVersionResponse = await api.POST(

--- a/e2e/tests/api/deployments.spec.ts
+++ b/e2e/tests/api/deployments.spec.ts
@@ -147,8 +147,8 @@ test.describe("Deployments API", () => {
     );
 
     expect(releaseTargetsBeforeDeleteResponse.response.status).toBe(200);
-    const deploymentMatchBeforeDelete = releaseTargetsBeforeDeleteResponse.data
-      ?.find(
+    const deploymentMatchBeforeDelete =
+      releaseTargetsBeforeDeleteResponse.data?.find(
         (rt) => rt.deployment.id === deploymentId,
       );
     expect(deploymentMatchBeforeDelete).toBeDefined();
@@ -190,8 +190,8 @@ test.describe("Deployments API", () => {
     );
 
     expect(releaseTargetsAfterDeleteResponse.response.status).toBe(200);
-    const deploymentMatchAfterDelete = releaseTargetsAfterDeleteResponse.data
-      ?.find(
+    const deploymentMatchAfterDelete =
+      releaseTargetsAfterDeleteResponse.data?.find(
         (rt) => rt.deployment.id === deploymentId,
       );
     expect(deploymentMatchAfterDelete).toBeUndefined();
@@ -269,7 +269,10 @@ test.describe("Deployments API", () => {
     expect(matchedEnvironment).toBeDefined();
   });
 
-  test("should update a deployment's resource selector and update matched resources", async ({ api, page }) => {
+  test("should update a deployment's resource selector and update matched resources", async ({
+    api,
+    page,
+  }) => {
     const systemPrefix = builder.result.system.slug.split("-")[0]!;
     const deploymentName = faker.string.alphanumeric(10);
     const deployment = await api.POST("/v1/deployments", {
@@ -370,11 +373,15 @@ test.describe("Deployments API", () => {
     expect(matchedEnvironment).toBeDefined();
   });
 
-  test("should not match deleted resources", async ({ api, page, workspace }) => {
+  test("should not match deleted resources", async ({
+    api,
+    page,
+    workspace,
+  }) => {
     const systemPrefix = builder.result.system.slug.split("-")[0]!;
-    const newResourceIdentifier = `${systemPrefix}-${
-      faker.string.alphanumeric(10)
-    }`;
+    const newResourceIdentifier = `${systemPrefix}-${faker.string.alphanumeric(
+      10,
+    )}`;
     const newResource = await api.POST("/v1/resources", {
       body: {
         name: faker.string.alphanumeric(10),
@@ -442,7 +449,11 @@ test.describe("Deployments API", () => {
     expect(resources.data?.resources?.length).toBe(0);
   });
 
-  test("should unmatch resources if resource selector is set to null", async ({ api, page, workspace }) => {
+  test("should unmatch resources if resource selector is set to null", async ({
+    api,
+    page,
+    workspace,
+  }) => {
     const systemPrefix = builder.result.system.slug.split("-")[0]!;
     const deploymentName = faker.string.alphanumeric(10);
     const deployment = await api.POST("/v1/deployments", {

--- a/e2e/tests/api/deployments.spec.ts
+++ b/e2e/tests/api/deployments.spec.ts
@@ -18,7 +18,7 @@ test.describe("Deployments API", () => {
   });
 
   test.afterAll(async ({ api, workspace }) => {
-    await cleanupImportedEntities(api, builder.result, workspace.id);
+    await cleanupImportedEntities(api, builder.cache, workspace.id);
   });
 
   test("should create a deployment", async ({ api }) => {
@@ -27,7 +27,7 @@ test.describe("Deployments API", () => {
       body: {
         name: deploymentName,
         slug: deploymentName,
-        systemId: builder.result.system.id,
+        systemId: builder.cache.system.id,
       },
     });
 
@@ -43,7 +43,7 @@ test.describe("Deployments API", () => {
       body: {
         name: deploymentName,
         slug: deploymentName,
-        systemId: builder.result.system.id,
+        systemId: builder.cache.system.id,
       },
     });
 
@@ -71,7 +71,7 @@ test.describe("Deployments API", () => {
       body: {
         name: deploymentName,
         slug: deploymentName,
-        systemId: builder.result.system.id,
+        systemId: builder.cache.system.id,
       },
     });
 
@@ -105,14 +105,14 @@ test.describe("Deployments API", () => {
   });
 
   test("should delete a deployment", async ({ api, workspace }) => {
-    const systemPrefix = builder.result.system.slug.split("-")[0]!;
+    const systemPrefix = builder.cache.system.slug.split("-")[0]!;
 
     const deploymentName = faker.string.alphanumeric(10);
     const deployment = await api.POST("/v1/deployments", {
       body: {
         name: deploymentName,
         slug: deploymentName,
-        systemId: builder.result.system.id,
+        systemId: builder.cache.system.id,
       },
     });
 
@@ -147,8 +147,8 @@ test.describe("Deployments API", () => {
     );
 
     expect(releaseTargetsBeforeDeleteResponse.response.status).toBe(200);
-    const deploymentMatchBeforeDelete =
-      releaseTargetsBeforeDeleteResponse.data?.find(
+    const deploymentMatchBeforeDelete = releaseTargetsBeforeDeleteResponse.data
+      ?.find(
         (rt) => rt.deployment.id === deploymentId,
       );
     expect(deploymentMatchBeforeDelete).toBeDefined();
@@ -190,21 +190,21 @@ test.describe("Deployments API", () => {
     );
 
     expect(releaseTargetsAfterDeleteResponse.response.status).toBe(200);
-    const deploymentMatchAfterDelete =
-      releaseTargetsAfterDeleteResponse.data?.find(
+    const deploymentMatchAfterDelete = releaseTargetsAfterDeleteResponse.data
+      ?.find(
         (rt) => rt.deployment.id === deploymentId,
       );
     expect(deploymentMatchAfterDelete).toBeUndefined();
   });
 
   test("should match resources to a deployment", async ({ api, page }) => {
-    const systemPrefix = builder.result.system.slug.split("-")[0]!;
+    const systemPrefix = builder.cache.system.slug.split("-")[0]!;
     const deploymentName = faker.string.alphanumeric(10);
     const deployment = await api.POST("/v1/deployments", {
       body: {
         name: deploymentName,
         slug: deploymentName,
-        systemId: builder.result.system.id,
+        systemId: builder.cache.system.id,
         resourceSelector: {
           type: "comparison",
           operator: "and",
@@ -248,7 +248,7 @@ test.describe("Deployments API", () => {
     expect(receivedResource).toBeDefined();
     if (!receivedResource) throw new Error("Resource is undefined");
     expect(receivedResource.identifier).toBe(
-      builder.result.resources.find((r) => r.metadata?.env === "qa")
+      builder.cache.resources.find((r) => r.metadata?.env === "qa")
         ?.identifier,
     );
 
@@ -263,23 +263,20 @@ test.describe("Deployments API", () => {
     expect(releaseTarget).toBeDefined();
     if (!releaseTarget) throw new Error("Release target is undefined");
     expect(releaseTarget.deployment.id).toBe(deploymentId);
-    const matchedEnvironment = builder.result.environments.find(
+    const matchedEnvironment = builder.cache.environments.find(
       (e) => e.id === releaseTarget.environment.id,
     );
     expect(matchedEnvironment).toBeDefined();
   });
 
-  test("should update a deployment's resource selector and update matched resources", async ({
-    api,
-    page,
-  }) => {
-    const systemPrefix = builder.result.system.slug.split("-")[0]!;
+  test("should update a deployment's resource selector and update matched resources", async ({api,page,}) => {
+    const systemPrefix = builder.cache.system.slug.split("-")[0]!;
     const deploymentName = faker.string.alphanumeric(10);
     const deployment = await api.POST("/v1/deployments", {
       body: {
         name: deploymentName,
         slug: deploymentName,
-        systemId: builder.result.system.id,
+        systemId: builder.cache.system.id,
         resourceSelector: {
           type: "comparison",
           operator: "and",
@@ -352,7 +349,7 @@ test.describe("Deployments API", () => {
     expect(receivedResource).toBeDefined();
     if (!receivedResource) throw new Error("Resource is undefined");
     expect(receivedResource.identifier).toBe(
-      builder.result.resources.find((r) => r.metadata?.env === "prod")
+      builder.cache.resources.find((r) => r.metadata?.env === "prod")
         ?.identifier,
     );
 
@@ -367,21 +364,19 @@ test.describe("Deployments API", () => {
     expect(releaseTarget).toBeDefined();
     if (!releaseTarget) throw new Error("Release target is undefined");
     expect(releaseTarget.deployment.id).toBe(deploymentId);
-    const matchedEnvironment = builder.result.environments.find(
+    const matchedEnvironment = builder.cache.environments.find(
       (e) => e.id === releaseTarget.environment.id,
     );
     expect(matchedEnvironment).toBeDefined();
   });
 
-  test("should not match deleted resources", async ({
-    api,
-    page,
-    workspace,
-  }) => {
-    const systemPrefix = builder.result.system.slug.split("-")[0]!;
-    const newResourceIdentifier = `${systemPrefix}-${faker.string.alphanumeric(
-      10,
-    )}`;
+  test("should not match deleted resources", async ({api,page,workspace,}) => {
+    const systemPrefix = builder.cache.system.slug.split("-")[0]!;
+    const newResourceIdentifier = `${systemPrefix}-${
+      faker.string.alphanumeric(
+        10,
+      )
+    }`;
     const newResource = await api.POST("/v1/resources", {
       body: {
         name: faker.string.alphanumeric(10),
@@ -407,7 +402,7 @@ test.describe("Deployments API", () => {
       body: {
         name: deploymentName,
         slug: deploymentName,
-        systemId: builder.result.system.id,
+        systemId: builder.cache.system.id,
         resourceSelector: {
           type: "comparison",
           operator: "and",
@@ -449,18 +444,14 @@ test.describe("Deployments API", () => {
     expect(resources.data?.resources?.length).toBe(0);
   });
 
-  test("should unmatch resources if resource selector is set to null", async ({
-    api,
-    page,
-    workspace,
-  }) => {
-    const systemPrefix = builder.result.system.slug.split("-")[0]!;
+  test("should unmatch resources if resource selector is set to null", async ({api,page,workspace,}) => {
+    const systemPrefix = builder.cache.system.slug.split("-")[0]!;
     const deploymentName = faker.string.alphanumeric(10);
     const deployment = await api.POST("/v1/deployments", {
       body: {
         name: deploymentName,
         slug: deploymentName,
-        systemId: builder.result.system.id,
+        systemId: builder.cache.system.id,
         resourceSelector: {
           type: "comparison",
           operator: "and",
@@ -506,7 +497,7 @@ test.describe("Deployments API", () => {
      * all resources should actually have release targets now
      * since the deployment no longer has a specific scope
      */
-    for (const resource of builder.result.resources) {
+    for (const resource of builder.cache.resources) {
       console.log(resource);
       const fetchedResourceResponse = await api.GET(
         "/v1/workspaces/{workspaceId}/resources/identifier/{identifier}",
@@ -534,7 +525,7 @@ test.describe("Deployments API", () => {
       expect(releaseTarget).toBeDefined();
       if (!releaseTarget) throw new Error("Release target is undefined");
       expect(releaseTarget.deployment.id).toBe(deploymentId);
-      const matchedEnvironment = builder.result.environments.find(
+      const matchedEnvironment = builder.cache.environments.find(
         (e) => e.id === releaseTarget.environment.id,
       );
       expect(matchedEnvironment).toBeDefined();

--- a/e2e/tests/api/deployments.spec.ts
+++ b/e2e/tests/api/deployments.spec.ts
@@ -147,8 +147,8 @@ test.describe("Deployments API", () => {
     );
 
     expect(releaseTargetsBeforeDeleteResponse.response.status).toBe(200);
-    const deploymentMatchBeforeDelete = releaseTargetsBeforeDeleteResponse.data
-      ?.find(
+    const deploymentMatchBeforeDelete =
+      releaseTargetsBeforeDeleteResponse.data?.find(
         (rt) => rt.deployment.id === deploymentId,
       );
     expect(deploymentMatchBeforeDelete).toBeDefined();
@@ -190,8 +190,8 @@ test.describe("Deployments API", () => {
     );
 
     expect(releaseTargetsAfterDeleteResponse.response.status).toBe(200);
-    const deploymentMatchAfterDelete = releaseTargetsAfterDeleteResponse.data
-      ?.find(
+    const deploymentMatchAfterDelete =
+      releaseTargetsAfterDeleteResponse.data?.find(
         (rt) => rt.deployment.id === deploymentId,
       );
     expect(deploymentMatchAfterDelete).toBeUndefined();
@@ -248,8 +248,7 @@ test.describe("Deployments API", () => {
     expect(receivedResource).toBeDefined();
     if (!receivedResource) throw new Error("Resource is undefined");
     expect(receivedResource.identifier).toBe(
-      builder.cache.resources.find((r) => r.metadata?.env === "qa")
-        ?.identifier,
+      builder.cache.resources.find((r) => r.metadata?.env === "qa")?.identifier,
     );
 
     const releaseTargets = await api.GET(
@@ -269,7 +268,10 @@ test.describe("Deployments API", () => {
     expect(matchedEnvironment).toBeDefined();
   });
 
-  test("should update a deployment's resource selector and update matched resources", async ({api,page,}) => {
+  test("should update a deployment's resource selector and update matched resources", async ({
+    api,
+    page,
+  }) => {
     const systemPrefix = builder.cache.system.slug.split("-")[0]!;
     const deploymentName = faker.string.alphanumeric(10);
     const deployment = await api.POST("/v1/deployments", {
@@ -370,13 +372,15 @@ test.describe("Deployments API", () => {
     expect(matchedEnvironment).toBeDefined();
   });
 
-  test("should not match deleted resources", async ({api,page,workspace,}) => {
+  test("should not match deleted resources", async ({
+    api,
+    page,
+    workspace,
+  }) => {
     const systemPrefix = builder.cache.system.slug.split("-")[0]!;
-    const newResourceIdentifier = `${systemPrefix}-${
-      faker.string.alphanumeric(
-        10,
-      )
-    }`;
+    const newResourceIdentifier = `${systemPrefix}-${faker.string.alphanumeric(
+      10,
+    )}`;
     const newResource = await api.POST("/v1/resources", {
       body: {
         name: faker.string.alphanumeric(10),
@@ -444,7 +448,11 @@ test.describe("Deployments API", () => {
     expect(resources.data?.resources?.length).toBe(0);
   });
 
-  test("should unmatch resources if resource selector is set to null", async ({api,page,workspace,}) => {
+  test("should unmatch resources if resource selector is set to null", async ({
+    api,
+    page,
+    workspace,
+  }) => {
     const systemPrefix = builder.cache.system.slug.split("-")[0]!;
     const deploymentName = faker.string.alphanumeric(10);
     const deployment = await api.POST("/v1/deployments", {

--- a/e2e/tests/api/deployments.spec.ts
+++ b/e2e/tests/api/deployments.spec.ts
@@ -4,15 +4,15 @@ import { expect } from "@playwright/test";
 
 import {
   cleanupImportedEntities,
-  ImportedEntities,
   importEntitiesFromYaml,
+  TestEntities,
 } from "../../api";
 import { test } from "../fixtures";
 
 const yamlPath = path.join(__dirname, "deployments.spec.yaml");
 
 test.describe("Deployments API", () => {
-  let importedEntities: ImportedEntities;
+  let importedEntities: TestEntities;
 
   test.beforeAll(async ({ api, workspace }) => {
     importedEntities = await importEntitiesFromYaml(
@@ -152,13 +152,14 @@ test.describe("Deployments API", () => {
     );
 
     expect(releaseTargetsBeforeDeleteResponse.response.status).toBe(200);
-    const deploymentMatchBeforeDelete =
-      releaseTargetsBeforeDeleteResponse.data?.find(
+    const deploymentMatchBeforeDelete = releaseTargetsBeforeDeleteResponse.data
+      ?.find(
         (rt) => rt.deployment.id === deploymentId,
       );
     expect(deploymentMatchBeforeDelete).toBeDefined();
-    if (!deploymentMatchBeforeDelete)
+    if (!deploymentMatchBeforeDelete) {
       throw new Error("No deployment match found");
+    }
 
     const deleteDeployment = await api.DELETE(
       "/v1/deployments/{deploymentId}",
@@ -194,8 +195,8 @@ test.describe("Deployments API", () => {
     );
 
     expect(releaseTargetsAfterDeleteResponse.response.status).toBe(200);
-    const deploymentMatchAfterDelete =
-      releaseTargetsAfterDeleteResponse.data?.find(
+    const deploymentMatchAfterDelete = releaseTargetsAfterDeleteResponse.data
+      ?.find(
         (rt) => rt.deployment.id === deploymentId,
       );
     expect(deploymentMatchAfterDelete).toBeUndefined();
@@ -273,10 +274,7 @@ test.describe("Deployments API", () => {
     expect(matchedEnvironment).toBeDefined();
   });
 
-  test("should update a deployment's resource selector and update matched resources", async ({
-    api,
-    page,
-  }) => {
+  test("should update a deployment's resource selector and update matched resources", async ({api,page,}) => {
     const systemPrefix = importedEntities.system.slug.split("-")[0]!;
     const deploymentName = faker.string.alphanumeric(10);
     const deployment = await api.POST("/v1/deployments", {
@@ -377,13 +375,11 @@ test.describe("Deployments API", () => {
     expect(matchedEnvironment).toBeDefined();
   });
 
-  test("should not match deleted resources", async ({
-    api,
-    page,
-    workspace,
-  }) => {
+  test("should not match deleted resources", async ({api,page,workspace,}) => {
     const systemPrefix = importedEntities.system.slug.split("-")[0]!;
-    const newResourceIdentifier = `${systemPrefix}-${faker.string.alphanumeric(10)}`;
+    const newResourceIdentifier = `${systemPrefix}-${
+      faker.string.alphanumeric(10)
+    }`;
     const newResource = await api.POST("/v1/resources", {
       body: {
         name: faker.string.alphanumeric(10),
@@ -451,11 +447,7 @@ test.describe("Deployments API", () => {
     expect(resources.data?.resources?.length).toBe(0);
   });
 
-  test("should unmatch resources if resource selector is set to null", async ({
-    api,
-    page,
-    workspace,
-  }) => {
+  test("should unmatch resources if resource selector is set to null", async ({api,page,workspace,}) => {
     const systemPrefix = importedEntities.system.slug.split("-")[0]!;
     const deploymentName = faker.string.alphanumeric(10);
     const deployment = await api.POST("/v1/deployments", {

--- a/e2e/tests/api/environments.spec.ts
+++ b/e2e/tests/api/environments.spec.ts
@@ -102,7 +102,9 @@ test.describe("Environments API", () => {
     expect(deploymentMatch.id).toBe(releaseTarget.deployment.id);
   });
 
-  test("should update environment selector and match new resources", async ({ api }) => {
+  test("should update environment selector and match new resources", async ({
+    api,
+  }) => {
     // First create an environment with a selector for QA resources
     const systemPrefix = builder.result.system.slug.split("-")[0]!;
     const environmentResponse = await api.POST("/v1/environments", {
@@ -218,7 +220,9 @@ test.describe("Environments API", () => {
     expect(deploymentMatch.id).toBe(releaseTarget.deployment.id);
   });
 
-  test("should unmatch resources if environment selector is set to null", async ({ api }) => {
+  test("should unmatch resources if environment selector is set to null", async ({
+    api,
+  }) => {
     const systemPrefix = builder.result.system.slug.split("-")[0]!;
     const environmentResponse = await api.POST("/v1/environments", {
       body: {
@@ -375,8 +379,8 @@ test.describe("Environments API", () => {
     );
 
     expect(releaseTargetsBeforeDeleteResponse.response.status).toBe(200);
-    const environmentMatchBeforeDelete = releaseTargetsBeforeDeleteResponse.data
-      ?.find(
+    const environmentMatchBeforeDelete =
+      releaseTargetsBeforeDeleteResponse.data?.find(
         (rt) => rt.environment.id === environmentId,
       );
     expect(environmentMatchBeforeDelete).toBeDefined();
@@ -414,18 +418,21 @@ test.describe("Environments API", () => {
     );
 
     expect(releaseTargetsAfterDeleteResponse.response.status).toBe(200);
-    const environmentMatchAfterDelete = releaseTargetsAfterDeleteResponse.data
-      ?.find(
+    const environmentMatchAfterDelete =
+      releaseTargetsAfterDeleteResponse.data?.find(
         (rt) => rt.environment.id === environmentId,
       );
     expect(environmentMatchAfterDelete).toBeUndefined();
   });
 
-  test("should match not match deleted resources", async ({ api, workspace }) => {
+  test("should match not match deleted resources", async ({
+    api,
+    workspace,
+  }) => {
     const systemPrefix = builder.result.system.slug.split("-")[0]!;
-    const newResourceIdentifier = `${systemPrefix}-${
-      faker.string.alphanumeric(10)
-    }`;
+    const newResourceIdentifier = `${systemPrefix}-${faker.string.alphanumeric(
+      10,
+    )}`;
     const newResource = await api.POST("/v1/resources", {
       body: {
         name: faker.string.alphanumeric(10),

--- a/e2e/tests/api/environments.spec.ts
+++ b/e2e/tests/api/environments.spec.ts
@@ -18,7 +18,7 @@ test.describe("Environments API", () => {
   });
 
   test.afterAll(async ({ api, workspace }) => {
-    await cleanupImportedEntities(api, builder.result, workspace.id);
+    await cleanupImportedEntities(api, builder.cache, workspace.id);
   });
 
   test("should create an environment", async ({ api }) => {
@@ -26,7 +26,7 @@ test.describe("Environments API", () => {
     const environment = await api.POST("/v1/environments", {
       body: {
         name: environmentName,
-        systemId: builder.result.system.id,
+        systemId: builder.cache.system.id,
       },
     });
 
@@ -36,11 +36,11 @@ test.describe("Environments API", () => {
   });
 
   test("should match resources to new environment", async ({ api }) => {
-    const systemPrefix = builder.result.system.slug.split("-")[0]!;
+    const systemPrefix = builder.cache.system.slug.split("-")[0]!;
     const environmentResponse = await api.POST("/v1/environments", {
       body: {
         name: faker.string.alphanumeric(10),
-        systemId: builder.result.system.id,
+        systemId: builder.cache.system.id,
         resourceSelector: {
           type: "comparison",
           operator: "and",
@@ -79,7 +79,7 @@ test.describe("Environments API", () => {
     expect(receivedResource).toBeDefined();
     if (!receivedResource) throw new Error("No resource found");
     expect(receivedResource.identifier).toBe(
-      builder.result.resources.find((r) => r.metadata?.env === "qa")
+      builder.cache.resources.find((r) => r.metadata?.env === "qa")
         ?.identifier,
     );
 
@@ -94,7 +94,7 @@ test.describe("Environments API", () => {
     expect(releaseTarget).toBeDefined();
     if (!releaseTarget) throw new Error("No release target found");
     expect(releaseTarget.environment.id).toBe(environment.id);
-    const deploymentMatch = builder.result.deployments.find(
+    const deploymentMatch = builder.cache.deployments.find(
       (d) => d.id === releaseTarget.deployment.id,
     );
     expect(deploymentMatch).toBeDefined();
@@ -102,15 +102,13 @@ test.describe("Environments API", () => {
     expect(deploymentMatch.id).toBe(releaseTarget.deployment.id);
   });
 
-  test("should update environment selector and match new resources", async ({
-    api,
-  }) => {
+  test("should update environment selector and match new resources", async ({api,}) => {
     // First create an environment with a selector for QA resources
-    const systemPrefix = builder.result.system.slug.split("-")[0]!;
+    const systemPrefix = builder.cache.system.slug.split("-")[0]!;
     const environmentResponse = await api.POST("/v1/environments", {
       body: {
         name: faker.string.alphanumeric(10),
-        systemId: builder.result.system.id,
+        systemId: builder.cache.system.id,
         resourceSelector: {
           type: "comparison",
           operator: "and",
@@ -147,7 +145,7 @@ test.describe("Environments API", () => {
     expect(initialResourcesResponse.response.status).toBe(200);
     expect(initialResourcesResponse.data?.resources?.length).toBe(1);
     expect(initialResourcesResponse.data?.resources?.[0]?.identifier).toBe(
-      builder.result.resources.find((r) => r.metadata?.env === "qa")
+      builder.cache.resources.find((r) => r.metadata?.env === "qa")
         ?.identifier,
     );
 
@@ -156,7 +154,7 @@ test.describe("Environments API", () => {
       body: {
         id: environment.id,
         name: environment.name,
-        systemId: builder.result.system.id,
+        systemId: builder.cache.system.id,
         resourceSelector: {
           type: "comparison",
           operator: "and",
@@ -197,7 +195,7 @@ test.describe("Environments API", () => {
     expect(receivedResource).toBeDefined();
     if (!receivedResource) throw new Error("No resource found");
     expect(receivedResource.identifier).toBe(
-      builder.result.resources.find((r) => r.metadata?.env === "prod")
+      builder.cache.resources.find((r) => r.metadata?.env === "prod")
         ?.identifier,
     );
 
@@ -212,7 +210,7 @@ test.describe("Environments API", () => {
     expect(releaseTarget).toBeDefined();
     if (!releaseTarget) throw new Error("No release target found");
     expect(releaseTarget.environment.id).toBe(updatedEnvironmentId);
-    const deploymentMatch = builder.result.deployments.find(
+    const deploymentMatch = builder.cache.deployments.find(
       (d) => d.id === releaseTarget.deployment.id,
     );
     expect(deploymentMatch).toBeDefined();
@@ -220,14 +218,12 @@ test.describe("Environments API", () => {
     expect(deploymentMatch.id).toBe(releaseTarget.deployment.id);
   });
 
-  test("should unmatch resources if environment selector is set to null", async ({
-    api,
-  }) => {
-    const systemPrefix = builder.result.system.slug.split("-")[0]!;
+  test("should unmatch resources if environment selector is set to null", async ({api,}) => {
+    const systemPrefix = builder.cache.system.slug.split("-")[0]!;
     const environmentResponse = await api.POST("/v1/environments", {
       body: {
         name: faker.string.alphanumeric(10),
-        systemId: builder.result.system.id,
+        systemId: builder.cache.system.id,
         resourceSelector: {
           type: "comparison",
           operator: "and",
@@ -259,7 +255,7 @@ test.describe("Environments API", () => {
       body: {
         id: environment.id,
         name: environment.name,
-        systemId: builder.result.system.id,
+        systemId: builder.cache.system.id,
         resourceSelector: undefined,
       },
     });
@@ -289,7 +285,7 @@ test.describe("Environments API", () => {
       body: {
         name: originalName,
         description: originalDescription,
-        systemId: builder.result.system.id,
+        systemId: builder.cache.system.id,
       },
     });
 
@@ -309,7 +305,7 @@ test.describe("Environments API", () => {
         id: environment.id,
         name: updatedName,
         description: updatedDescription,
-        systemId: builder.result.system.id,
+        systemId: builder.cache.system.id,
       },
     });
 
@@ -333,14 +329,14 @@ test.describe("Environments API", () => {
   });
 
   test("should delete an environment", async ({ api, workspace }) => {
-    const systemPrefix = builder.result.system.slug.split("-")[0]!;
+    const systemPrefix = builder.cache.system.slug.split("-")[0]!;
 
     // First create an environment
     const environmentName = faker.string.alphanumeric(10);
     const environmentResponse = await api.POST("/v1/environments", {
       body: {
         name: environmentName,
-        systemId: builder.result.system.id,
+        systemId: builder.cache.system.id,
         resourceSelector: {
           type: "identifier",
           operator: "equals",
@@ -379,8 +375,8 @@ test.describe("Environments API", () => {
     );
 
     expect(releaseTargetsBeforeDeleteResponse.response.status).toBe(200);
-    const environmentMatchBeforeDelete =
-      releaseTargetsBeforeDeleteResponse.data?.find(
+    const environmentMatchBeforeDelete = releaseTargetsBeforeDeleteResponse.data
+      ?.find(
         (rt) => rt.environment.id === environmentId,
       );
     expect(environmentMatchBeforeDelete).toBeDefined();
@@ -418,21 +414,20 @@ test.describe("Environments API", () => {
     );
 
     expect(releaseTargetsAfterDeleteResponse.response.status).toBe(200);
-    const environmentMatchAfterDelete =
-      releaseTargetsAfterDeleteResponse.data?.find(
+    const environmentMatchAfterDelete = releaseTargetsAfterDeleteResponse.data
+      ?.find(
         (rt) => rt.environment.id === environmentId,
       );
     expect(environmentMatchAfterDelete).toBeUndefined();
   });
 
-  test("should match not match deleted resources", async ({
-    api,
-    workspace,
-  }) => {
-    const systemPrefix = builder.result.system.slug.split("-")[0]!;
-    const newResourceIdentifier = `${systemPrefix}-${faker.string.alphanumeric(
-      10,
-    )}`;
+  test("should match not match deleted resources", async ({api,workspace,}) => {
+    const systemPrefix = builder.cache.system.slug.split("-")[0]!;
+    const newResourceIdentifier = `${systemPrefix}-${
+      faker.string.alphanumeric(
+        10,
+      )
+    }`;
     const newResource = await api.POST("/v1/resources", {
       body: {
         name: faker.string.alphanumeric(10),
@@ -456,7 +451,7 @@ test.describe("Environments API", () => {
     const environmentResponse = await api.POST("/v1/environments", {
       body: {
         name: faker.string.alphanumeric(10),
-        systemId: builder.result.system.id,
+        systemId: builder.cache.system.id,
         resourceSelector: {
           type: "comparison",
           operator: "and",

--- a/e2e/tests/api/environments.spec.ts
+++ b/e2e/tests/api/environments.spec.ts
@@ -79,8 +79,7 @@ test.describe("Environments API", () => {
     expect(receivedResource).toBeDefined();
     if (!receivedResource) throw new Error("No resource found");
     expect(receivedResource.identifier).toBe(
-      builder.cache.resources.find((r) => r.metadata?.env === "qa")
-        ?.identifier,
+      builder.cache.resources.find((r) => r.metadata?.env === "qa")?.identifier,
     );
 
     const releaseTargetsResponse = await api.GET(
@@ -102,7 +101,9 @@ test.describe("Environments API", () => {
     expect(deploymentMatch.id).toBe(releaseTarget.deployment.id);
   });
 
-  test("should update environment selector and match new resources", async ({api,}) => {
+  test("should update environment selector and match new resources", async ({
+    api,
+  }) => {
     // First create an environment with a selector for QA resources
     const systemPrefix = builder.cache.system.slug.split("-")[0]!;
     const environmentResponse = await api.POST("/v1/environments", {
@@ -145,8 +146,7 @@ test.describe("Environments API", () => {
     expect(initialResourcesResponse.response.status).toBe(200);
     expect(initialResourcesResponse.data?.resources?.length).toBe(1);
     expect(initialResourcesResponse.data?.resources?.[0]?.identifier).toBe(
-      builder.cache.resources.find((r) => r.metadata?.env === "qa")
-        ?.identifier,
+      builder.cache.resources.find((r) => r.metadata?.env === "qa")?.identifier,
     );
 
     // Now update the environment to select prod resources instead
@@ -218,7 +218,9 @@ test.describe("Environments API", () => {
     expect(deploymentMatch.id).toBe(releaseTarget.deployment.id);
   });
 
-  test("should unmatch resources if environment selector is set to null", async ({api,}) => {
+  test("should unmatch resources if environment selector is set to null", async ({
+    api,
+  }) => {
     const systemPrefix = builder.cache.system.slug.split("-")[0]!;
     const environmentResponse = await api.POST("/v1/environments", {
       body: {
@@ -375,8 +377,8 @@ test.describe("Environments API", () => {
     );
 
     expect(releaseTargetsBeforeDeleteResponse.response.status).toBe(200);
-    const environmentMatchBeforeDelete = releaseTargetsBeforeDeleteResponse.data
-      ?.find(
+    const environmentMatchBeforeDelete =
+      releaseTargetsBeforeDeleteResponse.data?.find(
         (rt) => rt.environment.id === environmentId,
       );
     expect(environmentMatchBeforeDelete).toBeDefined();
@@ -414,20 +416,21 @@ test.describe("Environments API", () => {
     );
 
     expect(releaseTargetsAfterDeleteResponse.response.status).toBe(200);
-    const environmentMatchAfterDelete = releaseTargetsAfterDeleteResponse.data
-      ?.find(
+    const environmentMatchAfterDelete =
+      releaseTargetsAfterDeleteResponse.data?.find(
         (rt) => rt.environment.id === environmentId,
       );
     expect(environmentMatchAfterDelete).toBeUndefined();
   });
 
-  test("should match not match deleted resources", async ({api,workspace,}) => {
+  test("should match not match deleted resources", async ({
+    api,
+    workspace,
+  }) => {
     const systemPrefix = builder.cache.system.slug.split("-")[0]!;
-    const newResourceIdentifier = `${systemPrefix}-${
-      faker.string.alphanumeric(
-        10,
-      )
-    }`;
+    const newResourceIdentifier = `${systemPrefix}-${faker.string.alphanumeric(
+      10,
+    )}`;
     const newResource = await api.POST("/v1/resources", {
       body: {
         name: faker.string.alphanumeric(10),

--- a/e2e/tests/api/job-agents.spec.ts
+++ b/e2e/tests/api/job-agents.spec.ts
@@ -54,11 +54,9 @@ test.describe("Job Agent API", () => {
     expect(agentId).toBeDefined();
 
     // Update the job agent with a new name
-    const updatedAgentName = `e2e-test-agent-updated-${
-      faker.string.alphanumeric(
-        8,
-      )
-    }`;
+    const updatedAgentName = `e2e-test-agent-updated-${faker.string.alphanumeric(
+      8,
+    )}`;
     const updateResponse = await api.PATCH("/v1/job-agents/name", {
       body: {
         workspaceId: workspace.id,

--- a/e2e/tests/api/job-agents.spec.ts
+++ b/e2e/tests/api/job-agents.spec.ts
@@ -18,7 +18,7 @@ test.describe("Job Agent API", () => {
   });
 
   test.afterAll(async ({ api, workspace }) => {
-    await cleanupImportedEntities(api, builder.result, workspace.id);
+    await cleanupImportedEntities(api, builder.cache, workspace.id);
   });
 
   test("create a job agent", async ({ api, workspace }) => {
@@ -54,9 +54,11 @@ test.describe("Job Agent API", () => {
     expect(agentId).toBeDefined();
 
     // Update the job agent with a new name
-    const updatedAgentName = `e2e-test-agent-updated-${faker.string.alphanumeric(
-      8,
-    )}`;
+    const updatedAgentName = `e2e-test-agent-updated-${
+      faker.string.alphanumeric(
+        8,
+      )
+    }`;
     const updateResponse = await api.PATCH("/v1/job-agents/name", {
       body: {
         workspaceId: workspace.id,

--- a/e2e/tests/api/job-agents.spec.ts
+++ b/e2e/tests/api/job-agents.spec.ts
@@ -54,9 +54,9 @@ test.describe("Job Agent API", () => {
     expect(agentId).toBeDefined();
 
     // Update the job agent with a new name
-    const updatedAgentName = `e2e-test-agent-updated-${
-      faker.string.alphanumeric(8)
-    }`;
+    const updatedAgentName = `e2e-test-agent-updated-${faker.string.alphanumeric(
+      8,
+    )}`;
     const updateResponse = await api.PATCH("/v1/job-agents/name", {
       body: {
         workspaceId: workspace.id,

--- a/e2e/tests/api/jobs/job-flow-1.spec.ts
+++ b/e2e/tests/api/jobs/job-flow-1.spec.ts
@@ -1,0 +1,42 @@
+import path from "path";
+
+import { cleanupImportedEntities, EntitiesBuilder } from "../../../api";
+import { test } from "../../fixtures";
+import { expect } from "@playwright/test";
+
+const yamlPath = path.join(__dirname, "job-flow-entities.spec.yaml");
+
+test.describe("Deployment Versions API", () => {
+  let builder: EntitiesBuilder;
+
+  test.beforeAll(async ({ api, workspace }) => {
+    builder = new EntitiesBuilder(api, workspace, yamlPath);
+    await builder.createSystem();
+    await builder.createResources();
+    await builder.createEnvironments();
+    await builder.createDeployments();
+    await builder.createAgents();
+    await builder.createDeploymentVersions();
+    await new Promise((resolve) => setTimeout(resolve, 5000));
+  });
+
+  test.afterAll(async ({ api, workspace }) => {
+    await cleanupImportedEntities(api, builder.cache, workspace.id);
+  });
+
+  test("should create a deployment version", async ({ api }) => {
+    const agentId = builder.cache.agents[0].id;
+    const jobQueueResponse = await api.GET(
+      "/v1/job-agents/{agentId}/queue/next",
+      {
+        params: {
+          path: {
+            agentId,
+          },
+        },
+      },
+    );
+
+    expect(jobQueueResponse.response.status).toBe(200);
+  });
+});

--- a/e2e/tests/api/jobs/job-flow-1.spec.ts
+++ b/e2e/tests/api/jobs/job-flow-1.spec.ts
@@ -1,8 +1,8 @@
 import path from "path";
+import { expect } from "@playwright/test";
 
 import { cleanupImportedEntities, EntitiesBuilder } from "../../../api";
 import { test } from "../../fixtures";
-import { expect } from "@playwright/test";
 
 const yamlPath = path.join(__dirname, "job-flow-entities.spec.yaml");
 

--- a/e2e/tests/api/jobs/job-flow-entities.spec.yaml
+++ b/e2e/tests/api/jobs/job-flow-entities.spec.yaml
@@ -1,0 +1,35 @@
+system:
+  name: "{{ prefix }}-deployment-version"
+  slug: "{{ prefix }}-deployment-version"
+  description: System for testing deployment versions
+
+resources:
+  - name: "{{ prefix }}-resource"
+    kind: "service"
+    identifier: "{{ prefix }}-resource"
+    version: "1.0.0"
+    config:
+      enabled: true
+
+deployments:
+  - name: "{{ prefix }}-deployment"
+    slug: "{{ prefix }}-deployment"
+    description: Deployment for testing deployment versions
+    versions:
+      - tag: "1.0.0"
+
+environments:
+  - name: "{{ prefix }}-environment"
+    slug: "{{ prefix }}-environment"
+    description: Environment for testing deployment versions
+    resourceSelector:
+      type: "comparison"
+      operator: "and"
+      conditions:
+        - type: "identifier"
+          operator: "equals"
+          value: "{{ prefix }}-resource"
+
+agents:
+  - name: "{{ prefix }}-agent"
+    type: "{{ prefix }}-agent-type"

--- a/e2e/tests/api/policies/matched-release-targets.spec.ts
+++ b/e2e/tests/api/policies/matched-release-targets.spec.ts
@@ -26,7 +26,11 @@ test.describe("Release Targets API", () => {
     await cleanupImportedEntities(api, builder.cache, workspace.id);
   });
 
-  test("should match a policy to a specific resource", async ({ api, workspace, page }) => {
+  test("should match a policy to a specific resource", async ({
+    api,
+    workspace,
+    page,
+  }) => {
     const { id: workspaceId } = workspace;
     const systemPrefix = builder.cache.system.slug.split("-")[0]!;
 
@@ -67,18 +71,24 @@ test.describe("Release Targets API", () => {
 
     expect(count).toBe(4);
 
-    const prodResourceMatch = releaseTargets?.filter(
-      (rt) => rt.resource.identifier === `${systemPrefix}-prod`,
-    ) ?? [];
+    const prodResourceMatch =
+      releaseTargets?.filter(
+        (rt) => rt.resource.identifier === `${systemPrefix}-prod`,
+      ) ?? [];
     expect(prodResourceMatch.length).toBe(4);
 
-    const qaResourceMatch = releaseTargets?.filter(
-      (rt) => rt.resource.identifier === `${systemPrefix}-qa`,
-    ) ?? [];
+    const qaResourceMatch =
+      releaseTargets?.filter(
+        (rt) => rt.resource.identifier === `${systemPrefix}-qa`,
+      ) ?? [];
     expect(qaResourceMatch.length).toBe(0);
   });
 
-  test("should update release targets when resource selector is updated", async ({ api, workspace, page }) => {
+  test("should update release targets when resource selector is updated", async ({
+    api,
+    workspace,
+    page,
+  }) => {
     const { id: workspaceId } = workspace;
     const systemPrefix = builder.cache.system.slug.split("-")[0]!;
     const policyName = faker.string.alphanumeric(10);
@@ -137,18 +147,24 @@ test.describe("Release Targets API", () => {
 
     expect(count).toBe(4);
 
-    const qaResourceMatch = releaseTargets?.filter(
-      (rt) => rt.resource.identifier === `${systemPrefix}-qa`,
-    ) ?? [];
+    const qaResourceMatch =
+      releaseTargets?.filter(
+        (rt) => rt.resource.identifier === `${systemPrefix}-qa`,
+      ) ?? [];
     expect(qaResourceMatch.length).toBe(4);
 
-    const prodResourceMatch = releaseTargets?.filter(
-      (rt) => rt.resource.identifier === `${systemPrefix}-prod`,
-    ) ?? [];
+    const prodResourceMatch =
+      releaseTargets?.filter(
+        (rt) => rt.resource.identifier === `${systemPrefix}-prod`,
+      ) ?? [];
     expect(prodResourceMatch.length).toBe(0);
   });
 
-  test("should not match a resource that is deleted", async ({ api, workspace, page }) => {
+  test("should not match a resource that is deleted", async ({
+    api,
+    workspace,
+    page,
+  }) => {
     const { id: workspaceId } = workspace;
     const systemPrefix = builder.cache.system.slug.split("-")[0]!;
     const resourceName = `${systemPrefix}-sample`;
@@ -216,7 +232,11 @@ test.describe("Release Targets API", () => {
     expect(count).toBe(0);
   });
 
-  test("should match a policy to a specific environment", async ({ api, workspace, page }) => {
+  test("should match a policy to a specific environment", async ({
+    api,
+    workspace,
+    page,
+  }) => {
     const { id: workspaceId } = workspace;
     const systemPrefix = builder.cache.system.slug.split("-")[0]!;
 
@@ -257,18 +277,24 @@ test.describe("Release Targets API", () => {
 
     expect(count).toBe(4);
 
-    const aEnvironmentMatch = releaseTargets?.filter(
-      (rt) => rt.environment.name === `${systemPrefix}-a`,
-    ) ?? [];
+    const aEnvironmentMatch =
+      releaseTargets?.filter(
+        (rt) => rt.environment.name === `${systemPrefix}-a`,
+      ) ?? [];
     expect(aEnvironmentMatch.length).toBe(4);
 
-    const bEnvironmentMatch = releaseTargets?.filter(
-      (rt) => rt.environment.name === `${systemPrefix}-b`,
-    ) ?? [];
+    const bEnvironmentMatch =
+      releaseTargets?.filter(
+        (rt) => rt.environment.name === `${systemPrefix}-b`,
+      ) ?? [];
     expect(bEnvironmentMatch.length).toBe(0);
   });
 
-  test("should update release targets when environment selector is updated", async ({ api, workspace, page }) => {
+  test("should update release targets when environment selector is updated", async ({
+    api,
+    workspace,
+    page,
+  }) => {
     const { id: workspaceId } = workspace;
     const systemPrefix = builder.cache.system.slug.split("-")[0]!;
     const policyName = faker.string.alphanumeric(10);
@@ -327,18 +353,24 @@ test.describe("Release Targets API", () => {
 
     expect(count).toBe(4);
 
-    const bEnvironmentMatch = releaseTargets?.filter(
-      (rt) => rt.environment.name === `${systemPrefix}-b`,
-    ) ?? [];
+    const bEnvironmentMatch =
+      releaseTargets?.filter(
+        (rt) => rt.environment.name === `${systemPrefix}-b`,
+      ) ?? [];
     expect(bEnvironmentMatch.length).toBe(4);
 
-    const aEnvironmentMatch = releaseTargets?.filter(
-      (rt) => rt.environment.name === `${systemPrefix}-a`,
-    ) ?? [];
+    const aEnvironmentMatch =
+      releaseTargets?.filter(
+        (rt) => rt.environment.name === `${systemPrefix}-a`,
+      ) ?? [];
     expect(aEnvironmentMatch.length).toBe(0);
   });
 
-  test("should not match an environment that is deleted", async ({ api, workspace, page }) => {
+  test("should not match an environment that is deleted", async ({
+    api,
+    workspace,
+    page,
+  }) => {
     const { id: workspaceId } = workspace;
     const systemPrefix = builder.cache.system.slug.split("-")[0]!;
     const environmentName = `${systemPrefix}-staging`;
@@ -411,7 +443,11 @@ test.describe("Release Targets API", () => {
     expect(count).toBe(0);
   });
 
-  test("should match a policy to a specific deployment", async ({ api, workspace, page }) => {
+  test("should match a policy to a specific deployment", async ({
+    api,
+    workspace,
+    page,
+  }) => {
     const { id: workspaceId } = workspace;
     const systemPrefix = importedEntities.system.slug.split("-")[0]!;
 
@@ -452,18 +488,24 @@ test.describe("Release Targets API", () => {
 
     expect(count).toBe(4);
 
-    const aDeploymentMatch = releaseTargets?.filter(
-      (rt) => rt.deployment.slug === `${systemPrefix}-deployment-a`,
-    ) ?? [];
+    const aDeploymentMatch =
+      releaseTargets?.filter(
+        (rt) => rt.deployment.slug === `${systemPrefix}-deployment-a`,
+      ) ?? [];
     expect(aDeploymentMatch.length).toBe(4);
 
-    const bDeploymentMatch = releaseTargets?.filter(
-      (rt) => rt.deployment.slug === `${systemPrefix}-deployment-b`,
-    ) ?? [];
+    const bDeploymentMatch =
+      releaseTargets?.filter(
+        (rt) => rt.deployment.slug === `${systemPrefix}-deployment-b`,
+      ) ?? [];
     expect(bDeploymentMatch.length).toBe(0);
   });
 
-  test("should update release targets when deployment selector is updated", async ({ api, workspace, page }) => {
+  test("should update release targets when deployment selector is updated", async ({
+    api,
+    workspace,
+    page,
+  }) => {
     const { id: workspaceId } = workspace;
     const systemPrefix = importedEntities.system.slug.split("-")[0]!;
     const policyName = faker.string.alphanumeric(10);
@@ -522,18 +564,24 @@ test.describe("Release Targets API", () => {
 
     expect(count).toBe(4);
 
-    const bDeploymentMatch = releaseTargets?.filter(
-      (rt) => rt.deployment.slug === `${systemPrefix}-deployment-b`,
-    ) ?? [];
+    const bDeploymentMatch =
+      releaseTargets?.filter(
+        (rt) => rt.deployment.slug === `${systemPrefix}-deployment-b`,
+      ) ?? [];
     expect(bDeploymentMatch.length).toBe(4);
 
-    const aDeploymentMatch = releaseTargets?.filter(
-      (rt) => rt.deployment.slug === `${systemPrefix}-deployment-a`,
-    ) ?? [];
+    const aDeploymentMatch =
+      releaseTargets?.filter(
+        (rt) => rt.deployment.slug === `${systemPrefix}-deployment-a`,
+      ) ?? [];
     expect(aDeploymentMatch.length).toBe(0);
   });
 
-  test("should not match a deployment that is deleted", async ({ api, workspace, page }) => {
+  test("should not match a deployment that is deleted", async ({
+    api,
+    workspace,
+    page,
+  }) => {
     const { id: workspaceId } = workspace;
     const systemPrefix = importedEntities.system.slug.split("-")[0]!;
     const deploymentName = `${systemPrefix}-deployment-c`;
@@ -607,7 +655,11 @@ test.describe("Release Targets API", () => {
     expect(count).toBe(0);
   });
 
-  test("should match a policy to a specific deployment and environment", async ({ api, workspace, page }) => {
+  test("should match a policy to a specific deployment and environment", async ({
+    api,
+    workspace,
+    page,
+  }) => {
     const { id: workspaceId } = workspace;
     const systemPrefix = importedEntities.system.slug.split("-")[0]!;
 
@@ -653,36 +705,44 @@ test.describe("Release Targets API", () => {
 
     expect(count).toBe(2);
 
-    const deploymentAEnvironmentAMatch = releaseTargets?.filter(
-      (rt) =>
-        rt.deployment.slug === `${systemPrefix}-deployment-a` &&
-        rt.environment.name === `${systemPrefix}-a`,
-    ) ?? [];
+    const deploymentAEnvironmentAMatch =
+      releaseTargets?.filter(
+        (rt) =>
+          rt.deployment.slug === `${systemPrefix}-deployment-a` &&
+          rt.environment.name === `${systemPrefix}-a`,
+      ) ?? [];
     expect(deploymentAEnvironmentAMatch.length).toBe(2);
 
-    const deploymentBEnvironmentAMatch = releaseTargets?.filter(
-      (rt) =>
-        rt.deployment.slug === `${systemPrefix}-deployment-b` &&
-        rt.environment.name === `${systemPrefix}-a`,
-    ) ?? [];
+    const deploymentBEnvironmentAMatch =
+      releaseTargets?.filter(
+        (rt) =>
+          rt.deployment.slug === `${systemPrefix}-deployment-b` &&
+          rt.environment.name === `${systemPrefix}-a`,
+      ) ?? [];
     expect(deploymentBEnvironmentAMatch.length).toBe(0);
 
-    const deploymentAEnvironmentBMatch = releaseTargets?.filter(
-      (rt) =>
-        rt.deployment.slug === `${systemPrefix}-deployment-a` &&
-        rt.environment.name === `${systemPrefix}-b`,
-    ) ?? [];
+    const deploymentAEnvironmentBMatch =
+      releaseTargets?.filter(
+        (rt) =>
+          rt.deployment.slug === `${systemPrefix}-deployment-a` &&
+          rt.environment.name === `${systemPrefix}-b`,
+      ) ?? [];
     expect(deploymentAEnvironmentBMatch.length).toBe(0);
 
-    const deploymentBEnvironmentBMatch = releaseTargets?.filter(
-      (rt) =>
-        rt.deployment.slug === `${systemPrefix}-deployment-b` &&
-        rt.environment.name === `${systemPrefix}-b`,
-    ) ?? [];
+    const deploymentBEnvironmentBMatch =
+      releaseTargets?.filter(
+        (rt) =>
+          rt.deployment.slug === `${systemPrefix}-deployment-b` &&
+          rt.environment.name === `${systemPrefix}-b`,
+      ) ?? [];
     expect(deploymentBEnvironmentBMatch.length).toBe(0);
   });
 
-  test("should update release targets when deployment and environment selectors are updated", async ({ api, workspace, page }) => {
+  test("should update release targets when deployment and environment selectors are updated", async ({
+    api,
+    workspace,
+    page,
+  }) => {
     const { id: workspaceId } = workspace;
     const systemPrefix = importedEntities.system.slug.split("-")[0]!;
     const policyName = faker.string.alphanumeric(10);
@@ -751,36 +811,44 @@ test.describe("Release Targets API", () => {
 
     expect(count).toBe(2);
 
-    const deploymentAEnvironmentAMatch = releaseTargets?.filter(
-      (rt) =>
-        rt.deployment.slug === `${systemPrefix}-deployment-a` &&
-        rt.environment.name === `${systemPrefix}-a`,
-    ) ?? [];
+    const deploymentAEnvironmentAMatch =
+      releaseTargets?.filter(
+        (rt) =>
+          rt.deployment.slug === `${systemPrefix}-deployment-a` &&
+          rt.environment.name === `${systemPrefix}-a`,
+      ) ?? [];
     expect(deploymentAEnvironmentAMatch.length).toBe(0);
 
-    const deploymentBEnvironmentAMatch = releaseTargets?.filter(
-      (rt) =>
-        rt.deployment.slug === `${systemPrefix}-deployment-b` &&
-        rt.environment.name === `${systemPrefix}-a`,
-    ) ?? [];
+    const deploymentBEnvironmentAMatch =
+      releaseTargets?.filter(
+        (rt) =>
+          rt.deployment.slug === `${systemPrefix}-deployment-b` &&
+          rt.environment.name === `${systemPrefix}-a`,
+      ) ?? [];
     expect(deploymentBEnvironmentAMatch.length).toBe(0);
 
-    const deploymentAEnvironmentBMatch = releaseTargets?.filter(
-      (rt) =>
-        rt.deployment.slug === `${systemPrefix}-deployment-a` &&
-        rt.environment.name === `${systemPrefix}-b`,
-    ) ?? [];
+    const deploymentAEnvironmentBMatch =
+      releaseTargets?.filter(
+        (rt) =>
+          rt.deployment.slug === `${systemPrefix}-deployment-a` &&
+          rt.environment.name === `${systemPrefix}-b`,
+      ) ?? [];
     expect(deploymentAEnvironmentBMatch.length).toBe(0);
 
-    const deploymentBEnvironmentBMatch = releaseTargets?.filter(
-      (rt) =>
-        rt.deployment.slug === `${systemPrefix}-deployment-b` &&
-        rt.environment.name === `${systemPrefix}-b`,
-    ) ?? [];
+    const deploymentBEnvironmentBMatch =
+      releaseTargets?.filter(
+        (rt) =>
+          rt.deployment.slug === `${systemPrefix}-deployment-b` &&
+          rt.environment.name === `${systemPrefix}-b`,
+      ) ?? [];
     expect(deploymentBEnvironmentBMatch.length).toBe(2);
   });
 
-  test("should match a policy to a specific resource and environment", async ({ api, workspace, page }) => {
+  test("should match a policy to a specific resource and environment", async ({
+    api,
+    workspace,
+    page,
+  }) => {
     const { id: workspaceId } = workspace;
     const systemPrefix = importedEntities.system.slug.split("-")[0]!;
 
@@ -826,36 +894,44 @@ test.describe("Release Targets API", () => {
 
     expect(count).toBe(2);
 
-    const prodEnvironmentAMatch = releaseTargets?.filter(
-      (rt) =>
-        rt.environment.name === `${systemPrefix}-a` &&
-        rt.resource.identifier === `${systemPrefix}-prod`,
-    ) ?? [];
+    const prodEnvironmentAMatch =
+      releaseTargets?.filter(
+        (rt) =>
+          rt.environment.name === `${systemPrefix}-a` &&
+          rt.resource.identifier === `${systemPrefix}-prod`,
+      ) ?? [];
     expect(prodEnvironmentAMatch.length).toBe(2);
 
-    const prodEnvironmentBMatch = releaseTargets?.filter(
-      (rt) =>
-        rt.environment.name === `${systemPrefix}-b` &&
-        rt.resource.identifier === `${systemPrefix}-prod`,
-    ) ?? [];
+    const prodEnvironmentBMatch =
+      releaseTargets?.filter(
+        (rt) =>
+          rt.environment.name === `${systemPrefix}-b` &&
+          rt.resource.identifier === `${systemPrefix}-prod`,
+      ) ?? [];
     expect(prodEnvironmentBMatch.length).toBe(0);
 
-    const qaEnvironmentAMatch = releaseTargets?.filter(
-      (rt) =>
-        rt.environment.name === `${systemPrefix}-a` &&
-        rt.resource.identifier === `${systemPrefix}-qa`,
-    ) ?? [];
+    const qaEnvironmentAMatch =
+      releaseTargets?.filter(
+        (rt) =>
+          rt.environment.name === `${systemPrefix}-a` &&
+          rt.resource.identifier === `${systemPrefix}-qa`,
+      ) ?? [];
     expect(qaEnvironmentAMatch.length).toBe(0);
 
-    const qaEnvironmentBMatch = releaseTargets?.filter(
-      (rt) =>
-        rt.environment.name === `${systemPrefix}-b` &&
-        rt.resource.identifier === `${systemPrefix}-qa`,
-    ) ?? [];
+    const qaEnvironmentBMatch =
+      releaseTargets?.filter(
+        (rt) =>
+          rt.environment.name === `${systemPrefix}-b` &&
+          rt.resource.identifier === `${systemPrefix}-qa`,
+      ) ?? [];
     expect(qaEnvironmentBMatch.length).toBe(0);
   });
 
-  test("should update release targets when resource and environment selectors are updated", async ({ api, workspace, page }) => {
+  test("should update release targets when resource and environment selectors are updated", async ({
+    api,
+    workspace,
+    page,
+  }) => {
     const { id: workspaceId } = workspace;
     const systemPrefix = importedEntities.system.slug.split("-")[0]!;
     const policyName = faker.string.alphanumeric(10);
@@ -924,36 +1000,44 @@ test.describe("Release Targets API", () => {
 
     expect(count).toBe(2);
 
-    const prodEnvironmentAMatch = releaseTargets?.filter(
-      (rt) =>
-        rt.environment.name === `${systemPrefix}-a` &&
-        rt.resource.identifier === `${systemPrefix}-prod`,
-    ) ?? [];
+    const prodEnvironmentAMatch =
+      releaseTargets?.filter(
+        (rt) =>
+          rt.environment.name === `${systemPrefix}-a` &&
+          rt.resource.identifier === `${systemPrefix}-prod`,
+      ) ?? [];
     expect(prodEnvironmentAMatch.length).toBe(0);
 
-    const prodEnvironmentBMatch = releaseTargets?.filter(
-      (rt) =>
-        rt.environment.name === `${systemPrefix}-b` &&
-        rt.resource.identifier === `${systemPrefix}-prod`,
-    ) ?? [];
+    const prodEnvironmentBMatch =
+      releaseTargets?.filter(
+        (rt) =>
+          rt.environment.name === `${systemPrefix}-b` &&
+          rt.resource.identifier === `${systemPrefix}-prod`,
+      ) ?? [];
     expect(prodEnvironmentBMatch.length).toBe(0);
 
-    const qaEnvironmentAMatch = releaseTargets?.filter(
-      (rt) =>
-        rt.environment.name === `${systemPrefix}-a` &&
-        rt.resource.identifier === `${systemPrefix}-qa`,
-    ) ?? [];
+    const qaEnvironmentAMatch =
+      releaseTargets?.filter(
+        (rt) =>
+          rt.environment.name === `${systemPrefix}-a` &&
+          rt.resource.identifier === `${systemPrefix}-qa`,
+      ) ?? [];
     expect(qaEnvironmentAMatch.length).toBe(0);
 
-    const qaEnvironmentBMatch = releaseTargets?.filter(
-      (rt) =>
-        rt.environment.name === `${systemPrefix}-b` &&
-        rt.resource.identifier === `${systemPrefix}-qa`,
-    ) ?? [];
+    const qaEnvironmentBMatch =
+      releaseTargets?.filter(
+        (rt) =>
+          rt.environment.name === `${systemPrefix}-b` &&
+          rt.resource.identifier === `${systemPrefix}-qa`,
+      ) ?? [];
     expect(qaEnvironmentBMatch.length).toBe(2);
   });
 
-  test("should match a policy to a specific resource and deployment", async ({ api, workspace, page }) => {
+  test("should match a policy to a specific resource and deployment", async ({
+    api,
+    workspace,
+    page,
+  }) => {
     const { id: workspaceId } = workspace;
     const systemPrefix = importedEntities.system.slug.split("-")[0]!;
 
@@ -999,36 +1083,44 @@ test.describe("Release Targets API", () => {
 
     expect(count).toBe(2);
 
-    const prodDeploymentAMatch = releaseTargets?.filter(
-      (rt) =>
-        rt.deployment.slug === `${systemPrefix}-deployment-a` &&
-        rt.resource.identifier === `${systemPrefix}-prod`,
-    ) ?? [];
+    const prodDeploymentAMatch =
+      releaseTargets?.filter(
+        (rt) =>
+          rt.deployment.slug === `${systemPrefix}-deployment-a` &&
+          rt.resource.identifier === `${systemPrefix}-prod`,
+      ) ?? [];
     expect(prodDeploymentAMatch.length).toBe(2);
 
-    const prodDeploymentBMatch = releaseTargets?.filter(
-      (rt) =>
-        rt.deployment.slug === `${systemPrefix}-deployment-b` &&
-        rt.resource.identifier === `${systemPrefix}-prod`,
-    ) ?? [];
+    const prodDeploymentBMatch =
+      releaseTargets?.filter(
+        (rt) =>
+          rt.deployment.slug === `${systemPrefix}-deployment-b` &&
+          rt.resource.identifier === `${systemPrefix}-prod`,
+      ) ?? [];
     expect(prodDeploymentBMatch.length).toBe(0);
 
-    const qaDeploymentAMatch = releaseTargets?.filter(
-      (rt) =>
-        rt.deployment.slug === `${systemPrefix}-deployment-a` &&
-        rt.resource.identifier === `${systemPrefix}-qa`,
-    ) ?? [];
+    const qaDeploymentAMatch =
+      releaseTargets?.filter(
+        (rt) =>
+          rt.deployment.slug === `${systemPrefix}-deployment-a` &&
+          rt.resource.identifier === `${systemPrefix}-qa`,
+      ) ?? [];
     expect(qaDeploymentAMatch.length).toBe(0);
 
-    const qaDeploymentBMatch = releaseTargets?.filter(
-      (rt) =>
-        rt.deployment.slug === `${systemPrefix}-deployment-b` &&
-        rt.resource.identifier === `${systemPrefix}-qa`,
-    ) ?? [];
+    const qaDeploymentBMatch =
+      releaseTargets?.filter(
+        (rt) =>
+          rt.deployment.slug === `${systemPrefix}-deployment-b` &&
+          rt.resource.identifier === `${systemPrefix}-qa`,
+      ) ?? [];
     expect(qaDeploymentBMatch.length).toBe(0);
   });
 
-  test("should update release targets when resource and deployment selectors are updated", async ({ api, workspace, page }) => {
+  test("should update release targets when resource and deployment selectors are updated", async ({
+    api,
+    workspace,
+    page,
+  }) => {
     const { id: workspaceId } = workspace;
     const systemPrefix = importedEntities.system.slug.split("-")[0]!;
     const policyName = faker.string.alphanumeric(10);
@@ -1097,36 +1189,44 @@ test.describe("Release Targets API", () => {
 
     expect(count).toBe(2);
 
-    const prodDeploymentAMatch = releaseTargets?.filter(
-      (rt) =>
-        rt.deployment.slug === `${systemPrefix}-deployment-a` &&
-        rt.resource.identifier === `${systemPrefix}-prod`,
-    ) ?? [];
+    const prodDeploymentAMatch =
+      releaseTargets?.filter(
+        (rt) =>
+          rt.deployment.slug === `${systemPrefix}-deployment-a` &&
+          rt.resource.identifier === `${systemPrefix}-prod`,
+      ) ?? [];
     expect(prodDeploymentAMatch.length).toBe(0);
 
-    const prodDeploymentBMatch = releaseTargets?.filter(
-      (rt) =>
-        rt.deployment.slug === `${systemPrefix}-deployment-b` &&
-        rt.resource.identifier === `${systemPrefix}-prod`,
-    ) ?? [];
+    const prodDeploymentBMatch =
+      releaseTargets?.filter(
+        (rt) =>
+          rt.deployment.slug === `${systemPrefix}-deployment-b` &&
+          rt.resource.identifier === `${systemPrefix}-prod`,
+      ) ?? [];
     expect(prodDeploymentBMatch.length).toBe(0);
 
-    const qaDeploymentAMatch = releaseTargets?.filter(
-      (rt) =>
-        rt.deployment.slug === `${systemPrefix}-deployment-a` &&
-        rt.resource.identifier === `${systemPrefix}-qa`,
-    ) ?? [];
+    const qaDeploymentAMatch =
+      releaseTargets?.filter(
+        (rt) =>
+          rt.deployment.slug === `${systemPrefix}-deployment-a` &&
+          rt.resource.identifier === `${systemPrefix}-qa`,
+      ) ?? [];
     expect(qaDeploymentAMatch.length).toBe(0);
 
-    const qaDeploymentBMatch = releaseTargets?.filter(
-      (rt) =>
-        rt.deployment.slug === `${systemPrefix}-deployment-b` &&
-        rt.resource.identifier === `${systemPrefix}-qa`,
-    ) ?? [];
+    const qaDeploymentBMatch =
+      releaseTargets?.filter(
+        (rt) =>
+          rt.deployment.slug === `${systemPrefix}-deployment-b` &&
+          rt.resource.identifier === `${systemPrefix}-qa`,
+      ) ?? [];
     expect(qaDeploymentBMatch.length).toBe(2);
   });
 
-  test("should match a policy to a specific resource and deployment and environment", async ({ api, workspace, page }) => {
+  test("should match a policy to a specific resource and deployment and environment", async ({
+    api,
+    workspace,
+    page,
+  }) => {
     const { id: workspaceId } = workspace;
     const systemPrefix = importedEntities.system.slug.split("-")[0]!;
 
@@ -1177,72 +1277,84 @@ test.describe("Release Targets API", () => {
 
     expect(count).toBe(1);
 
-    const prodDeploymentAEnvironmentAMatch = releaseTargets?.filter(
-      (rt) =>
-        rt.deployment.slug === `${systemPrefix}-deployment-a` &&
-        rt.environment.name === `${systemPrefix}-a` &&
-        rt.resource.identifier === `${systemPrefix}-prod`,
-    ) ?? [];
+    const prodDeploymentAEnvironmentAMatch =
+      releaseTargets?.filter(
+        (rt) =>
+          rt.deployment.slug === `${systemPrefix}-deployment-a` &&
+          rt.environment.name === `${systemPrefix}-a` &&
+          rt.resource.identifier === `${systemPrefix}-prod`,
+      ) ?? [];
     expect(prodDeploymentAEnvironmentAMatch.length).toBe(1);
 
-    const prodDeploymentAEnvironmentBMatch = releaseTargets?.filter(
-      (rt) =>
-        rt.deployment.slug === `${systemPrefix}-deployment-a` &&
-        rt.environment.name === `${systemPrefix}-b` &&
-        rt.resource.identifier === `${systemPrefix}-prod`,
-    ) ?? [];
+    const prodDeploymentAEnvironmentBMatch =
+      releaseTargets?.filter(
+        (rt) =>
+          rt.deployment.slug === `${systemPrefix}-deployment-a` &&
+          rt.environment.name === `${systemPrefix}-b` &&
+          rt.resource.identifier === `${systemPrefix}-prod`,
+      ) ?? [];
     expect(prodDeploymentAEnvironmentBMatch.length).toBe(0);
 
-    const prodDeploymentBEnvironmentAMatch = releaseTargets?.filter(
-      (rt) =>
-        rt.deployment.slug === `${systemPrefix}-deployment-b` &&
-        rt.environment.name === `${systemPrefix}-a` &&
-        rt.resource.identifier === `${systemPrefix}-prod`,
-    ) ?? [];
+    const prodDeploymentBEnvironmentAMatch =
+      releaseTargets?.filter(
+        (rt) =>
+          rt.deployment.slug === `${systemPrefix}-deployment-b` &&
+          rt.environment.name === `${systemPrefix}-a` &&
+          rt.resource.identifier === `${systemPrefix}-prod`,
+      ) ?? [];
     expect(prodDeploymentBEnvironmentAMatch.length).toBe(0);
 
-    const prodDeploymentBEnvironmentBMatch = releaseTargets?.filter(
-      (rt) =>
-        rt.deployment.slug === `${systemPrefix}-deployment-b` &&
-        rt.environment.name === `${systemPrefix}-b` &&
-        rt.resource.identifier === `${systemPrefix}-prod`,
-    ) ?? [];
+    const prodDeploymentBEnvironmentBMatch =
+      releaseTargets?.filter(
+        (rt) =>
+          rt.deployment.slug === `${systemPrefix}-deployment-b` &&
+          rt.environment.name === `${systemPrefix}-b` &&
+          rt.resource.identifier === `${systemPrefix}-prod`,
+      ) ?? [];
     expect(prodDeploymentBEnvironmentBMatch.length).toBe(0);
 
-    const qaDeploymentAEnvironmentAMatch = releaseTargets?.filter(
-      (rt) =>
-        rt.deployment.slug === `${systemPrefix}-deployment-a` &&
-        rt.environment.name === `${systemPrefix}-a` &&
-        rt.resource.identifier === `${systemPrefix}-qa`,
-    ) ?? [];
+    const qaDeploymentAEnvironmentAMatch =
+      releaseTargets?.filter(
+        (rt) =>
+          rt.deployment.slug === `${systemPrefix}-deployment-a` &&
+          rt.environment.name === `${systemPrefix}-a` &&
+          rt.resource.identifier === `${systemPrefix}-qa`,
+      ) ?? [];
     expect(qaDeploymentAEnvironmentAMatch.length).toBe(0);
 
-    const qaDeploymentAEnvironmentBMatch = releaseTargets?.filter(
-      (rt) =>
-        rt.deployment.slug === `${systemPrefix}-deployment-a` &&
-        rt.environment.name === `${systemPrefix}-b` &&
-        rt.resource.identifier === `${systemPrefix}-qa`,
-    ) ?? [];
+    const qaDeploymentAEnvironmentBMatch =
+      releaseTargets?.filter(
+        (rt) =>
+          rt.deployment.slug === `${systemPrefix}-deployment-a` &&
+          rt.environment.name === `${systemPrefix}-b` &&
+          rt.resource.identifier === `${systemPrefix}-qa`,
+      ) ?? [];
     expect(qaDeploymentAEnvironmentBMatch.length).toBe(0);
 
-    const qaDeploymentBEnvironmentAMatch = releaseTargets?.filter(
-      (rt) =>
-        rt.deployment.slug === `${systemPrefix}-deployment-b` &&
-        rt.environment.name === `${systemPrefix}-a` &&
-        rt.resource.identifier === `${systemPrefix}-qa`,
-    ) ?? [];
+    const qaDeploymentBEnvironmentAMatch =
+      releaseTargets?.filter(
+        (rt) =>
+          rt.deployment.slug === `${systemPrefix}-deployment-b` &&
+          rt.environment.name === `${systemPrefix}-a` &&
+          rt.resource.identifier === `${systemPrefix}-qa`,
+      ) ?? [];
     expect(qaDeploymentBEnvironmentAMatch.length).toBe(0);
 
-    const qaDeploymentBEnvironmentBMatch = releaseTargets?.filter(
-      (rt) =>
-        rt.deployment.slug === `${systemPrefix}-deployment-b` &&
-        rt.environment.name === `${systemPrefix}-b` &&
-        rt.resource.identifier === `${systemPrefix}-qa`,
-    ) ?? [];
+    const qaDeploymentBEnvironmentBMatch =
+      releaseTargets?.filter(
+        (rt) =>
+          rt.deployment.slug === `${systemPrefix}-deployment-b` &&
+          rt.environment.name === `${systemPrefix}-b` &&
+          rt.resource.identifier === `${systemPrefix}-qa`,
+      ) ?? [];
     expect(qaDeploymentBEnvironmentBMatch.length).toBe(0);
   });
 
-  test("should update release targets when resource and deployment and environment selectors are updated", async ({ api, workspace, page }) => {
+  test("should update release targets when resource and deployment and environment selectors are updated", async ({
+    api,
+    workspace,
+    page,
+  }) => {
     const { id: workspaceId } = workspace;
     const systemPrefix = importedEntities.system.slug.split("-")[0]!;
     const policyName = faker.string.alphanumeric(10);
@@ -1321,68 +1433,76 @@ test.describe("Release Targets API", () => {
 
     expect(count).toBe(1);
 
-    const prodDeploymentAEnvironmentAMatch = releaseTargets?.filter(
-      (rt) =>
-        rt.deployment.slug === `${systemPrefix}-deployment-a` &&
-        rt.environment.name === `${systemPrefix}-a` &&
-        rt.resource.identifier === `${systemPrefix}-prod`,
-    ) ?? [];
+    const prodDeploymentAEnvironmentAMatch =
+      releaseTargets?.filter(
+        (rt) =>
+          rt.deployment.slug === `${systemPrefix}-deployment-a` &&
+          rt.environment.name === `${systemPrefix}-a` &&
+          rt.resource.identifier === `${systemPrefix}-prod`,
+      ) ?? [];
     expect(prodDeploymentAEnvironmentAMatch.length).toBe(0);
 
-    const prodDeploymentAEnvironmentBMatch = releaseTargets?.filter(
-      (rt) =>
-        rt.deployment.slug === `${systemPrefix}-deployment-a` &&
-        rt.environment.name === `${systemPrefix}-b` &&
-        rt.resource.identifier === `${systemPrefix}-prod`,
-    ) ?? [];
+    const prodDeploymentAEnvironmentBMatch =
+      releaseTargets?.filter(
+        (rt) =>
+          rt.deployment.slug === `${systemPrefix}-deployment-a` &&
+          rt.environment.name === `${systemPrefix}-b` &&
+          rt.resource.identifier === `${systemPrefix}-prod`,
+      ) ?? [];
     expect(prodDeploymentAEnvironmentBMatch.length).toBe(0);
 
-    const prodDeploymentBEnvironmentAMatch = releaseTargets?.filter(
-      (rt) =>
-        rt.deployment.slug === `${systemPrefix}-deployment-b` &&
-        rt.environment.name === `${systemPrefix}-a` &&
-        rt.resource.identifier === `${systemPrefix}-prod`,
-    ) ?? [];
+    const prodDeploymentBEnvironmentAMatch =
+      releaseTargets?.filter(
+        (rt) =>
+          rt.deployment.slug === `${systemPrefix}-deployment-b` &&
+          rt.environment.name === `${systemPrefix}-a` &&
+          rt.resource.identifier === `${systemPrefix}-prod`,
+      ) ?? [];
     expect(prodDeploymentBEnvironmentAMatch.length).toBe(0);
 
-    const prodDeploymentBEnvironmentBMatch = releaseTargets?.filter(
-      (rt) =>
-        rt.deployment.slug === `${systemPrefix}-deployment-b` &&
-        rt.environment.name === `${systemPrefix}-b` &&
-        rt.resource.identifier === `${systemPrefix}-prod`,
-    ) ?? [];
+    const prodDeploymentBEnvironmentBMatch =
+      releaseTargets?.filter(
+        (rt) =>
+          rt.deployment.slug === `${systemPrefix}-deployment-b` &&
+          rt.environment.name === `${systemPrefix}-b` &&
+          rt.resource.identifier === `${systemPrefix}-prod`,
+      ) ?? [];
     expect(prodDeploymentBEnvironmentBMatch.length).toBe(0);
 
-    const qaDeploymentAEnvironmentAMatch = releaseTargets?.filter(
-      (rt) =>
-        rt.deployment.slug === `${systemPrefix}-deployment-a` &&
-        rt.environment.name === `${systemPrefix}-a` &&
-        rt.resource.identifier === `${systemPrefix}-qa`,
-    ) ?? [];
+    const qaDeploymentAEnvironmentAMatch =
+      releaseTargets?.filter(
+        (rt) =>
+          rt.deployment.slug === `${systemPrefix}-deployment-a` &&
+          rt.environment.name === `${systemPrefix}-a` &&
+          rt.resource.identifier === `${systemPrefix}-qa`,
+      ) ?? [];
     expect(qaDeploymentAEnvironmentAMatch.length).toBe(0);
 
-    const qaDeploymentAEnvironmentBMatch = releaseTargets?.filter(
-      (rt) =>
-        rt.deployment.slug === `${systemPrefix}-deployment-a` &&
-        rt.environment.name === `${systemPrefix}-b` &&
-        rt.resource.identifier === `${systemPrefix}-qa`,
-    ) ?? [];
+    const qaDeploymentAEnvironmentBMatch =
+      releaseTargets?.filter(
+        (rt) =>
+          rt.deployment.slug === `${systemPrefix}-deployment-a` &&
+          rt.environment.name === `${systemPrefix}-b` &&
+          rt.resource.identifier === `${systemPrefix}-qa`,
+      ) ?? [];
     expect(qaDeploymentAEnvironmentBMatch.length).toBe(0);
 
-    const qaDeploymentBEnvironmentAMatch = releaseTargets?.filter(
-      (rt) =>
-        rt.deployment.slug === `${systemPrefix}-deployment-b` &&
-        rt.environment.name === `${systemPrefix}-a` &&
-        rt.resource.identifier === `${systemPrefix}-qa`,
-    ) ?? [];
+    const qaDeploymentBEnvironmentAMatch =
+      releaseTargets?.filter(
+        (rt) =>
+          rt.deployment.slug === `${systemPrefix}-deployment-b` &&
+          rt.environment.name === `${systemPrefix}-a` &&
+          rt.resource.identifier === `${systemPrefix}-qa`,
+      ) ?? [];
     expect(qaDeploymentBEnvironmentAMatch.length).toBe(0);
 
-    const qaDeploymentBEnvironmentBMatch = releaseTargets?.filter(
-      (rt) =>
-        rt.deployment.slug === `${systemPrefix}-deployment-b` &&
-        rt.environment.name === `${systemPrefix}-b` &&
-        rt.resource.identifier === `${systemPrefix}-qa`,
-    ) ?? [];
+    const qaDeploymentBEnvironmentBMatch =
+      releaseTargets?.filter(
+        (rt) =>
+          rt.deployment.slug === `${systemPrefix}-deployment-b` &&
+          rt.environment.name === `${systemPrefix}-b` &&
+          rt.resource.identifier === `${systemPrefix}-qa`,
+      ) ?? [];
     expect(qaDeploymentBEnvironmentBMatch.length).toBe(1);
   });
 });

--- a/e2e/tests/api/policies/matched-release-targets.spec.ts
+++ b/e2e/tests/api/policies/matched-release-targets.spec.ts
@@ -3,39 +3,32 @@ import { faker } from "@faker-js/faker";
 import { expect } from "@playwright/test";
 import _ from "lodash";
 
-import {
-  cleanupImportedEntities,
-  ImportedEntities,
-  importEntitiesFromYaml,
-} from "../../../api";
+import { cleanupImportedEntities, EntitiesBuilder } from "../../../api";
 import { test } from "../../fixtures";
 
 const yamlPath = path.join(__dirname, "matched-release-targets.spec.yaml");
 
 test.describe("Release Targets API", () => {
-  let importedEntities: ImportedEntities;
+  let builder: EntitiesBuilder;
 
   test.beforeAll(async ({ api, workspace }) => {
-    importedEntities = await importEntitiesFromYaml(
-      api,
-      workspace.id,
-      yamlPath,
-    );
+    builder = new EntitiesBuilder(api, workspace, yamlPath);
+
+    builder.createSystem();
+    builder.createResources();
+    builder.createEnvironments();
+    builder.createDeployments();
 
     await new Promise((resolve) => setTimeout(resolve, 1_000));
   });
 
   test.afterAll(async ({ api, workspace }) => {
-    await cleanupImportedEntities(api, importedEntities, workspace.id);
+    await cleanupImportedEntities(api, builder.cache, workspace.id);
   });
 
-  test("should match a policy to a specific resource", async ({
-    api,
-    workspace,
-    page,
-  }) => {
+  test("should match a policy to a specific resource", async ({ api, workspace, page }) => {
     const { id: workspaceId } = workspace;
-    const systemPrefix = importedEntities.system.slug.split("-")[0]!;
+    const systemPrefix = builder.cache.system.slug.split("-")[0]!;
 
     const policyName = faker.string.alphanumeric(10);
     const policyResponse = await api.POST("/v1/policies", {
@@ -74,26 +67,20 @@ test.describe("Release Targets API", () => {
 
     expect(count).toBe(4);
 
-    const prodResourceMatch =
-      releaseTargets?.filter(
-        (rt) => rt.resource.identifier === `${systemPrefix}-prod`,
-      ) ?? [];
+    const prodResourceMatch = releaseTargets?.filter(
+      (rt) => rt.resource.identifier === `${systemPrefix}-prod`,
+    ) ?? [];
     expect(prodResourceMatch.length).toBe(4);
 
-    const qaResourceMatch =
-      releaseTargets?.filter(
-        (rt) => rt.resource.identifier === `${systemPrefix}-qa`,
-      ) ?? [];
+    const qaResourceMatch = releaseTargets?.filter(
+      (rt) => rt.resource.identifier === `${systemPrefix}-qa`,
+    ) ?? [];
     expect(qaResourceMatch.length).toBe(0);
   });
 
-  test("should update release targets when resource selector is updated", async ({
-    api,
-    workspace,
-    page,
-  }) => {
+  test("should update release targets when resource selector is updated", async ({ api, workspace, page }) => {
     const { id: workspaceId } = workspace;
-    const systemPrefix = importedEntities.system.slug.split("-")[0]!;
+    const systemPrefix = builder.cache.system.slug.split("-")[0]!;
     const policyName = faker.string.alphanumeric(10);
     const policyResponse = await api.POST("/v1/policies", {
       body: {
@@ -150,26 +137,20 @@ test.describe("Release Targets API", () => {
 
     expect(count).toBe(4);
 
-    const qaResourceMatch =
-      releaseTargets?.filter(
-        (rt) => rt.resource.identifier === `${systemPrefix}-qa`,
-      ) ?? [];
+    const qaResourceMatch = releaseTargets?.filter(
+      (rt) => rt.resource.identifier === `${systemPrefix}-qa`,
+    ) ?? [];
     expect(qaResourceMatch.length).toBe(4);
 
-    const prodResourceMatch =
-      releaseTargets?.filter(
-        (rt) => rt.resource.identifier === `${systemPrefix}-prod`,
-      ) ?? [];
+    const prodResourceMatch = releaseTargets?.filter(
+      (rt) => rt.resource.identifier === `${systemPrefix}-prod`,
+    ) ?? [];
     expect(prodResourceMatch.length).toBe(0);
   });
 
-  test("should not match a resource that is deleted", async ({
-    api,
-    workspace,
-    page,
-  }) => {
+  test("should not match a resource that is deleted", async ({ api, workspace, page }) => {
     const { id: workspaceId } = workspace;
-    const systemPrefix = importedEntities.system.slug.split("-")[0]!;
+    const systemPrefix = builder.cache.system.slug.split("-")[0]!;
     const resourceName = `${systemPrefix}-sample`;
     const sampleResourceResponse = await api.POST("/v1/resources", {
       body: {
@@ -235,13 +216,9 @@ test.describe("Release Targets API", () => {
     expect(count).toBe(0);
   });
 
-  test("should match a policy to a specific environment", async ({
-    api,
-    workspace,
-    page,
-  }) => {
+  test("should match a policy to a specific environment", async ({ api, workspace, page }) => {
     const { id: workspaceId } = workspace;
-    const systemPrefix = importedEntities.system.slug.split("-")[0]!;
+    const systemPrefix = builder.cache.system.slug.split("-")[0]!;
 
     const policyName = faker.string.alphanumeric(10);
     const policyResponse = await api.POST("/v1/policies", {
@@ -280,26 +257,20 @@ test.describe("Release Targets API", () => {
 
     expect(count).toBe(4);
 
-    const aEnvironmentMatch =
-      releaseTargets?.filter(
-        (rt) => rt.environment.name === `${systemPrefix}-a`,
-      ) ?? [];
+    const aEnvironmentMatch = releaseTargets?.filter(
+      (rt) => rt.environment.name === `${systemPrefix}-a`,
+    ) ?? [];
     expect(aEnvironmentMatch.length).toBe(4);
 
-    const bEnvironmentMatch =
-      releaseTargets?.filter(
-        (rt) => rt.environment.name === `${systemPrefix}-b`,
-      ) ?? [];
+    const bEnvironmentMatch = releaseTargets?.filter(
+      (rt) => rt.environment.name === `${systemPrefix}-b`,
+    ) ?? [];
     expect(bEnvironmentMatch.length).toBe(0);
   });
 
-  test("should update release targets when environment selector is updated", async ({
-    api,
-    workspace,
-    page,
-  }) => {
+  test("should update release targets when environment selector is updated", async ({ api, workspace, page }) => {
     const { id: workspaceId } = workspace;
-    const systemPrefix = importedEntities.system.slug.split("-")[0]!;
+    const systemPrefix = builder.cache.system.slug.split("-")[0]!;
     const policyName = faker.string.alphanumeric(10);
     const policyResponse = await api.POST("/v1/policies", {
       body: {
@@ -356,32 +327,26 @@ test.describe("Release Targets API", () => {
 
     expect(count).toBe(4);
 
-    const bEnvironmentMatch =
-      releaseTargets?.filter(
-        (rt) => rt.environment.name === `${systemPrefix}-b`,
-      ) ?? [];
+    const bEnvironmentMatch = releaseTargets?.filter(
+      (rt) => rt.environment.name === `${systemPrefix}-b`,
+    ) ?? [];
     expect(bEnvironmentMatch.length).toBe(4);
 
-    const aEnvironmentMatch =
-      releaseTargets?.filter(
-        (rt) => rt.environment.name === `${systemPrefix}-a`,
-      ) ?? [];
+    const aEnvironmentMatch = releaseTargets?.filter(
+      (rt) => rt.environment.name === `${systemPrefix}-a`,
+    ) ?? [];
     expect(aEnvironmentMatch.length).toBe(0);
   });
 
-  test("should not match an environment that is deleted", async ({
-    api,
-    workspace,
-    page,
-  }) => {
+  test("should not match an environment that is deleted", async ({ api, workspace, page }) => {
     const { id: workspaceId } = workspace;
-    const systemPrefix = importedEntities.system.slug.split("-")[0]!;
+    const systemPrefix = builder.cache.system.slug.split("-")[0]!;
     const environmentName = `${systemPrefix}-staging`;
 
     const environmentResponse = await api.POST("/v1/environments", {
       body: {
         name: environmentName,
-        systemId: importedEntities.system.id,
+        systemId: builder.cache.system.id,
         resourceSelector: {
           type: "identifier",
           operator: "equals",
@@ -446,11 +411,7 @@ test.describe("Release Targets API", () => {
     expect(count).toBe(0);
   });
 
-  test("should match a policy to a specific deployment", async ({
-    api,
-    workspace,
-    page,
-  }) => {
+  test("should match a policy to a specific deployment", async ({ api, workspace, page }) => {
     const { id: workspaceId } = workspace;
     const systemPrefix = importedEntities.system.slug.split("-")[0]!;
 
@@ -491,24 +452,18 @@ test.describe("Release Targets API", () => {
 
     expect(count).toBe(4);
 
-    const aDeploymentMatch =
-      releaseTargets?.filter(
-        (rt) => rt.deployment.slug === `${systemPrefix}-deployment-a`,
-      ) ?? [];
+    const aDeploymentMatch = releaseTargets?.filter(
+      (rt) => rt.deployment.slug === `${systemPrefix}-deployment-a`,
+    ) ?? [];
     expect(aDeploymentMatch.length).toBe(4);
 
-    const bDeploymentMatch =
-      releaseTargets?.filter(
-        (rt) => rt.deployment.slug === `${systemPrefix}-deployment-b`,
-      ) ?? [];
+    const bDeploymentMatch = releaseTargets?.filter(
+      (rt) => rt.deployment.slug === `${systemPrefix}-deployment-b`,
+    ) ?? [];
     expect(bDeploymentMatch.length).toBe(0);
   });
 
-  test("should update release targets when deployment selector is updated", async ({
-    api,
-    workspace,
-    page,
-  }) => {
+  test("should update release targets when deployment selector is updated", async ({ api, workspace, page }) => {
     const { id: workspaceId } = workspace;
     const systemPrefix = importedEntities.system.slug.split("-")[0]!;
     const policyName = faker.string.alphanumeric(10);
@@ -567,24 +522,18 @@ test.describe("Release Targets API", () => {
 
     expect(count).toBe(4);
 
-    const bDeploymentMatch =
-      releaseTargets?.filter(
-        (rt) => rt.deployment.slug === `${systemPrefix}-deployment-b`,
-      ) ?? [];
+    const bDeploymentMatch = releaseTargets?.filter(
+      (rt) => rt.deployment.slug === `${systemPrefix}-deployment-b`,
+    ) ?? [];
     expect(bDeploymentMatch.length).toBe(4);
 
-    const aDeploymentMatch =
-      releaseTargets?.filter(
-        (rt) => rt.deployment.slug === `${systemPrefix}-deployment-a`,
-      ) ?? [];
+    const aDeploymentMatch = releaseTargets?.filter(
+      (rt) => rt.deployment.slug === `${systemPrefix}-deployment-a`,
+    ) ?? [];
     expect(aDeploymentMatch.length).toBe(0);
   });
 
-  test("should not match a deployment that is deleted", async ({
-    api,
-    workspace,
-    page,
-  }) => {
+  test("should not match a deployment that is deleted", async ({ api, workspace, page }) => {
     const { id: workspaceId } = workspace;
     const systemPrefix = importedEntities.system.slug.split("-")[0]!;
     const deploymentName = `${systemPrefix}-deployment-c`;
@@ -658,11 +607,7 @@ test.describe("Release Targets API", () => {
     expect(count).toBe(0);
   });
 
-  test("should match a policy to a specific deployment and environment", async ({
-    api,
-    workspace,
-    page,
-  }) => {
+  test("should match a policy to a specific deployment and environment", async ({ api, workspace, page }) => {
     const { id: workspaceId } = workspace;
     const systemPrefix = importedEntities.system.slug.split("-")[0]!;
 
@@ -708,44 +653,36 @@ test.describe("Release Targets API", () => {
 
     expect(count).toBe(2);
 
-    const deploymentAEnvironmentAMatch =
-      releaseTargets?.filter(
-        (rt) =>
-          rt.deployment.slug === `${systemPrefix}-deployment-a` &&
-          rt.environment.name === `${systemPrefix}-a`,
-      ) ?? [];
+    const deploymentAEnvironmentAMatch = releaseTargets?.filter(
+      (rt) =>
+        rt.deployment.slug === `${systemPrefix}-deployment-a` &&
+        rt.environment.name === `${systemPrefix}-a`,
+    ) ?? [];
     expect(deploymentAEnvironmentAMatch.length).toBe(2);
 
-    const deploymentBEnvironmentAMatch =
-      releaseTargets?.filter(
-        (rt) =>
-          rt.deployment.slug === `${systemPrefix}-deployment-b` &&
-          rt.environment.name === `${systemPrefix}-a`,
-      ) ?? [];
+    const deploymentBEnvironmentAMatch = releaseTargets?.filter(
+      (rt) =>
+        rt.deployment.slug === `${systemPrefix}-deployment-b` &&
+        rt.environment.name === `${systemPrefix}-a`,
+    ) ?? [];
     expect(deploymentBEnvironmentAMatch.length).toBe(0);
 
-    const deploymentAEnvironmentBMatch =
-      releaseTargets?.filter(
-        (rt) =>
-          rt.deployment.slug === `${systemPrefix}-deployment-a` &&
-          rt.environment.name === `${systemPrefix}-b`,
-      ) ?? [];
+    const deploymentAEnvironmentBMatch = releaseTargets?.filter(
+      (rt) =>
+        rt.deployment.slug === `${systemPrefix}-deployment-a` &&
+        rt.environment.name === `${systemPrefix}-b`,
+    ) ?? [];
     expect(deploymentAEnvironmentBMatch.length).toBe(0);
 
-    const deploymentBEnvironmentBMatch =
-      releaseTargets?.filter(
-        (rt) =>
-          rt.deployment.slug === `${systemPrefix}-deployment-b` &&
-          rt.environment.name === `${systemPrefix}-b`,
-      ) ?? [];
+    const deploymentBEnvironmentBMatch = releaseTargets?.filter(
+      (rt) =>
+        rt.deployment.slug === `${systemPrefix}-deployment-b` &&
+        rt.environment.name === `${systemPrefix}-b`,
+    ) ?? [];
     expect(deploymentBEnvironmentBMatch.length).toBe(0);
   });
 
-  test("should update release targets when deployment and environment selectors are updated", async ({
-    api,
-    workspace,
-    page,
-  }) => {
+  test("should update release targets when deployment and environment selectors are updated", async ({ api, workspace, page }) => {
     const { id: workspaceId } = workspace;
     const systemPrefix = importedEntities.system.slug.split("-")[0]!;
     const policyName = faker.string.alphanumeric(10);
@@ -814,44 +751,36 @@ test.describe("Release Targets API", () => {
 
     expect(count).toBe(2);
 
-    const deploymentAEnvironmentAMatch =
-      releaseTargets?.filter(
-        (rt) =>
-          rt.deployment.slug === `${systemPrefix}-deployment-a` &&
-          rt.environment.name === `${systemPrefix}-a`,
-      ) ?? [];
+    const deploymentAEnvironmentAMatch = releaseTargets?.filter(
+      (rt) =>
+        rt.deployment.slug === `${systemPrefix}-deployment-a` &&
+        rt.environment.name === `${systemPrefix}-a`,
+    ) ?? [];
     expect(deploymentAEnvironmentAMatch.length).toBe(0);
 
-    const deploymentBEnvironmentAMatch =
-      releaseTargets?.filter(
-        (rt) =>
-          rt.deployment.slug === `${systemPrefix}-deployment-b` &&
-          rt.environment.name === `${systemPrefix}-a`,
-      ) ?? [];
+    const deploymentBEnvironmentAMatch = releaseTargets?.filter(
+      (rt) =>
+        rt.deployment.slug === `${systemPrefix}-deployment-b` &&
+        rt.environment.name === `${systemPrefix}-a`,
+    ) ?? [];
     expect(deploymentBEnvironmentAMatch.length).toBe(0);
 
-    const deploymentAEnvironmentBMatch =
-      releaseTargets?.filter(
-        (rt) =>
-          rt.deployment.slug === `${systemPrefix}-deployment-a` &&
-          rt.environment.name === `${systemPrefix}-b`,
-      ) ?? [];
+    const deploymentAEnvironmentBMatch = releaseTargets?.filter(
+      (rt) =>
+        rt.deployment.slug === `${systemPrefix}-deployment-a` &&
+        rt.environment.name === `${systemPrefix}-b`,
+    ) ?? [];
     expect(deploymentAEnvironmentBMatch.length).toBe(0);
 
-    const deploymentBEnvironmentBMatch =
-      releaseTargets?.filter(
-        (rt) =>
-          rt.deployment.slug === `${systemPrefix}-deployment-b` &&
-          rt.environment.name === `${systemPrefix}-b`,
-      ) ?? [];
+    const deploymentBEnvironmentBMatch = releaseTargets?.filter(
+      (rt) =>
+        rt.deployment.slug === `${systemPrefix}-deployment-b` &&
+        rt.environment.name === `${systemPrefix}-b`,
+    ) ?? [];
     expect(deploymentBEnvironmentBMatch.length).toBe(2);
   });
 
-  test("should match a policy to a specific resource and environment", async ({
-    api,
-    workspace,
-    page,
-  }) => {
+  test("should match a policy to a specific resource and environment", async ({ api, workspace, page }) => {
     const { id: workspaceId } = workspace;
     const systemPrefix = importedEntities.system.slug.split("-")[0]!;
 
@@ -897,44 +826,36 @@ test.describe("Release Targets API", () => {
 
     expect(count).toBe(2);
 
-    const prodEnvironmentAMatch =
-      releaseTargets?.filter(
-        (rt) =>
-          rt.environment.name === `${systemPrefix}-a` &&
-          rt.resource.identifier === `${systemPrefix}-prod`,
-      ) ?? [];
+    const prodEnvironmentAMatch = releaseTargets?.filter(
+      (rt) =>
+        rt.environment.name === `${systemPrefix}-a` &&
+        rt.resource.identifier === `${systemPrefix}-prod`,
+    ) ?? [];
     expect(prodEnvironmentAMatch.length).toBe(2);
 
-    const prodEnvironmentBMatch =
-      releaseTargets?.filter(
-        (rt) =>
-          rt.environment.name === `${systemPrefix}-b` &&
-          rt.resource.identifier === `${systemPrefix}-prod`,
-      ) ?? [];
+    const prodEnvironmentBMatch = releaseTargets?.filter(
+      (rt) =>
+        rt.environment.name === `${systemPrefix}-b` &&
+        rt.resource.identifier === `${systemPrefix}-prod`,
+    ) ?? [];
     expect(prodEnvironmentBMatch.length).toBe(0);
 
-    const qaEnvironmentAMatch =
-      releaseTargets?.filter(
-        (rt) =>
-          rt.environment.name === `${systemPrefix}-a` &&
-          rt.resource.identifier === `${systemPrefix}-qa`,
-      ) ?? [];
+    const qaEnvironmentAMatch = releaseTargets?.filter(
+      (rt) =>
+        rt.environment.name === `${systemPrefix}-a` &&
+        rt.resource.identifier === `${systemPrefix}-qa`,
+    ) ?? [];
     expect(qaEnvironmentAMatch.length).toBe(0);
 
-    const qaEnvironmentBMatch =
-      releaseTargets?.filter(
-        (rt) =>
-          rt.environment.name === `${systemPrefix}-b` &&
-          rt.resource.identifier === `${systemPrefix}-qa`,
-      ) ?? [];
+    const qaEnvironmentBMatch = releaseTargets?.filter(
+      (rt) =>
+        rt.environment.name === `${systemPrefix}-b` &&
+        rt.resource.identifier === `${systemPrefix}-qa`,
+    ) ?? [];
     expect(qaEnvironmentBMatch.length).toBe(0);
   });
 
-  test("should update release targets when resource and environment selectors are updated", async ({
-    api,
-    workspace,
-    page,
-  }) => {
+  test("should update release targets when resource and environment selectors are updated", async ({ api, workspace, page }) => {
     const { id: workspaceId } = workspace;
     const systemPrefix = importedEntities.system.slug.split("-")[0]!;
     const policyName = faker.string.alphanumeric(10);
@@ -1003,44 +924,36 @@ test.describe("Release Targets API", () => {
 
     expect(count).toBe(2);
 
-    const prodEnvironmentAMatch =
-      releaseTargets?.filter(
-        (rt) =>
-          rt.environment.name === `${systemPrefix}-a` &&
-          rt.resource.identifier === `${systemPrefix}-prod`,
-      ) ?? [];
+    const prodEnvironmentAMatch = releaseTargets?.filter(
+      (rt) =>
+        rt.environment.name === `${systemPrefix}-a` &&
+        rt.resource.identifier === `${systemPrefix}-prod`,
+    ) ?? [];
     expect(prodEnvironmentAMatch.length).toBe(0);
 
-    const prodEnvironmentBMatch =
-      releaseTargets?.filter(
-        (rt) =>
-          rt.environment.name === `${systemPrefix}-b` &&
-          rt.resource.identifier === `${systemPrefix}-prod`,
-      ) ?? [];
+    const prodEnvironmentBMatch = releaseTargets?.filter(
+      (rt) =>
+        rt.environment.name === `${systemPrefix}-b` &&
+        rt.resource.identifier === `${systemPrefix}-prod`,
+    ) ?? [];
     expect(prodEnvironmentBMatch.length).toBe(0);
 
-    const qaEnvironmentAMatch =
-      releaseTargets?.filter(
-        (rt) =>
-          rt.environment.name === `${systemPrefix}-a` &&
-          rt.resource.identifier === `${systemPrefix}-qa`,
-      ) ?? [];
+    const qaEnvironmentAMatch = releaseTargets?.filter(
+      (rt) =>
+        rt.environment.name === `${systemPrefix}-a` &&
+        rt.resource.identifier === `${systemPrefix}-qa`,
+    ) ?? [];
     expect(qaEnvironmentAMatch.length).toBe(0);
 
-    const qaEnvironmentBMatch =
-      releaseTargets?.filter(
-        (rt) =>
-          rt.environment.name === `${systemPrefix}-b` &&
-          rt.resource.identifier === `${systemPrefix}-qa`,
-      ) ?? [];
+    const qaEnvironmentBMatch = releaseTargets?.filter(
+      (rt) =>
+        rt.environment.name === `${systemPrefix}-b` &&
+        rt.resource.identifier === `${systemPrefix}-qa`,
+    ) ?? [];
     expect(qaEnvironmentBMatch.length).toBe(2);
   });
 
-  test("should match a policy to a specific resource and deployment", async ({
-    api,
-    workspace,
-    page,
-  }) => {
+  test("should match a policy to a specific resource and deployment", async ({ api, workspace, page }) => {
     const { id: workspaceId } = workspace;
     const systemPrefix = importedEntities.system.slug.split("-")[0]!;
 
@@ -1086,44 +999,36 @@ test.describe("Release Targets API", () => {
 
     expect(count).toBe(2);
 
-    const prodDeploymentAMatch =
-      releaseTargets?.filter(
-        (rt) =>
-          rt.deployment.slug === `${systemPrefix}-deployment-a` &&
-          rt.resource.identifier === `${systemPrefix}-prod`,
-      ) ?? [];
+    const prodDeploymentAMatch = releaseTargets?.filter(
+      (rt) =>
+        rt.deployment.slug === `${systemPrefix}-deployment-a` &&
+        rt.resource.identifier === `${systemPrefix}-prod`,
+    ) ?? [];
     expect(prodDeploymentAMatch.length).toBe(2);
 
-    const prodDeploymentBMatch =
-      releaseTargets?.filter(
-        (rt) =>
-          rt.deployment.slug === `${systemPrefix}-deployment-b` &&
-          rt.resource.identifier === `${systemPrefix}-prod`,
-      ) ?? [];
+    const prodDeploymentBMatch = releaseTargets?.filter(
+      (rt) =>
+        rt.deployment.slug === `${systemPrefix}-deployment-b` &&
+        rt.resource.identifier === `${systemPrefix}-prod`,
+    ) ?? [];
     expect(prodDeploymentBMatch.length).toBe(0);
 
-    const qaDeploymentAMatch =
-      releaseTargets?.filter(
-        (rt) =>
-          rt.deployment.slug === `${systemPrefix}-deployment-a` &&
-          rt.resource.identifier === `${systemPrefix}-qa`,
-      ) ?? [];
+    const qaDeploymentAMatch = releaseTargets?.filter(
+      (rt) =>
+        rt.deployment.slug === `${systemPrefix}-deployment-a` &&
+        rt.resource.identifier === `${systemPrefix}-qa`,
+    ) ?? [];
     expect(qaDeploymentAMatch.length).toBe(0);
 
-    const qaDeploymentBMatch =
-      releaseTargets?.filter(
-        (rt) =>
-          rt.deployment.slug === `${systemPrefix}-deployment-b` &&
-          rt.resource.identifier === `${systemPrefix}-qa`,
-      ) ?? [];
+    const qaDeploymentBMatch = releaseTargets?.filter(
+      (rt) =>
+        rt.deployment.slug === `${systemPrefix}-deployment-b` &&
+        rt.resource.identifier === `${systemPrefix}-qa`,
+    ) ?? [];
     expect(qaDeploymentBMatch.length).toBe(0);
   });
 
-  test("should update release targets when resource and deployment selectors are updated", async ({
-    api,
-    workspace,
-    page,
-  }) => {
+  test("should update release targets when resource and deployment selectors are updated", async ({ api, workspace, page }) => {
     const { id: workspaceId } = workspace;
     const systemPrefix = importedEntities.system.slug.split("-")[0]!;
     const policyName = faker.string.alphanumeric(10);
@@ -1192,44 +1097,36 @@ test.describe("Release Targets API", () => {
 
     expect(count).toBe(2);
 
-    const prodDeploymentAMatch =
-      releaseTargets?.filter(
-        (rt) =>
-          rt.deployment.slug === `${systemPrefix}-deployment-a` &&
-          rt.resource.identifier === `${systemPrefix}-prod`,
-      ) ?? [];
+    const prodDeploymentAMatch = releaseTargets?.filter(
+      (rt) =>
+        rt.deployment.slug === `${systemPrefix}-deployment-a` &&
+        rt.resource.identifier === `${systemPrefix}-prod`,
+    ) ?? [];
     expect(prodDeploymentAMatch.length).toBe(0);
 
-    const prodDeploymentBMatch =
-      releaseTargets?.filter(
-        (rt) =>
-          rt.deployment.slug === `${systemPrefix}-deployment-b` &&
-          rt.resource.identifier === `${systemPrefix}-prod`,
-      ) ?? [];
+    const prodDeploymentBMatch = releaseTargets?.filter(
+      (rt) =>
+        rt.deployment.slug === `${systemPrefix}-deployment-b` &&
+        rt.resource.identifier === `${systemPrefix}-prod`,
+    ) ?? [];
     expect(prodDeploymentBMatch.length).toBe(0);
 
-    const qaDeploymentAMatch =
-      releaseTargets?.filter(
-        (rt) =>
-          rt.deployment.slug === `${systemPrefix}-deployment-a` &&
-          rt.resource.identifier === `${systemPrefix}-qa`,
-      ) ?? [];
+    const qaDeploymentAMatch = releaseTargets?.filter(
+      (rt) =>
+        rt.deployment.slug === `${systemPrefix}-deployment-a` &&
+        rt.resource.identifier === `${systemPrefix}-qa`,
+    ) ?? [];
     expect(qaDeploymentAMatch.length).toBe(0);
 
-    const qaDeploymentBMatch =
-      releaseTargets?.filter(
-        (rt) =>
-          rt.deployment.slug === `${systemPrefix}-deployment-b` &&
-          rt.resource.identifier === `${systemPrefix}-qa`,
-      ) ?? [];
+    const qaDeploymentBMatch = releaseTargets?.filter(
+      (rt) =>
+        rt.deployment.slug === `${systemPrefix}-deployment-b` &&
+        rt.resource.identifier === `${systemPrefix}-qa`,
+    ) ?? [];
     expect(qaDeploymentBMatch.length).toBe(2);
   });
 
-  test("should match a policy to a specific resource and deployment and environment", async ({
-    api,
-    workspace,
-    page,
-  }) => {
+  test("should match a policy to a specific resource and deployment and environment", async ({ api, workspace, page }) => {
     const { id: workspaceId } = workspace;
     const systemPrefix = importedEntities.system.slug.split("-")[0]!;
 
@@ -1280,84 +1177,72 @@ test.describe("Release Targets API", () => {
 
     expect(count).toBe(1);
 
-    const prodDeploymentAEnvironmentAMatch =
-      releaseTargets?.filter(
-        (rt) =>
-          rt.deployment.slug === `${systemPrefix}-deployment-a` &&
-          rt.environment.name === `${systemPrefix}-a` &&
-          rt.resource.identifier === `${systemPrefix}-prod`,
-      ) ?? [];
+    const prodDeploymentAEnvironmentAMatch = releaseTargets?.filter(
+      (rt) =>
+        rt.deployment.slug === `${systemPrefix}-deployment-a` &&
+        rt.environment.name === `${systemPrefix}-a` &&
+        rt.resource.identifier === `${systemPrefix}-prod`,
+    ) ?? [];
     expect(prodDeploymentAEnvironmentAMatch.length).toBe(1);
 
-    const prodDeploymentAEnvironmentBMatch =
-      releaseTargets?.filter(
-        (rt) =>
-          rt.deployment.slug === `${systemPrefix}-deployment-a` &&
-          rt.environment.name === `${systemPrefix}-b` &&
-          rt.resource.identifier === `${systemPrefix}-prod`,
-      ) ?? [];
+    const prodDeploymentAEnvironmentBMatch = releaseTargets?.filter(
+      (rt) =>
+        rt.deployment.slug === `${systemPrefix}-deployment-a` &&
+        rt.environment.name === `${systemPrefix}-b` &&
+        rt.resource.identifier === `${systemPrefix}-prod`,
+    ) ?? [];
     expect(prodDeploymentAEnvironmentBMatch.length).toBe(0);
 
-    const prodDeploymentBEnvironmentAMatch =
-      releaseTargets?.filter(
-        (rt) =>
-          rt.deployment.slug === `${systemPrefix}-deployment-b` &&
-          rt.environment.name === `${systemPrefix}-a` &&
-          rt.resource.identifier === `${systemPrefix}-prod`,
-      ) ?? [];
+    const prodDeploymentBEnvironmentAMatch = releaseTargets?.filter(
+      (rt) =>
+        rt.deployment.slug === `${systemPrefix}-deployment-b` &&
+        rt.environment.name === `${systemPrefix}-a` &&
+        rt.resource.identifier === `${systemPrefix}-prod`,
+    ) ?? [];
     expect(prodDeploymentBEnvironmentAMatch.length).toBe(0);
 
-    const prodDeploymentBEnvironmentBMatch =
-      releaseTargets?.filter(
-        (rt) =>
-          rt.deployment.slug === `${systemPrefix}-deployment-b` &&
-          rt.environment.name === `${systemPrefix}-b` &&
-          rt.resource.identifier === `${systemPrefix}-prod`,
-      ) ?? [];
+    const prodDeploymentBEnvironmentBMatch = releaseTargets?.filter(
+      (rt) =>
+        rt.deployment.slug === `${systemPrefix}-deployment-b` &&
+        rt.environment.name === `${systemPrefix}-b` &&
+        rt.resource.identifier === `${systemPrefix}-prod`,
+    ) ?? [];
     expect(prodDeploymentBEnvironmentBMatch.length).toBe(0);
 
-    const qaDeploymentAEnvironmentAMatch =
-      releaseTargets?.filter(
-        (rt) =>
-          rt.deployment.slug === `${systemPrefix}-deployment-a` &&
-          rt.environment.name === `${systemPrefix}-a` &&
-          rt.resource.identifier === `${systemPrefix}-qa`,
-      ) ?? [];
+    const qaDeploymentAEnvironmentAMatch = releaseTargets?.filter(
+      (rt) =>
+        rt.deployment.slug === `${systemPrefix}-deployment-a` &&
+        rt.environment.name === `${systemPrefix}-a` &&
+        rt.resource.identifier === `${systemPrefix}-qa`,
+    ) ?? [];
     expect(qaDeploymentAEnvironmentAMatch.length).toBe(0);
 
-    const qaDeploymentAEnvironmentBMatch =
-      releaseTargets?.filter(
-        (rt) =>
-          rt.deployment.slug === `${systemPrefix}-deployment-a` &&
-          rt.environment.name === `${systemPrefix}-b` &&
-          rt.resource.identifier === `${systemPrefix}-qa`,
-      ) ?? [];
+    const qaDeploymentAEnvironmentBMatch = releaseTargets?.filter(
+      (rt) =>
+        rt.deployment.slug === `${systemPrefix}-deployment-a` &&
+        rt.environment.name === `${systemPrefix}-b` &&
+        rt.resource.identifier === `${systemPrefix}-qa`,
+    ) ?? [];
     expect(qaDeploymentAEnvironmentBMatch.length).toBe(0);
 
-    const qaDeploymentBEnvironmentAMatch =
-      releaseTargets?.filter(
-        (rt) =>
-          rt.deployment.slug === `${systemPrefix}-deployment-b` &&
-          rt.environment.name === `${systemPrefix}-a` &&
-          rt.resource.identifier === `${systemPrefix}-qa`,
-      ) ?? [];
+    const qaDeploymentBEnvironmentAMatch = releaseTargets?.filter(
+      (rt) =>
+        rt.deployment.slug === `${systemPrefix}-deployment-b` &&
+        rt.environment.name === `${systemPrefix}-a` &&
+        rt.resource.identifier === `${systemPrefix}-qa`,
+    ) ?? [];
     expect(qaDeploymentBEnvironmentAMatch.length).toBe(0);
 
-    const qaDeploymentBEnvironmentBMatch =
-      releaseTargets?.filter(
-        (rt) =>
-          rt.deployment.slug === `${systemPrefix}-deployment-b` &&
-          rt.environment.name === `${systemPrefix}-b` &&
-          rt.resource.identifier === `${systemPrefix}-qa`,
-      ) ?? [];
+    const qaDeploymentBEnvironmentBMatch = releaseTargets?.filter(
+      (rt) =>
+        rt.deployment.slug === `${systemPrefix}-deployment-b` &&
+        rt.environment.name === `${systemPrefix}-b` &&
+        rt.resource.identifier === `${systemPrefix}-qa`,
+    ) ?? [];
     expect(qaDeploymentBEnvironmentBMatch.length).toBe(0);
   });
 
-  test("should update release targets when resource and deployment and environment selectors are updated", async ({
-    api,
-    workspace,
-    page,
-  }) => {
+  test("should update release targets when resource and deployment and environment selectors are updated", async ({ api, workspace, page }) => {
     const { id: workspaceId } = workspace;
     const systemPrefix = importedEntities.system.slug.split("-")[0]!;
     const policyName = faker.string.alphanumeric(10);
@@ -1436,76 +1321,68 @@ test.describe("Release Targets API", () => {
 
     expect(count).toBe(1);
 
-    const prodDeploymentAEnvironmentAMatch =
-      releaseTargets?.filter(
-        (rt) =>
-          rt.deployment.slug === `${systemPrefix}-deployment-a` &&
-          rt.environment.name === `${systemPrefix}-a` &&
-          rt.resource.identifier === `${systemPrefix}-prod`,
-      ) ?? [];
+    const prodDeploymentAEnvironmentAMatch = releaseTargets?.filter(
+      (rt) =>
+        rt.deployment.slug === `${systemPrefix}-deployment-a` &&
+        rt.environment.name === `${systemPrefix}-a` &&
+        rt.resource.identifier === `${systemPrefix}-prod`,
+    ) ?? [];
     expect(prodDeploymentAEnvironmentAMatch.length).toBe(0);
 
-    const prodDeploymentAEnvironmentBMatch =
-      releaseTargets?.filter(
-        (rt) =>
-          rt.deployment.slug === `${systemPrefix}-deployment-a` &&
-          rt.environment.name === `${systemPrefix}-b` &&
-          rt.resource.identifier === `${systemPrefix}-prod`,
-      ) ?? [];
+    const prodDeploymentAEnvironmentBMatch = releaseTargets?.filter(
+      (rt) =>
+        rt.deployment.slug === `${systemPrefix}-deployment-a` &&
+        rt.environment.name === `${systemPrefix}-b` &&
+        rt.resource.identifier === `${systemPrefix}-prod`,
+    ) ?? [];
     expect(prodDeploymentAEnvironmentBMatch.length).toBe(0);
 
-    const prodDeploymentBEnvironmentAMatch =
-      releaseTargets?.filter(
-        (rt) =>
-          rt.deployment.slug === `${systemPrefix}-deployment-b` &&
-          rt.environment.name === `${systemPrefix}-a` &&
-          rt.resource.identifier === `${systemPrefix}-prod`,
-      ) ?? [];
+    const prodDeploymentBEnvironmentAMatch = releaseTargets?.filter(
+      (rt) =>
+        rt.deployment.slug === `${systemPrefix}-deployment-b` &&
+        rt.environment.name === `${systemPrefix}-a` &&
+        rt.resource.identifier === `${systemPrefix}-prod`,
+    ) ?? [];
     expect(prodDeploymentBEnvironmentAMatch.length).toBe(0);
 
-    const prodDeploymentBEnvironmentBMatch =
-      releaseTargets?.filter(
-        (rt) =>
-          rt.deployment.slug === `${systemPrefix}-deployment-b` &&
-          rt.environment.name === `${systemPrefix}-b` &&
-          rt.resource.identifier === `${systemPrefix}-prod`,
-      ) ?? [];
+    const prodDeploymentBEnvironmentBMatch = releaseTargets?.filter(
+      (rt) =>
+        rt.deployment.slug === `${systemPrefix}-deployment-b` &&
+        rt.environment.name === `${systemPrefix}-b` &&
+        rt.resource.identifier === `${systemPrefix}-prod`,
+    ) ?? [];
     expect(prodDeploymentBEnvironmentBMatch.length).toBe(0);
 
-    const qaDeploymentAEnvironmentAMatch =
-      releaseTargets?.filter(
-        (rt) =>
-          rt.deployment.slug === `${systemPrefix}-deployment-a` &&
-          rt.environment.name === `${systemPrefix}-a` &&
-          rt.resource.identifier === `${systemPrefix}-qa`,
-      ) ?? [];
+    const qaDeploymentAEnvironmentAMatch = releaseTargets?.filter(
+      (rt) =>
+        rt.deployment.slug === `${systemPrefix}-deployment-a` &&
+        rt.environment.name === `${systemPrefix}-a` &&
+        rt.resource.identifier === `${systemPrefix}-qa`,
+    ) ?? [];
     expect(qaDeploymentAEnvironmentAMatch.length).toBe(0);
 
-    const qaDeploymentAEnvironmentBMatch =
-      releaseTargets?.filter(
-        (rt) =>
-          rt.deployment.slug === `${systemPrefix}-deployment-a` &&
-          rt.environment.name === `${systemPrefix}-b` &&
-          rt.resource.identifier === `${systemPrefix}-qa`,
-      ) ?? [];
+    const qaDeploymentAEnvironmentBMatch = releaseTargets?.filter(
+      (rt) =>
+        rt.deployment.slug === `${systemPrefix}-deployment-a` &&
+        rt.environment.name === `${systemPrefix}-b` &&
+        rt.resource.identifier === `${systemPrefix}-qa`,
+    ) ?? [];
     expect(qaDeploymentAEnvironmentBMatch.length).toBe(0);
 
-    const qaDeploymentBEnvironmentAMatch =
-      releaseTargets?.filter(
-        (rt) =>
-          rt.deployment.slug === `${systemPrefix}-deployment-b` &&
-          rt.environment.name === `${systemPrefix}-a` &&
-          rt.resource.identifier === `${systemPrefix}-qa`,
-      ) ?? [];
+    const qaDeploymentBEnvironmentAMatch = releaseTargets?.filter(
+      (rt) =>
+        rt.deployment.slug === `${systemPrefix}-deployment-b` &&
+        rt.environment.name === `${systemPrefix}-a` &&
+        rt.resource.identifier === `${systemPrefix}-qa`,
+    ) ?? [];
     expect(qaDeploymentBEnvironmentAMatch.length).toBe(0);
 
-    const qaDeploymentBEnvironmentBMatch =
-      releaseTargets?.filter(
-        (rt) =>
-          rt.deployment.slug === `${systemPrefix}-deployment-b` &&
-          rt.environment.name === `${systemPrefix}-b` &&
-          rt.resource.identifier === `${systemPrefix}-qa`,
-      ) ?? [];
+    const qaDeploymentBEnvironmentBMatch = releaseTargets?.filter(
+      (rt) =>
+        rt.deployment.slug === `${systemPrefix}-deployment-b` &&
+        rt.environment.name === `${systemPrefix}-b` &&
+        rt.resource.identifier === `${systemPrefix}-qa`,
+    ) ?? [];
     expect(qaDeploymentBEnvironmentBMatch.length).toBe(1);
   });
 });

--- a/e2e/tests/api/release-targets.spec.ts
+++ b/e2e/tests/api/release-targets.spec.ts
@@ -1,38 +1,29 @@
 import path from "path";
-import { faker } from "@faker-js/faker";
 import { expect } from "@playwright/test";
 
-import {
-  cleanupImportedEntities,
-  ImportedEntities,
-  importEntitiesFromYaml,
-} from "../../api";
+import { cleanupImportedEntities, EntitiesBuilder } from "../../api";
 import { test } from "../fixtures";
 
 const yamlPath = path.join(__dirname, "release-targets.spec.yaml");
 
 test.describe("Release Targets API", () => {
-  let importedEntities: ImportedEntities;
+  let builder: EntitiesBuilder;
 
   test.beforeAll(async ({ api, workspace }) => {
-    importedEntities = await importEntitiesFromYaml(
-      api,
-      workspace.id,
-      yamlPath,
-    );
+    builder = new EntitiesBuilder(api, workspace, yamlPath);
+    await builder.createSystem();
+    await builder.createResources();
+    await builder.createEnvironments();
+    await builder.createDeployments();
   });
 
   test.afterAll(async ({ api, workspace }) => {
-    await cleanupImportedEntities(api, importedEntities, workspace.id);
+    await cleanupImportedEntities(api, builder.result, workspace.id);
   });
 
-  test("should fetch release targets for a resource", async ({
-    api,
-    page,
-    workspace,
-  }) => {
+  test("should fetch release targets for a resource", async ({ api, page, workspace }) => {
     await page.waitForTimeout(5_000);
-    const importedResource = importedEntities.resources.at(0);
+    const importedResource = builder.result.resources.at(0);
     expect(importedResource).toBeDefined();
     if (!importedResource) throw new Error("No resource found");
 
@@ -68,13 +59,13 @@ test.describe("Release Targets API", () => {
     if (!releaseTarget) throw new Error("No release target found");
 
     expect(releaseTarget.resource.id).toBe(resourceId);
-    const environmentMatch = importedEntities.environments.find(
+    const environmentMatch = builder.result.environments.find(
       (e) => e.id === releaseTarget.environment.id,
     );
     expect(environmentMatch).toBeDefined();
     if (!environmentMatch) throw new Error("No environment match found");
 
-    const deploymentMatch = importedEntities.deployments.find(
+    const deploymentMatch = builder.result.deployments.find(
       (d) => d.id === releaseTarget.deployment.id,
     );
     expect(deploymentMatch).toBeDefined();

--- a/e2e/tests/api/release-targets.spec.ts
+++ b/e2e/tests/api/release-targets.spec.ts
@@ -21,7 +21,11 @@ test.describe("Release Targets API", () => {
     await cleanupImportedEntities(api, builder.result, workspace.id);
   });
 
-  test("should fetch release targets for a resource", async ({ api, page, workspace }) => {
+  test("should fetch release targets for a resource", async ({
+    api,
+    page,
+    workspace,
+  }) => {
     await page.waitForTimeout(5_000);
     const importedResource = builder.result.resources.at(0);
     expect(importedResource).toBeDefined();

--- a/e2e/tests/api/release-targets.spec.ts
+++ b/e2e/tests/api/release-targets.spec.ts
@@ -21,7 +21,11 @@ test.describe("Release Targets API", () => {
     await cleanupImportedEntities(api, builder.cache, workspace.id);
   });
 
-  test("should fetch release targets for a resource", async ({api,page,workspace,}) => {
+  test("should fetch release targets for a resource", async ({
+    api,
+    page,
+    workspace,
+  }) => {
     await page.waitForTimeout(5_000);
     const importedResource = builder.cache.resources.at(0);
     expect(importedResource).toBeDefined();

--- a/e2e/tests/api/release-targets.spec.ts
+++ b/e2e/tests/api/release-targets.spec.ts
@@ -18,16 +18,12 @@ test.describe("Release Targets API", () => {
   });
 
   test.afterAll(async ({ api, workspace }) => {
-    await cleanupImportedEntities(api, builder.result, workspace.id);
+    await cleanupImportedEntities(api, builder.cache, workspace.id);
   });
 
-  test("should fetch release targets for a resource", async ({
-    api,
-    page,
-    workspace,
-  }) => {
+  test("should fetch release targets for a resource", async ({api,page,workspace,}) => {
     await page.waitForTimeout(5_000);
-    const importedResource = builder.result.resources.at(0);
+    const importedResource = builder.cache.resources.at(0);
     expect(importedResource).toBeDefined();
     if (!importedResource) throw new Error("No resource found");
 
@@ -63,13 +59,13 @@ test.describe("Release Targets API", () => {
     if (!releaseTarget) throw new Error("No release target found");
 
     expect(releaseTarget.resource.id).toBe(resourceId);
-    const environmentMatch = builder.result.environments.find(
+    const environmentMatch = builder.cache.environments.find(
       (e) => e.id === releaseTarget.environment.id,
     );
     expect(environmentMatch).toBeDefined();
     if (!environmentMatch) throw new Error("No environment match found");
 
-    const deploymentMatch = builder.result.deployments.find(
+    const deploymentMatch = builder.cache.deployments.find(
       (d) => d.id === releaseTarget.deployment.id,
     );
     expect(deploymentMatch).toBeDefined();

--- a/e2e/tests/api/release.spec.ts
+++ b/e2e/tests/api/release.spec.ts
@@ -22,7 +22,11 @@ test.describe("Release Creation", () => {
     await cleanupImportedEntities(api, builder.cache, workspace.id);
   });
 
-  test("should create a release when a new version is created", async ({api,page,workspace,}) => {
+  test("should create a release when a new version is created", async ({
+    api,
+    page,
+    workspace,
+  }) => {
     const systemPrefix = builder.cache.system.slug.split("-")[0]!;
     const deploymentName = `${systemPrefix}-${faker.string.alphanumeric(10)}`;
     const deploymentCreateResponse = await api.POST("/v1/deployments", {
@@ -100,7 +104,11 @@ test.describe("Release Creation", () => {
     expect(release.version.tag).toBe(versionTag);
   });
 
-  test("should create a release when a new deployment variable is added", async ({api,page,workspace,}) => {
+  test("should create a release when a new deployment variable is added", async ({
+    api,
+    page,
+    workspace,
+  }) => {
     const systemPrefix = builder.cache.system.slug.split("-")[0]!;
     const deploymentName = `${systemPrefix}-${faker.string.alphanumeric(10)}`;
     const deploymentCreateResponse = await api.POST("/v1/deployments", {
@@ -208,7 +216,11 @@ test.describe("Release Creation", () => {
     expect(variable.value).toBe("test-a");
   });
 
-  test("should create a release with a null variable value", async ({api,page,workspace,}) => {
+  test("should create a release with a null variable value", async ({
+    api,
+    page,
+    workspace,
+  }) => {
     const systemPrefix = builder.cache.system.slug.split("-")[0]!;
     const deploymentName = `${systemPrefix}-${faker.string.alphanumeric(10)}`;
     const deploymentCreateResponse = await api.POST("/v1/deployments", {
@@ -308,7 +320,11 @@ test.describe("Release Creation", () => {
     expect(variable.value).toBe("null");
   });
 
-  test("should create a release when a new resource is created", async ({api,page,workspace,}) => {
+  test("should create a release when a new resource is created", async ({
+    api,
+    page,
+    workspace,
+  }) => {
     const systemPrefix = builder.cache.system.slug.split("-")[0]!;
     const deploymentName = `${systemPrefix}-${faker.string.alphanumeric(10)}`;
     const deploymentCreateResponse = await api.POST("/v1/deployments", {
@@ -417,7 +433,11 @@ test.describe("Release Creation", () => {
     expect(variable.value).toBe("test-a");
   });
 
-  test("should create a release when a new resource is created that does not match any policy target", async ({api,page,workspace,}) => {
+  test("should create a release when a new resource is created that does not match any policy target", async ({
+    api,
+    page,
+    workspace,
+  }) => {
     const policyName = faker.string.alphanumeric(10);
     const policyResponse = await api.POST("/v1/policies", {
       body: {
@@ -545,7 +565,11 @@ test.describe("Release Creation", () => {
     expect(variable.value).toBe("test-a");
   });
 
-  test("should not create a release when an existing resource is updated", async ({api,page,workspace,}) => {
+  test("should not create a release when an existing resource is updated", async ({
+    api,
+    page,
+    workspace,
+  }) => {
     const systemPrefix = builder.cache.system.slug.split("-")[0]!;
     const deploymentName = `${systemPrefix}-${faker.string.alphanumeric(10)}`;
     const deploymentCreateResponse = await api.POST("/v1/deployments", {
@@ -665,7 +689,11 @@ test.describe("Release Creation", () => {
     expect(variable.value).toBe("test-a");
   });
 
-  test("should create a release when a resource variable is added and matches a deployment variable", async ({api,page,workspace,}) => {
+  test("should create a release when a resource variable is added and matches a deployment variable", async ({
+    api,
+    page,
+    workspace,
+  }) => {
     const systemPrefix = builder.cache.system.slug.split("-")[0]!;
     const deploymentName = `${systemPrefix}-${faker.string.alphanumeric(10)}`;
     const deploymentCreateResponse = await api.POST("/v1/deployments", {
@@ -785,7 +813,11 @@ test.describe("Release Creation", () => {
     expect(variable.value).toBe("test-c");
   });
 
-  test("should not create a release when a resource variable is added and does not match a deployment variable", async ({api,page,workspace,}) => {
+  test("should not create a release when a resource variable is added and does not match a deployment variable", async ({
+    api,
+    page,
+    workspace,
+  }) => {
     const systemPrefix = builder.cache.system.slug.split("-")[0]!;
     const deploymentName = `${systemPrefix}-${faker.string.alphanumeric(10)}`;
     const deploymentCreateResponse = await api.POST("/v1/deployments", {

--- a/e2e/tests/api/release.spec.ts
+++ b/e2e/tests/api/release.spec.ts
@@ -22,7 +22,11 @@ test.describe("Release Creation", () => {
     await cleanupImportedEntities(api, builder.result, workspace.id);
   });
 
-  test("should create a release when a new version is created", async ({ api, page, workspace }) => {
+  test("should create a release when a new version is created", async ({
+    api,
+    page,
+    workspace,
+  }) => {
     const systemPrefix = builder.result.system.slug.split("-")[0]!;
     const deploymentName = `${systemPrefix}-${faker.string.alphanumeric(10)}`;
     const deploymentCreateResponse = await api.POST("/v1/deployments", {
@@ -100,7 +104,11 @@ test.describe("Release Creation", () => {
     expect(release.version.tag).toBe(versionTag);
   });
 
-  test("should create a release when a new deployment variable is added", async ({ api, page, workspace }) => {
+  test("should create a release when a new deployment variable is added", async ({
+    api,
+    page,
+    workspace,
+  }) => {
     const systemPrefix = builder.result.system.slug.split("-")[0]!;
     const deploymentName = `${systemPrefix}-${faker.string.alphanumeric(10)}`;
     const deploymentCreateResponse = await api.POST("/v1/deployments", {
@@ -208,7 +216,11 @@ test.describe("Release Creation", () => {
     expect(variable.value).toBe("test-a");
   });
 
-  test("should create a release with a null variable value", async ({ api, page, workspace }) => {
+  test("should create a release with a null variable value", async ({
+    api,
+    page,
+    workspace,
+  }) => {
     const systemPrefix = builder.result.system.slug.split("-")[0]!;
     const deploymentName = `${systemPrefix}-${faker.string.alphanumeric(10)}`;
     const deploymentCreateResponse = await api.POST("/v1/deployments", {
@@ -308,7 +320,11 @@ test.describe("Release Creation", () => {
     expect(variable.value).toBe("null");
   });
 
-  test("should create a release when a new resource is created", async ({ api, page, workspace }) => {
+  test("should create a release when a new resource is created", async ({
+    api,
+    page,
+    workspace,
+  }) => {
     const systemPrefix = builder.result.system.slug.split("-")[0]!;
     const deploymentName = `${systemPrefix}-${faker.string.alphanumeric(10)}`;
     const deploymentCreateResponse = await api.POST("/v1/deployments", {
@@ -417,7 +433,11 @@ test.describe("Release Creation", () => {
     expect(variable.value).toBe("test-a");
   });
 
-  test("should create a release when a new resource is created that does not match any policy target", async ({ api, page, workspace }) => {
+  test("should create a release when a new resource is created that does not match any policy target", async ({
+    api,
+    page,
+    workspace,
+  }) => {
     const policyName = faker.string.alphanumeric(10);
     const policyResponse = await api.POST("/v1/policies", {
       body: {
@@ -545,7 +565,11 @@ test.describe("Release Creation", () => {
     expect(variable.value).toBe("test-a");
   });
 
-  test("should not create a release when an existing resource is updated", async ({ api, page, workspace }) => {
+  test("should not create a release when an existing resource is updated", async ({
+    api,
+    page,
+    workspace,
+  }) => {
     const systemPrefix = builder.result.system.slug.split("-")[0]!;
     const deploymentName = `${systemPrefix}-${faker.string.alphanumeric(10)}`;
     const deploymentCreateResponse = await api.POST("/v1/deployments", {
@@ -665,7 +689,11 @@ test.describe("Release Creation", () => {
     expect(variable.value).toBe("test-a");
   });
 
-  test("should create a release when a resource variable is added and matches a deployment variable", async ({ api, page, workspace }) => {
+  test("should create a release when a resource variable is added and matches a deployment variable", async ({
+    api,
+    page,
+    workspace,
+  }) => {
     const systemPrefix = builder.result.system.slug.split("-")[0]!;
     const deploymentName = `${systemPrefix}-${faker.string.alphanumeric(10)}`;
     const deploymentCreateResponse = await api.POST("/v1/deployments", {
@@ -785,7 +813,11 @@ test.describe("Release Creation", () => {
     expect(variable.value).toBe("test-c");
   });
 
-  test("should not create a release when a resource variable is added and does not match a deployment variable", async ({ api, page, workspace }) => {
+  test("should not create a release when a resource variable is added and does not match a deployment variable", async ({
+    api,
+    page,
+    workspace,
+  }) => {
     const systemPrefix = builder.result.system.slug.split("-")[0]!;
     const deploymentName = `${systemPrefix}-${faker.string.alphanumeric(10)}`;
     const deploymentCreateResponse = await api.POST("/v1/deployments", {

--- a/e2e/tests/api/release.spec.ts
+++ b/e2e/tests/api/release.spec.ts
@@ -19,21 +19,17 @@ test.describe("Release Creation", () => {
   });
 
   test.afterAll(async ({ api, workspace }) => {
-    await cleanupImportedEntities(api, builder.result, workspace.id);
+    await cleanupImportedEntities(api, builder.cache, workspace.id);
   });
 
-  test("should create a release when a new version is created", async ({
-    api,
-    page,
-    workspace,
-  }) => {
-    const systemPrefix = builder.result.system.slug.split("-")[0]!;
+  test("should create a release when a new version is created", async ({api,page,workspace,}) => {
+    const systemPrefix = builder.cache.system.slug.split("-")[0]!;
     const deploymentName = `${systemPrefix}-${faker.string.alphanumeric(10)}`;
     const deploymentCreateResponse = await api.POST("/v1/deployments", {
       body: {
         name: deploymentName,
         slug: deploymentName,
-        systemId: builder.result.system.id,
+        systemId: builder.cache.system.id,
       },
     });
     expect(deploymentCreateResponse.response.status).toBe(201);
@@ -49,7 +45,7 @@ test.describe("Release Creation", () => {
     });
     expect(versionResponse.response.status).toBe(201);
 
-    const importedResource = builder.result.resources.at(0)!;
+    const importedResource = builder.cache.resources.at(0)!;
     const resourceResponse = await api.GET(
       "/v1/workspaces/{workspaceId}/resources/identifier/{identifier}",
       {
@@ -104,18 +100,14 @@ test.describe("Release Creation", () => {
     expect(release.version.tag).toBe(versionTag);
   });
 
-  test("should create a release when a new deployment variable is added", async ({
-    api,
-    page,
-    workspace,
-  }) => {
-    const systemPrefix = builder.result.system.slug.split("-")[0]!;
+  test("should create a release when a new deployment variable is added", async ({api,page,workspace,}) => {
+    const systemPrefix = builder.cache.system.slug.split("-")[0]!;
     const deploymentName = `${systemPrefix}-${faker.string.alphanumeric(10)}`;
     const deploymentCreateResponse = await api.POST("/v1/deployments", {
       body: {
         name: deploymentName,
         slug: deploymentName,
-        systemId: builder.result.system.id,
+        systemId: builder.cache.system.id,
       },
     });
     expect(deploymentCreateResponse.response.status).toBe(201);
@@ -157,7 +149,7 @@ test.describe("Release Creation", () => {
     );
     expect(variableCreateResponse.response.status).toBe(201);
 
-    const importedResource = builder.result.resources.at(0)!;
+    const importedResource = builder.cache.resources.at(0)!;
     const resourceResponse = await api.GET(
       "/v1/workspaces/{workspaceId}/resources/identifier/{identifier}",
       {
@@ -216,18 +208,14 @@ test.describe("Release Creation", () => {
     expect(variable.value).toBe("test-a");
   });
 
-  test("should create a release with a null variable value", async ({
-    api,
-    page,
-    workspace,
-  }) => {
-    const systemPrefix = builder.result.system.slug.split("-")[0]!;
+  test("should create a release with a null variable value", async ({api,page,workspace,}) => {
+    const systemPrefix = builder.cache.system.slug.split("-")[0]!;
     const deploymentName = `${systemPrefix}-${faker.string.alphanumeric(10)}`;
     const deploymentCreateResponse = await api.POST("/v1/deployments", {
       body: {
         name: deploymentName,
         slug: deploymentName,
-        systemId: builder.result.system.id,
+        systemId: builder.cache.system.id,
       },
     });
     expect(deploymentCreateResponse.response.status).toBe(201);
@@ -261,7 +249,7 @@ test.describe("Release Creation", () => {
     );
     expect(variableCreateResponse.response.status).toBe(201);
 
-    const importedResource = builder.result.resources.at(0)!;
+    const importedResource = builder.cache.resources.at(0)!;
     const resourceResponse = await api.GET(
       "/v1/workspaces/{workspaceId}/resources/identifier/{identifier}",
       {
@@ -320,18 +308,14 @@ test.describe("Release Creation", () => {
     expect(variable.value).toBe("null");
   });
 
-  test("should create a release when a new resource is created", async ({
-    api,
-    page,
-    workspace,
-  }) => {
-    const systemPrefix = builder.result.system.slug.split("-")[0]!;
+  test("should create a release when a new resource is created", async ({api,page,workspace,}) => {
+    const systemPrefix = builder.cache.system.slug.split("-")[0]!;
     const deploymentName = `${systemPrefix}-${faker.string.alphanumeric(10)}`;
     const deploymentCreateResponse = await api.POST("/v1/deployments", {
       body: {
         name: deploymentName,
         slug: deploymentName,
-        systemId: builder.result.system.id,
+        systemId: builder.cache.system.id,
       },
     });
     expect(deploymentCreateResponse.response.status).toBe(201);
@@ -433,11 +417,7 @@ test.describe("Release Creation", () => {
     expect(variable.value).toBe("test-a");
   });
 
-  test("should create a release when a new resource is created that does not match any policy target", async ({
-    api,
-    page,
-    workspace,
-  }) => {
+  test("should create a release when a new resource is created that does not match any policy target", async ({api,page,workspace,}) => {
     const policyName = faker.string.alphanumeric(10);
     const policyResponse = await api.POST("/v1/policies", {
       body: {
@@ -457,13 +437,13 @@ test.describe("Release Creation", () => {
     });
     expect(policyResponse.response.status).toBe(200);
 
-    const systemPrefix = builder.result.system.slug.split("-")[0]!;
+    const systemPrefix = builder.cache.system.slug.split("-")[0]!;
     const deploymentName = `${systemPrefix}-${faker.string.alphanumeric(10)}`;
     const deploymentCreateResponse = await api.POST("/v1/deployments", {
       body: {
         name: deploymentName,
         slug: deploymentName,
-        systemId: builder.result.system.id,
+        systemId: builder.cache.system.id,
       },
     });
     expect(deploymentCreateResponse.response.status).toBe(201);
@@ -565,18 +545,14 @@ test.describe("Release Creation", () => {
     expect(variable.value).toBe("test-a");
   });
 
-  test("should not create a release when an existing resource is updated", async ({
-    api,
-    page,
-    workspace,
-  }) => {
-    const systemPrefix = builder.result.system.slug.split("-")[0]!;
+  test("should not create a release when an existing resource is updated", async ({api,page,workspace,}) => {
+    const systemPrefix = builder.cache.system.slug.split("-")[0]!;
     const deploymentName = `${systemPrefix}-${faker.string.alphanumeric(10)}`;
     const deploymentCreateResponse = await api.POST("/v1/deployments", {
       body: {
         name: deploymentName,
         slug: deploymentName,
-        systemId: builder.result.system.id,
+        systemId: builder.cache.system.id,
       },
     });
     expect(deploymentCreateResponse.response.status).toBe(201);
@@ -689,18 +665,14 @@ test.describe("Release Creation", () => {
     expect(variable.value).toBe("test-a");
   });
 
-  test("should create a release when a resource variable is added and matches a deployment variable", async ({
-    api,
-    page,
-    workspace,
-  }) => {
-    const systemPrefix = builder.result.system.slug.split("-")[0]!;
+  test("should create a release when a resource variable is added and matches a deployment variable", async ({api,page,workspace,}) => {
+    const systemPrefix = builder.cache.system.slug.split("-")[0]!;
     const deploymentName = `${systemPrefix}-${faker.string.alphanumeric(10)}`;
     const deploymentCreateResponse = await api.POST("/v1/deployments", {
       body: {
         name: deploymentName,
         slug: deploymentName,
-        systemId: builder.result.system.id,
+        systemId: builder.cache.system.id,
       },
     });
     expect(deploymentCreateResponse.response.status).toBe(201);
@@ -813,18 +785,14 @@ test.describe("Release Creation", () => {
     expect(variable.value).toBe("test-c");
   });
 
-  test("should not create a release when a resource variable is added and does not match a deployment variable", async ({
-    api,
-    page,
-    workspace,
-  }) => {
-    const systemPrefix = builder.result.system.slug.split("-")[0]!;
+  test("should not create a release when a resource variable is added and does not match a deployment variable", async ({api,page,workspace,}) => {
+    const systemPrefix = builder.cache.system.slug.split("-")[0]!;
     const deploymentName = `${systemPrefix}-${faker.string.alphanumeric(10)}`;
     const deploymentCreateResponse = await api.POST("/v1/deployments", {
       body: {
         name: deploymentName,
         slug: deploymentName,
-        systemId: builder.result.system.id,
+        systemId: builder.cache.system.id,
       },
     });
     expect(deploymentCreateResponse.response.status).toBe(201);

--- a/e2e/tests/api/resource-grouping.spec.ts
+++ b/e2e/tests/api/resource-grouping.spec.ts
@@ -1,19 +1,17 @@
 import path from "path";
 import { expect } from "@playwright/test";
 
-import { ImportedEntities, importEntitiesFromYaml } from "../../api";
+import { EntitiesBuilder } from "../../api";
 import { test } from "../fixtures";
 
 const yamlPath = path.join(__dirname, "resource-grouping.spec.yaml");
 
 test.describe("Resource Provider API", () => {
-  let importedEntities: ImportedEntities;
+  let builder: EntitiesBuilder;
   test.beforeAll(async ({ api, workspace }) => {
-    importedEntities = await importEntitiesFromYaml(
-      api,
-      workspace.id,
-      yamlPath,
-    );
+    builder = new EntitiesBuilder(api, workspace, yamlPath);
+    await builder.createSystem();
+    await builder.createResources();
   });
 
   test("basic resource grouping", async ({ api, workspace }) => {

--- a/e2e/tests/api/resource-grouping.spec.yaml
+++ b/e2e/tests/api/resource-grouping.spec.yaml
@@ -3,8 +3,6 @@ system:
   slug: "{{ prefix }}-selectors"
   description: System for testing resource selectors
 
-environments: []
-
 resources:
   - name: Group A Resource 1
     kind: TestResource
@@ -80,6 +78,3 @@ resources:
     metadata:
       group: c
       priority: low
-
-deployments: []
-policies: []

--- a/e2e/tests/api/resource-relationships.spec.ts
+++ b/e2e/tests/api/resource-relationships.spec.ts
@@ -4,15 +4,15 @@ import { expect } from "@playwright/test";
 
 import {
   cleanupImportedEntities,
-  ImportedEntities,
   importEntitiesFromYaml,
+  TestEntities,
 } from "../../api";
 import { test } from "../fixtures";
 
 const yamlPath = path.join(__dirname, "resource-relationships.spec.yaml");
 
 test.describe("Resource Relationships API", () => {
-  let importedEntities: ImportedEntities;
+  let importedEntities: TestEntities;
 
   test.beforeAll(async ({ api, workspace }) => {
     importedEntities = await importEntitiesFromYaml(
@@ -26,12 +26,10 @@ test.describe("Resource Relationships API", () => {
     await cleanupImportedEntities(api, importedEntities, workspace.id);
   });
 
-  test("create a relationship with metadata match", async ({
-    api,
-    workspace,
-  }) => {
-    const reference =
-      `${importedEntities.prefix}-${faker.string.alphanumeric(10)}`.toLocaleLowerCase();
+  test("create a relationship with metadata match", async ({api,workspace,}) => {
+    const reference = `${importedEntities.prefix}-${
+      faker.string.alphanumeric(10)
+    }`.toLocaleLowerCase();
     const resourceRelationship = await api.POST(
       "/v1/resource-relationship-rules",
       {
@@ -97,12 +95,10 @@ test.describe("Resource Relationships API", () => {
     expect(target?.target?.config).toBeDefined();
   });
 
-  test("create a relationship with metadata equals", async ({
-    api,
-    workspace,
-  }) => {
-    const reference =
-      `${importedEntities.prefix}-${faker.string.alphanumeric(10)}`.toLocaleLowerCase();
+  test("create a relationship with metadata equals", async ({api,workspace,}) => {
+    const reference = `${importedEntities.prefix}-${
+      faker.string.alphanumeric(10)
+    }`.toLocaleLowerCase();
     const resourceRelationship = await api.POST(
       "/v1/resource-relationship-rules",
       {
@@ -151,8 +147,9 @@ test.describe("Resource Relationships API", () => {
   });
 
   test("upsert a relationship rule", async ({ api, workspace }) => {
-    const reference =
-      `${importedEntities.prefix}-${faker.string.alphanumeric(10)}`.toLocaleLowerCase();
+    const reference = `${importedEntities.prefix}-${
+      faker.string.alphanumeric(10)
+    }`.toLocaleLowerCase();
     // First create a new relationship rule
     const initialRule = await api.POST("/v1/resource-relationship-rules", {
       body: {
@@ -210,12 +207,10 @@ test.describe("Resource Relationships API", () => {
     expect(updatedRule.data?.description).toBe("Updated description");
   });
 
-  test("should not match if some rules are not satisfied", async ({
-    api,
-    workspace,
-  }) => {
-    const reference =
-      `${importedEntities.prefix}-${faker.string.alphanumeric(10)}`.toLocaleLowerCase();
+  test("should not match if some rules are not satisfied", async ({api,workspace,}) => {
+    const reference = `${importedEntities.prefix}-${
+      faker.string.alphanumeric(10)
+    }`.toLocaleLowerCase();
 
     const sourceResourceCreate = await api.POST("/v1/resources", {
       body: {

--- a/e2e/tests/api/resource-relationships.spec.ts
+++ b/e2e/tests/api/resource-relationships.spec.ts
@@ -20,11 +20,13 @@ test.describe("Resource Relationships API", () => {
     await cleanupImportedEntities(api, builder.result, workspace.id);
   });
 
-  test("create a relationship with metadata match", async ({ api, workspace }) => {
-    const reference = `${builder.result.prefix}-${
-      faker.string.alphanumeric(10)
-    }`
-      .toLocaleLowerCase();
+  test("create a relationship with metadata match", async ({
+    api,
+    workspace,
+  }) => {
+    const reference = `${builder.result.prefix}-${faker.string.alphanumeric(
+      10,
+    )}`.toLocaleLowerCase();
     const resourceRelationship = await api.POST(
       "/v1/resource-relationship-rules",
       {
@@ -90,11 +92,13 @@ test.describe("Resource Relationships API", () => {
     expect(target?.target?.config).toBeDefined();
   });
 
-  test("create a relationship with metadata equals", async ({ api, workspace }) => {
-    const reference = `${builder.result.prefix}-${
-      faker.string.alphanumeric(10)
-    }`
-      .toLocaleLowerCase();
+  test("create a relationship with metadata equals", async ({
+    api,
+    workspace,
+  }) => {
+    const reference = `${builder.result.prefix}-${faker.string.alphanumeric(
+      10,
+    )}`.toLocaleLowerCase();
     const resourceRelationship = await api.POST(
       "/v1/resource-relationship-rules",
       {
@@ -107,9 +111,7 @@ test.describe("Resource Relationships API", () => {
           sourceVersion: `${builder.result.prefix}-test-version/v1`,
           targetKind: "Target",
           targetVersion: `${builder.result.prefix}-test-version/v1`,
-          targetMetadataEquals: [
-            { key: builder.result.prefix, value: "true" },
-          ],
+          targetMetadataEquals: [{ key: builder.result.prefix, value: "true" }],
         },
       },
     );
@@ -143,10 +145,9 @@ test.describe("Resource Relationships API", () => {
   });
 
   test("upsert a relationship rule", async ({ api, workspace }) => {
-    const reference = `${builder.result.prefix}-${
-      faker.string.alphanumeric(10)
-    }`
-      .toLocaleLowerCase();
+    const reference = `${builder.result.prefix}-${faker.string.alphanumeric(
+      10,
+    )}`.toLocaleLowerCase();
     // First create a new relationship rule
     const initialRule = await api.POST("/v1/resource-relationship-rules", {
       body: {
@@ -164,9 +165,7 @@ test.describe("Resource Relationships API", () => {
     });
 
     expect(initialRule.response.status).toBe(200);
-    expect(initialRule.data?.name).toBe(
-      builder.result.prefix + "-upsert-rule",
-    );
+    expect(initialRule.data?.name).toBe(builder.result.prefix + "-upsert-rule");
     expect(initialRule.data?.sourceKind).toBe("SourceA");
     expect(initialRule.data?.targetKind).toBe("TargetA");
 
@@ -194,9 +193,7 @@ test.describe("Resource Relationships API", () => {
 
     expect(updatedRule.response.status).toBe(200);
     expect(updatedRule.data?.id).toBe(initialRule.data?.id); // Should maintain same ID
-    expect(updatedRule.data?.name).toBe(
-      builder.result.prefix + "-upsert-rule",
-    );
+    expect(updatedRule.data?.name).toBe(builder.result.prefix + "-upsert-rule");
     expect(updatedRule.data?.sourceKind).toBe("SourceB");
     expect(updatedRule.data?.sourceVersion).toBe("test-version/v2");
     expect(updatedRule.data?.targetKind).toBe("TargetB");
@@ -204,11 +201,13 @@ test.describe("Resource Relationships API", () => {
     expect(updatedRule.data?.description).toBe("Updated description");
   });
 
-  test("should not match if some rules are not satisfied", async ({ api, workspace }) => {
-    const reference = `${builder.result.prefix}-${
-      faker.string.alphanumeric(10)
-    }`
-      .toLocaleLowerCase();
+  test("should not match if some rules are not satisfied", async ({
+    api,
+    workspace,
+  }) => {
+    const reference = `${builder.result.prefix}-${faker.string.alphanumeric(
+      10,
+    )}`.toLocaleLowerCase();
 
     const sourceResourceCreate = await api.POST("/v1/resources", {
       body: {

--- a/e2e/tests/api/resource-relationships.spec.ts
+++ b/e2e/tests/api/resource-relationships.spec.ts
@@ -23,12 +23,13 @@ test.describe("Resource Relationships API", () => {
     await cleanupImportedEntities(api, builder.cache, workspace.id);
   });
 
-  test("create a relationship with metadata match", async ({ api, workspace }) => {
-    const reference = `${prefix}-${
-      faker.string.alphanumeric(
-        10,
-      )
-    }`.toLocaleLowerCase();
+  test("create a relationship with metadata match", async ({
+    api,
+    workspace,
+  }) => {
+    const reference = `${prefix}-${faker.string.alphanumeric(
+      10,
+    )}`.toLocaleLowerCase();
     const resourceRelationship = await api.POST(
       "/v1/resource-relationship-rules",
       {
@@ -94,12 +95,13 @@ test.describe("Resource Relationships API", () => {
     expect(target?.target?.config).toBeDefined();
   });
 
-  test("create a relationship with metadata equals", async ({ api, workspace }) => {
-    const reference = `${prefix}-${
-      faker.string.alphanumeric(
-        10,
-      )
-    }`.toLocaleLowerCase();
+  test("create a relationship with metadata equals", async ({
+    api,
+    workspace,
+  }) => {
+    const reference = `${prefix}-${faker.string.alphanumeric(
+      10,
+    )}`.toLocaleLowerCase();
     const resourceRelationship = await api.POST(
       "/v1/resource-relationship-rules",
       {
@@ -146,11 +148,9 @@ test.describe("Resource Relationships API", () => {
   });
 
   test("upsert a relationship rule", async ({ api, workspace }) => {
-    const reference = `${prefix}-${
-      faker.string.alphanumeric(
-        10,
-      )
-    }`.toLocaleLowerCase();
+    const reference = `${prefix}-${faker.string.alphanumeric(
+      10,
+    )}`.toLocaleLowerCase();
     // First create a new relationship rule
     const initialRule = await api.POST("/v1/resource-relationship-rules", {
       body: {
@@ -204,12 +204,13 @@ test.describe("Resource Relationships API", () => {
     expect(updatedRule.data?.description).toBe("Updated description");
   });
 
-  test("should not match if some rules are not satisfied", async ({ api, workspace }) => {
-    const reference = `${prefix}-${
-      faker.string.alphanumeric(
-        10,
-      )
-    }`.toLocaleLowerCase();
+  test("should not match if some rules are not satisfied", async ({
+    api,
+    workspace,
+  }) => {
+    const reference = `${prefix}-${faker.string.alphanumeric(
+      10,
+    )}`.toLocaleLowerCase();
 
     const sourceResourceCreate = await api.POST("/v1/resources", {
       body: {

--- a/e2e/tests/api/resource-relationships.spec.yaml
+++ b/e2e/tests/api/resource-relationships.spec.yaml
@@ -9,6 +9,8 @@ resources:
     identifier: "{{ prefix }}-source-resource"
     name: "{{ prefix }}-source-resource"
     slug: "{{ prefix }}-source-resource"
+    config:
+      enabled: true
     metadata:
       "{{ prefix }}": "true"
       e2e/test: "true"
@@ -17,6 +19,8 @@ resources:
     identifier: "{{ prefix }}-secondary-source-resource"
     name: "{{ prefix }}-secondary-source-resource"
     slug: "{{ prefix }}-secondary-source-resource"
+    config:
+      enabled: true
     metadata:
       "{{ prefix }}": "true"
       e2e/test: "true"
@@ -25,6 +29,8 @@ resources:
     identifier: "{{ prefix }}-target-resource"
     name: "{{ prefix }}-target-resource"
     slug: "{{ prefix }}-target-resource"
+    config:
+      enabled: true
     metadata:
       "{{ prefix }}": "true"
       e2e/test: "true"

--- a/e2e/tests/api/resource-variables.spec.ts
+++ b/e2e/tests/api/resource-variables.spec.ts
@@ -134,7 +134,10 @@ test.describe("Resource Variables API", () => {
     });
   });
 
-  test("use resource variables in deployments and environments", async ({api,workspace,}) => {
+  test("use resource variables in deployments and environments", async ({
+    api,
+    workspace,
+  }) => {
     const systemPrefix = builder.cache.system.slug.split("-")[0]!;
     const resourceName = `${systemPrefix}-${faker.string.alphanumeric(10)}`;
 
@@ -164,10 +167,11 @@ test.describe("Resource Variables API", () => {
     });
   });
 
-  test("reference variables from related resources", async ({api,workspace,}) => {
-    const systemPrefix = builder.cache.system.slug
-      .split("-")[0]!
-      .toLowerCase();
+  test("reference variables from related resources", async ({
+    api,
+    workspace,
+  }) => {
+    const systemPrefix = builder.cache.system.slug.split("-")[0]!.toLowerCase();
     const reference = faker.string.alphanumeric(10).toLowerCase();
 
     // Create target resource
@@ -257,10 +261,12 @@ test.describe("Resource Variables API", () => {
     });
   });
 
-  test("reference variables from related resources when the deployment variable value is reference type", async ({api,workspace,page,}) => {
-    const systemPrefix = builder.cache.system.slug
-      .split("-")[0]!
-      .toLowerCase();
+  test("reference variables from related resources when the deployment variable value is reference type", async ({
+    api,
+    workspace,
+    page,
+  }) => {
+    const systemPrefix = builder.cache.system.slug.split("-")[0]!.toLowerCase();
     const reference = faker.string.alphanumeric(10).toLowerCase();
     // Create target resource
     const targetResource = await api.POST("/v1/resources", {
@@ -408,10 +414,12 @@ test.describe("Resource Variables API", () => {
     });
   });
 
-  test("should trigger a release target evaluation if a referenced resource is updated", async ({api,workspace,page,}) => {
-    const systemPrefix = builder.cache.system.slug
-      .split("-")[0]!
-      .toLowerCase();
+  test("should trigger a release target evaluation if a referenced resource is updated", async ({
+    api,
+    workspace,
+    page,
+  }) => {
+    const systemPrefix = builder.cache.system.slug.split("-")[0]!.toLowerCase();
     const reference = faker.string.alphanumeric(10).toLowerCase();
 
     // Create target resource
@@ -582,10 +590,12 @@ test.describe("Resource Variables API", () => {
     });
   });
 
-  test("should trigger a release target evaluation if a related resource is deleted and its variables are referenced", async ({api,workspace,page,}) => {
-    const systemPrefix = builder.cache.system.slug
-      .split("-")[0]!
-      .toLowerCase();
+  test("should trigger a release target evaluation if a related resource is deleted and its variables are referenced", async ({
+    api,
+    workspace,
+    page,
+  }) => {
+    const systemPrefix = builder.cache.system.slug.split("-")[0]!.toLowerCase();
     const reference = faker.string.alphanumeric(10).toLowerCase();
 
     // Create target resource

--- a/e2e/tests/api/resource-variables.spec.ts
+++ b/e2e/tests/api/resource-variables.spec.ts
@@ -134,7 +134,10 @@ test.describe("Resource Variables API", () => {
     });
   });
 
-  test("use resource variables in deployments and environments", async ({ api, workspace }) => {
+  test("use resource variables in deployments and environments", async ({
+    api,
+    workspace,
+  }) => {
     const systemPrefix = builder.result.system.slug.split("-")[0]!;
     const resourceName = `${systemPrefix}-${faker.string.alphanumeric(10)}`;
 
@@ -164,7 +167,10 @@ test.describe("Resource Variables API", () => {
     });
   });
 
-  test("reference variables from related resources", async ({ api, workspace }) => {
+  test("reference variables from related resources", async ({
+    api,
+    workspace,
+  }) => {
     const systemPrefix = builder.result.system.slug
       .split("-")[0]!
       .toLowerCase();
@@ -257,7 +263,11 @@ test.describe("Resource Variables API", () => {
     });
   });
 
-  test("reference variables from related resources when the deployment variable value is reference type", async ({ api, workspace, page }) => {
+  test("reference variables from related resources when the deployment variable value is reference type", async ({
+    api,
+    workspace,
+    page,
+  }) => {
     const systemPrefix = builder.result.system.slug
       .split("-")[0]!
       .toLowerCase();
@@ -408,7 +418,11 @@ test.describe("Resource Variables API", () => {
     });
   });
 
-  test("should trigger a release target evaluation if a referenced resource is updated", async ({ api, workspace, page }) => {
+  test("should trigger a release target evaluation if a referenced resource is updated", async ({
+    api,
+    workspace,
+    page,
+  }) => {
     const systemPrefix = builder.result.system.slug
       .split("-")[0]!
       .toLowerCase();
@@ -582,7 +596,11 @@ test.describe("Resource Variables API", () => {
     });
   });
 
-  test("should trigger a release target evaluation if a related resource is deleted and its variables are referenced", async ({ api, workspace, page }) => {
+  test("should trigger a release target evaluation if a related resource is deleted and its variables are referenced", async ({
+    api,
+    workspace,
+    page,
+  }) => {
     const systemPrefix = builder.result.system.slug
       .split("-")[0]!
       .toLowerCase();

--- a/e2e/tests/api/resource-variables.spec.ts
+++ b/e2e/tests/api/resource-variables.spec.ts
@@ -18,11 +18,11 @@ test.describe("Resource Variables API", () => {
   });
 
   test.afterAll(async ({ api, workspace }) => {
-    await cleanupImportedEntities(api, builder.result, workspace.id);
+    await cleanupImportedEntities(api, builder.cache, workspace.id);
   });
 
   test("create a resource with variables", async ({ api, workspace }) => {
-    const systemPrefix = builder.result.system.slug.split("-")[0]!;
+    const systemPrefix = builder.cache.system.slug.split("-")[0]!;
     const resourceName = `${systemPrefix}-${faker.string.alphanumeric(10)}`;
 
     // Create a resource with variables
@@ -77,7 +77,7 @@ test.describe("Resource Variables API", () => {
   });
 
   test("update resource variables", async ({ api, workspace }) => {
-    const systemPrefix = builder.result.system.slug.split("-")[0]!;
+    const systemPrefix = builder.cache.system.slug.split("-")[0]!;
     const resourceName = `${systemPrefix}-${faker.string.alphanumeric(10)}`;
 
     // Create a resource with initial variables
@@ -134,11 +134,8 @@ test.describe("Resource Variables API", () => {
     });
   });
 
-  test("use resource variables in deployments and environments", async ({
-    api,
-    workspace,
-  }) => {
-    const systemPrefix = builder.result.system.slug.split("-")[0]!;
+  test("use resource variables in deployments and environments", async ({api,workspace,}) => {
+    const systemPrefix = builder.cache.system.slug.split("-")[0]!;
     const resourceName = `${systemPrefix}-${faker.string.alphanumeric(10)}`;
 
     // Create a resource with variables
@@ -167,11 +164,8 @@ test.describe("Resource Variables API", () => {
     });
   });
 
-  test("reference variables from related resources", async ({
-    api,
-    workspace,
-  }) => {
-    const systemPrefix = builder.result.system.slug
+  test("reference variables from related resources", async ({api,workspace,}) => {
+    const systemPrefix = builder.cache.system.slug
       .split("-")[0]!
       .toLowerCase();
     const reference = faker.string.alphanumeric(10).toLowerCase();
@@ -263,12 +257,8 @@ test.describe("Resource Variables API", () => {
     });
   });
 
-  test("reference variables from related resources when the deployment variable value is reference type", async ({
-    api,
-    workspace,
-    page,
-  }) => {
-    const systemPrefix = builder.result.system.slug
+  test("reference variables from related resources when the deployment variable value is reference type", async ({api,workspace,page,}) => {
+    const systemPrefix = builder.cache.system.slug
       .split("-")[0]!
       .toLowerCase();
     const reference = faker.string.alphanumeric(10).toLowerCase();
@@ -327,7 +317,7 @@ test.describe("Resource Variables API", () => {
     expect(relationship.response.status).toBe(200);
 
     // Create a deployment variable with reference type
-    const deployment = builder.result.deployments[0]!;
+    const deployment = builder.cache.deployments[0]!;
 
     await api.POST("/v1/deployments/{deploymentId}/variables", {
       params: {
@@ -418,12 +408,8 @@ test.describe("Resource Variables API", () => {
     });
   });
 
-  test("should trigger a release target evaluation if a referenced resource is updated", async ({
-    api,
-    workspace,
-    page,
-  }) => {
-    const systemPrefix = builder.result.system.slug
+  test("should trigger a release target evaluation if a referenced resource is updated", async ({api,workspace,page,}) => {
+    const systemPrefix = builder.cache.system.slug
       .split("-")[0]!
       .toLowerCase();
     const reference = faker.string.alphanumeric(10).toLowerCase();
@@ -485,7 +471,7 @@ test.describe("Resource Variables API", () => {
     expect(relationship.response.status).toBe(200);
 
     // Create a deployment variable with reference type
-    const deployment = builder.result.deployments[0]!;
+    const deployment = builder.cache.deployments[0]!;
 
     const key = faker.string.alphanumeric(10);
 
@@ -596,12 +582,8 @@ test.describe("Resource Variables API", () => {
     });
   });
 
-  test("should trigger a release target evaluation if a related resource is deleted and its variables are referenced", async ({
-    api,
-    workspace,
-    page,
-  }) => {
-    const systemPrefix = builder.result.system.slug
+  test("should trigger a release target evaluation if a related resource is deleted and its variables are referenced", async ({api,workspace,page,}) => {
+    const systemPrefix = builder.cache.system.slug
       .split("-")[0]!
       .toLowerCase();
     const reference = faker.string.alphanumeric(10).toLowerCase();
@@ -662,7 +644,7 @@ test.describe("Resource Variables API", () => {
     expect(relationship.response.status).toBe(200);
 
     // Create a deployment variable with reference type
-    const deployment = builder.result.deployments[0]!;
+    const deployment = builder.cache.deployments[0]!;
 
     const key = faker.string.alphanumeric(10);
 

--- a/e2e/tests/api/resources.spec.ts
+++ b/e2e/tests/api/resources.spec.ts
@@ -4,15 +4,15 @@ import { expect } from "@playwright/test";
 
 import {
   cleanupImportedEntities,
-  ImportedEntities,
   importEntitiesFromYaml,
+  TestEntities,
 } from "../../api";
 import { test } from "../fixtures";
 
 const yamlPath = path.join(__dirname, "resources.spec.yaml");
 
 test.describe("Resource API", () => {
-  let importedEntities: ImportedEntities;
+  let importedEntities: TestEntities;
 
   test.beforeAll(async ({ api, workspace }) => {
     importedEntities = await importEntitiesFromYaml(
@@ -235,10 +235,7 @@ test.describe("Resource API", () => {
     expect(releaseTarget).toBeDefined();
   });
 
-  test("updating non metadata fields should not change resource's current metadata", async ({
-    api,
-    workspace,
-  }) => {
+  test("updating non metadata fields should not change resource's current metadata", async ({api,workspace,}) => {
     // First create a resource
     const systemPrefix = importedEntities.system.slug.split("-")[0]!;
     const resourceName = `${systemPrefix}-${faker.string.alphanumeric(10)}`;
@@ -289,7 +286,9 @@ test.describe("Resource API", () => {
     // First create a resource
     const systemPrefix = importedEntities.system.slug.split("-")[0]!;
     const resourceName = `${systemPrefix}-${faker.string.alphanumeric(10)}`;
-    const resourceIdentifer = `${resourceName}/${faker.string.alphanumeric(10)}`;
+    const resourceIdentifer = `${resourceName}/${
+      faker.string.alphanumeric(10)
+    }`;
     const resourceResponse = await api.POST("/v1/resources", {
       body: {
         workspaceId: workspace.id,

--- a/e2e/tests/api/resources.spec.ts
+++ b/e2e/tests/api/resources.spec.ts
@@ -230,7 +230,10 @@ test.describe("Resource API", () => {
     expect(releaseTarget).toBeDefined();
   });
 
-  test("updating non metadata fields should not change resource's current metadata", async ({ api, workspace }) => {
+  test("updating non metadata fields should not change resource's current metadata", async ({
+    api,
+    workspace,
+  }) => {
     // First create a resource
     const systemPrefix = builder.result.system.slug.split("-")[0]!;
     const resourceName = `${systemPrefix}-${faker.string.alphanumeric(10)}`;
@@ -281,9 +284,9 @@ test.describe("Resource API", () => {
     // First create a resource
     const systemPrefix = builder.result.system.slug.split("-")[0]!;
     const resourceName = `${systemPrefix}-${faker.string.alphanumeric(10)}`;
-    const resourceIdentifer = `${resourceName}/${
-      faker.string.alphanumeric(10)
-    }`;
+    const resourceIdentifer = `${resourceName}/${faker.string.alphanumeric(
+      10,
+    )}`;
     const resourceResponse = await api.POST("/v1/resources", {
       body: {
         workspaceId: workspace.id,

--- a/e2e/tests/api/resources.spec.ts
+++ b/e2e/tests/api/resources.spec.ts
@@ -18,11 +18,11 @@ test.describe("Resource API", () => {
   });
 
   test.afterAll(async ({ api, workspace }) => {
-    await cleanupImportedEntities(api, builder.result, workspace.id);
+    await cleanupImportedEntities(api, builder.cache, workspace.id);
   });
 
   test("create a resource", async ({ api, workspace }) => {
-    const systemPrefix = builder.result.system.slug.split("-")[0]!;
+    const systemPrefix = builder.cache.system.slug.split("-")[0]!;
     const resourceName1 = `${systemPrefix}-${faker.string.alphanumeric(10)}`;
     const resource = await api.POST("/v1/resources", {
       body: {
@@ -49,8 +49,8 @@ test.describe("Resource API", () => {
 
     await new Promise((resolve) => setTimeout(resolve, 5_000));
 
-    const environment = builder.result.environments[0]!;
-    const deployment = builder.result.deployments[0]!;
+    const environment = builder.cache.environments[0]!;
+    const deployment = builder.cache.deployments[0]!;
 
     const environmentResourcesResponse = await api.GET(
       "/v1/environments/{environmentId}/resources",
@@ -100,7 +100,7 @@ test.describe("Resource API", () => {
   });
 
   test("get a resource by identifier", async ({ api, workspace }) => {
-    const systemPrefix = builder.result.system.slug.split("-")[0]!;
+    const systemPrefix = builder.cache.system.slug.split("-")[0]!;
     const resourceName = `${systemPrefix}-${faker.string.alphanumeric(10)}`;
     await api.POST("/v1/resources", {
       body: {
@@ -134,7 +134,7 @@ test.describe("Resource API", () => {
   });
 
   test("list resources", async ({ api, workspace }) => {
-    const systemPrefix = builder.result.system.slug.split("-")[0]!;
+    const systemPrefix = builder.cache.system.slug.split("-")[0]!;
     const resourceName = `${systemPrefix}-${faker.string.alphanumeric(10)}`;
     await api.POST("/v1/resources", {
       body: {
@@ -163,7 +163,7 @@ test.describe("Resource API", () => {
 
   test("update a resource", async ({ api, workspace }) => {
     // First create a resource
-    const systemPrefix = builder.result.system.slug.split("-")[0]!;
+    const systemPrefix = builder.cache.system.slug.split("-")[0]!;
     const resourceName = `${systemPrefix}-${faker.string.alphanumeric(10)}`;
     await api.POST("/v1/resources", {
       body: {
@@ -212,8 +212,8 @@ test.describe("Resource API", () => {
 
     await new Promise((resolve) => setTimeout(resolve, 5_000));
 
-    const environment = builder.result.environments[0]!;
-    const deployment = builder.result.deployments[0]!;
+    const environment = builder.cache.environments[0]!;
+    const deployment = builder.cache.deployments[0]!;
     const releaseTargetsResponse = await api.GET(
       "/v1/resources/{resourceId}/release-targets",
       {
@@ -230,12 +230,9 @@ test.describe("Resource API", () => {
     expect(releaseTarget).toBeDefined();
   });
 
-  test("updating non metadata fields should not change resource's current metadata", async ({
-    api,
-    workspace,
-  }) => {
+  test("updating non metadata fields should not change resource's current metadata", async ({api,workspace,}) => {
     // First create a resource
-    const systemPrefix = builder.result.system.slug.split("-")[0]!;
+    const systemPrefix = builder.cache.system.slug.split("-")[0]!;
     const resourceName = `${systemPrefix}-${faker.string.alphanumeric(10)}`;
     await api.POST("/v1/resources", {
       body: {
@@ -282,11 +279,13 @@ test.describe("Resource API", () => {
 
   test("delete a resource", async ({ api, workspace }) => {
     // First create a resource
-    const systemPrefix = builder.result.system.slug.split("-")[0]!;
+    const systemPrefix = builder.cache.system.slug.split("-")[0]!;
     const resourceName = `${systemPrefix}-${faker.string.alphanumeric(10)}`;
-    const resourceIdentifer = `${resourceName}/${faker.string.alphanumeric(
-      10,
-    )}`;
+    const resourceIdentifer = `${resourceName}/${
+      faker.string.alphanumeric(
+        10,
+      )
+    }`;
     const resourceResponse = await api.POST("/v1/resources", {
       body: {
         workspaceId: workspace.id,
@@ -335,8 +334,8 @@ test.describe("Resource API", () => {
 
     await new Promise((resolve) => setTimeout(resolve, 5_000));
 
-    const environment = builder.result.environments[0]!;
-    const deployment = builder.result.deployments[0]!;
+    const environment = builder.cache.environments[0]!;
+    const deployment = builder.cache.deployments[0]!;
 
     const environmentResourcesResponse = await api.GET(
       "/v1/environments/{environmentId}/resources",
@@ -364,7 +363,7 @@ test.describe("Resource API", () => {
   });
 
   test("create resource relationship", async ({ api, workspace }) => {
-    const systemPrefix = builder.result.system.slug.split("-")[0]!;
+    const systemPrefix = builder.cache.system.slug.split("-")[0]!;
     // Create two resources
     const resource1Name = `${systemPrefix}-${faker.string.alphanumeric(10)}`;
     const resource2Name = `${systemPrefix}-${faker.string.alphanumeric(10)}`;

--- a/e2e/tests/api/resources.spec.ts
+++ b/e2e/tests/api/resources.spec.ts
@@ -230,7 +230,10 @@ test.describe("Resource API", () => {
     expect(releaseTarget).toBeDefined();
   });
 
-  test("updating non metadata fields should not change resource's current metadata", async ({api,workspace,}) => {
+  test("updating non metadata fields should not change resource's current metadata", async ({
+    api,
+    workspace,
+  }) => {
     // First create a resource
     const systemPrefix = builder.cache.system.slug.split("-")[0]!;
     const resourceName = `${systemPrefix}-${faker.string.alphanumeric(10)}`;
@@ -281,11 +284,9 @@ test.describe("Resource API", () => {
     // First create a resource
     const systemPrefix = builder.cache.system.slug.split("-")[0]!;
     const resourceName = `${systemPrefix}-${faker.string.alphanumeric(10)}`;
-    const resourceIdentifer = `${resourceName}/${
-      faker.string.alphanumeric(
-        10,
-      )
-    }`;
+    const resourceIdentifer = `${resourceName}/${faker.string.alphanumeric(
+      10,
+    )}`;
     const resourceResponse = await api.POST("/v1/resources", {
       body: {
         workspaceId: workspace.id,

--- a/e2e/tests/api/workspace.spec.ts
+++ b/e2e/tests/api/workspace.spec.ts
@@ -1,9 +1,6 @@
-import path from "path";
 import { expect } from "@playwright/test";
 
 import { test } from "../fixtures";
-
-const yamlPath = path.join(__dirname, "workspace.spec.yaml");
 
 test.describe("Workspace API", () => {
   test("should fetch a workspace by ID", async ({ api, workspace }) => {

--- a/e2e/tests/api/yaml-import.spec.ts
+++ b/e2e/tests/api/yaml-import.spec.ts
@@ -4,7 +4,7 @@ import { expect } from "@playwright/test";
 import {
   cleanupImportedEntities,
   EntitiesBuilder,
-} from "../../api/yaml-loader";
+} from "../../api/entities-builder";
 import { test } from "../fixtures";
 
 const yamlPath = path.join(__dirname, "yaml-import.spec.yaml");
@@ -43,7 +43,10 @@ test.describe("YAML Entity Import", () => {
     expect(response.data?.description).toBe("System created from YAML fixture");
   });
 
-  test("should have created resources from YAML", async ({api,workspace,}) => {
+  test("should have created resources from YAML", async ({
+    api,
+    workspace,
+  }) => {
     // List resources in workspace
     const response = await api.GET("/v1/workspaces/{workspaceId}/resources", {
       params: { path: { workspaceId: workspace.id } },

--- a/e2e/tests/api/yaml-import.spec.ts
+++ b/e2e/tests/api/yaml-import.spec.ts
@@ -43,7 +43,10 @@ test.describe("YAML Entity Import", () => {
     expect(response.data?.description).toBe("System created from YAML fixture");
   });
 
-  test("should have created resources from YAML", async ({ api, workspace }) => {
+  test("should have created resources from YAML", async ({
+    api,
+    workspace,
+  }) => {
     // List resources in workspace
     const response = await api.GET("/v1/workspaces/{workspaceId}/resources", {
       params: { path: { workspaceId: workspace.id } },

--- a/e2e/tests/api/yaml-import.spec.ts
+++ b/e2e/tests/api/yaml-import.spec.ts
@@ -27,15 +27,15 @@ test.describe("YAML Entity Import", () => {
 
   test.afterAll(async ({ api, workspace }) => {
     // Clean up all imported entities
-    if (builder.result) {
-      await cleanupImportedEntities(api, builder.result, workspace.id);
+    if (builder.cache) {
+      await cleanupImportedEntities(api, builder.cache, workspace.id);
     }
   });
 
   test("should have created a system from YAML", async ({ api }) => {
     // Get the system by ID
     const response = await api.GET("/v1/systems/{systemId}", {
-      params: { path: { systemId: builder.result.system.id } },
+      params: { path: { systemId: builder.cache.system.id } },
     });
 
     // Verify system data
@@ -43,10 +43,7 @@ test.describe("YAML Entity Import", () => {
     expect(response.data?.description).toBe("System created from YAML fixture");
   });
 
-  test("should have created resources from YAML", async ({
-    api,
-    workspace,
-  }) => {
+  test("should have created resources from YAML", async ({api,workspace,}) => {
     // List resources in workspace
     const response = await api.GET("/v1/workspaces/{workspaceId}/resources", {
       params: { path: { workspaceId: workspace.id } },
@@ -71,10 +68,10 @@ test.describe("YAML Entity Import", () => {
 
   test("should have created environments from YAML", async ({ api }) => {
     // Check that we have correct number of environments
-    expect(builder.result.environments.length).toBe(2);
+    expect(builder.cache.environments.length).toBe(2);
 
     // Get environment details for first environment
-    const prodEnvId = builder.result.environments.find(
+    const prodEnvId = builder.cache.environments.find(
       (e) => e.name === "Production",
     )?.id;
     expect(prodEnvId).toBeDefined();
@@ -90,9 +87,9 @@ test.describe("YAML Entity Import", () => {
   });
 
   test("should have created deployments from YAML", async ({ api }) => {
-    expect(builder.result.deployments.length).toBe(2);
+    expect(builder.cache.deployments.length).toBe(2);
 
-    const apiDeploymentId = builder.result.deployments.find(
+    const apiDeploymentId = builder.cache.deployments.find(
       (d) => d.name === "API Deployment",
     )?.id;
     expect(apiDeploymentId).toBeDefined();

--- a/e2e/tests/api/yaml-import.spec.ts
+++ b/e2e/tests/api/yaml-import.spec.ts
@@ -3,23 +3,23 @@ import { expect } from "@playwright/test";
 
 import {
   cleanupImportedEntities,
-  ImportedEntities,
-  importEntitiesFromYaml,
+  EntitiesBuilder,
 } from "../../api/yaml-loader";
 import { test } from "../fixtures";
 
 const yamlPath = path.join(__dirname, "yaml-import.spec.yaml");
 
 test.describe("YAML Entity Import", () => {
-  let importedEntities: ImportedEntities;
+  let builder: EntitiesBuilder;
 
   test.beforeAll(async ({ api, workspace }) => {
-    // Import entities from YAML file
-    importedEntities = await importEntitiesFromYaml(
-      api,
-      workspace.id,
-      yamlPath,
-    );
+    builder = new EntitiesBuilder(api, workspace, yamlPath);
+    await builder.createSystem();
+    await builder.createResources();
+    await builder.createEnvironments();
+    await builder.createDeployments();
+    await builder.createDeploymentVariables();
+    await builder.createPolicies();
 
     // Allow time for resources to be processed
     await new Promise((resolve) => setTimeout(resolve, 5000));
@@ -27,15 +27,15 @@ test.describe("YAML Entity Import", () => {
 
   test.afterAll(async ({ api, workspace }) => {
     // Clean up all imported entities
-    if (importedEntities) {
-      await cleanupImportedEntities(api, importedEntities, workspace.id);
+    if (builder.result) {
+      await cleanupImportedEntities(api, builder.result, workspace.id);
     }
   });
 
   test("should have created a system from YAML", async ({ api }) => {
     // Get the system by ID
     const response = await api.GET("/v1/systems/{systemId}", {
-      params: { path: { systemId: importedEntities.system.id } },
+      params: { path: { systemId: builder.result.system.id } },
     });
 
     // Verify system data
@@ -43,10 +43,7 @@ test.describe("YAML Entity Import", () => {
     expect(response.data?.description).toBe("System created from YAML fixture");
   });
 
-  test("should have created resources from YAML", async ({
-    api,
-    workspace,
-  }) => {
+  test("should have created resources from YAML", async ({ api, workspace }) => {
     // List resources in workspace
     const response = await api.GET("/v1/workspaces/{workspaceId}/resources", {
       params: { path: { workspaceId: workspace.id } },
@@ -71,10 +68,10 @@ test.describe("YAML Entity Import", () => {
 
   test("should have created environments from YAML", async ({ api }) => {
     // Check that we have correct number of environments
-    expect(importedEntities.environments.length).toBe(2);
+    expect(builder.result.environments.length).toBe(2);
 
     // Get environment details for first environment
-    const prodEnvId = importedEntities.environments.find(
+    const prodEnvId = builder.result.environments.find(
       (e) => e.name === "Production",
     )?.id;
     expect(prodEnvId).toBeDefined();
@@ -90,9 +87,9 @@ test.describe("YAML Entity Import", () => {
   });
 
   test("should have created deployments from YAML", async ({ api }) => {
-    expect(importedEntities.deployments.length).toBe(2);
+    expect(builder.result.deployments.length).toBe(2);
 
-    const apiDeploymentId = importedEntities.deployments.find(
+    const apiDeploymentId = builder.result.deployments.find(
       (d) => d.name === "API Deployment",
     )?.id;
     expect(apiDeploymentId).toBeDefined();

--- a/e2e/tests/api/yaml-import.spec.yaml
+++ b/e2e/tests/api/yaml-import.spec.yaml
@@ -109,4 +109,4 @@ policies:
               key: tier
               value: production
     versionAnyApprovals:
-      requiredApprovalsCount: 2
+      - requiredApprovalsCount: 2


### PR DESCRIPTION
In order to test different orderings of entity creation, the yaml-entity loader:
* now requires a separate call for each type of entity created: createSystem, createResources, createDeployments, createDeploymentVariables, etc.
* will be expanded to include many more creation options in the future.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Refactor**
  - Introduced a new stepwise builder pattern for test entity setup with the `EntitiesBuilder` class.
  - Updated all test suites to use the builder for creating and managing test entities instead of the previous import function.
  - Enhanced test initialization and cleanup consistency.
  - Improved code readability with minor formatting adjustments.

- **Chores**
  - Removed unused YAML keys and unnecessary imports in test specifications.

- **New Features**
  - Added structured entity fixture definitions and validation for test data.
  - Provided a cleanup function to remove created test entities in a controlled order.
  - Added a new end-to-end test suite verifying deployment version creation via job agent queue.

- **Bug Fixes**
  - Adjusted API schema types for improved consistency in request and response payloads.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->