### PR TITLE
fix: correctly handle policy target locks in compute system release targets worker

### DIFF
--- a/apps/event-worker/src/utils/dispatch-compute-system-jobs.ts
+++ b/apps/event-worker/src/utils/dispatch-compute-system-jobs.ts
@@ -5,6 +5,7 @@ import { Channel, getQueue } from "@ctrlplane/events";
 export const dispatchComputeSystemReleaseTargetsJobs = async (
   system: schema.System,
   redeployAll?: boolean,
+  processedPolicyTargetIds?: string[],
 ) => {
   const { id } = system;
   const q = getQueue(Channel.ComputeSystemsReleaseTargets);
@@ -13,5 +14,5 @@ export const dispatchComputeSystemReleaseTargetsJobs = async (
     (job) => job.data.id === id && job.data.redeployAll === redeployAll,
   );
   if (isAlreadyQueued) return;
-  await q.add(id, { id, redeployAll });
+  await q.add(id, { id, redeployAll, processedPolicyTargetIds });
 };

--- a/apps/event-worker/src/workers/compute-systems-release-targets.ts
+++ b/apps/event-worker/src/workers/compute-systems-release-targets.ts
@@ -191,7 +191,10 @@ export const computeSystemsReleaseTargetsWorker = createWorker(
         .where(
           and(
             eq(schema.policy.workspaceId, workspaceId),
-            notInArray(schema.policyTarget.id, processedPolicyTargetIds ?? []),
+            processedPolicyTargetIds != null &&
+              processedPolicyTargetIds.length > 0
+              ? notInArray(schema.policyTarget.id, processedPolicyTargetIds)
+              : undefined,
           ),
         );
 
@@ -203,11 +206,6 @@ export const computeSystemsReleaseTargetsWorker = createWorker(
           additionalProcessedPolicyTargetIds.push(policyTarget.id);
         } catch (e: any) {
           if (e.code === "55P03") {
-            log.info("re-dispatching compute system release targets job", {
-              systemId: system.id,
-              error: e,
-              policyTarget,
-            });
             dispatchComputeSystemReleaseTargetsJobs(system, true, [
               ...(processedPolicyTargetIds ?? []),
               ...additionalProcessedPolicyTargetIds,

--- a/e2e/tests/api/policies/matched-release-targets.spec.yaml
+++ b/e2e/tests/api/policies/matched-release-targets.spec.yaml
@@ -47,3 +47,1005 @@ deployments:
   - name: "{{ prefix }}-deployment-b"
     slug: "{{ prefix }}-deployment-b"
     description: Deployment for testing matched release targets
+
+policies:
+  - name: "{{ prefix }}-policy-1"
+    targets:
+      - environmentSelector:
+          type: name
+          operator: equals
+          value: "{{ prefix }}-a"
+      - deploymentSelector:
+          type: name
+          operator: equals
+          value: "{{ prefix }}-deployment-a"
+  - name: "{{ prefix }}-policy-2"
+    targets:
+      - environmentSelector:
+          type: name
+          operator: equals
+          value: "{{ prefix }}-b"
+      - deploymentSelector:
+          type: name
+          operator: equals
+          value: "{{ prefix }}-deployment-b"
+  - name: "{{ prefix }}-policy-3"
+    targets:
+      - environmentSelector:
+          type: name
+          operator: equals
+          value: "{{ prefix }}-a"
+      - deploymentSelector:
+          type: name
+          operator: equals
+          value: "{{ prefix }}-deployment-a"
+  - name: "{{ prefix }}-policy-4"
+    targets:
+      - environmentSelector:
+          type: name
+          operator: equals
+          value: "{{ prefix }}-b"
+      - deploymentSelector:
+          type: name
+          operator: equals
+          value: "{{ prefix }}-deployment-b"
+  - name: "{{ prefix }}-policy-5"
+    targets:
+      - environmentSelector:
+          type: name
+          operator: equals
+          value: "{{ prefix }}-a"
+      - deploymentSelector:
+          type: name
+          operator: equals
+          value: "{{ prefix }}-deployment-a"
+  - name: "{{ prefix }}-policy-6"
+    targets:
+      - environmentSelector:
+          type: name
+          operator: equals
+          value: "{{ prefix }}-b"
+      - deploymentSelector:
+          type: name
+          operator: equals
+          value: "{{ prefix }}-deployment-b"
+  - name: "{{ prefix }}-policy-7"
+    targets:
+      - environmentSelector:
+          type: name
+          operator: equals
+          value: "{{ prefix }}-a"
+      - deploymentSelector:
+          type: name
+          operator: equals
+          value: "{{ prefix }}-deployment-a"
+  - name: "{{ prefix }}-policy-8"
+    targets:
+      - environmentSelector:
+          type: name
+          operator: equals
+          value: "{{ prefix }}-b"
+      - deploymentSelector:
+          type: name
+          operator: equals
+          value: "{{ prefix }}-deployment-b"
+  - name: "{{ prefix }}-policy-9"
+    targets:
+      - environmentSelector:
+          type: name
+          operator: equals
+          value: "{{ prefix }}-a"
+      - deploymentSelector:
+          type: name
+          operator: equals
+          value: "{{ prefix }}-deployment-a"
+  - name: "{{ prefix }}-policy-10"
+    targets:
+      - environmentSelector:
+          type: name
+          operator: equals
+          value: "{{ prefix }}-b"
+      - deploymentSelector:
+          type: name
+          operator: equals
+          value: "{{ prefix }}-deployment-b"
+  - name: "{{ prefix }}-policy-11"
+    targets:
+      - environmentSelector:
+          type: name
+          operator: equals
+          value: "{{ prefix }}-a"
+      - deploymentSelector:
+          type: name
+          operator: equals
+          value: "{{ prefix }}-deployment-a"
+  - name: "{{ prefix }}-policy-12"
+    targets:
+      - environmentSelector:
+          type: name
+          operator: equals
+          value: "{{ prefix }}-b"
+      - deploymentSelector:
+          type: name
+          operator: equals
+          value: "{{ prefix }}-deployment-b"
+  - name: "{{ prefix }}-policy-13"
+    targets:
+      - environmentSelector:
+          type: name
+          operator: equals
+          value: "{{ prefix }}-a"
+      - deploymentSelector:
+          type: name
+          operator: equals
+          value: "{{ prefix }}-deployment-a"
+  - name: "{{ prefix }}-policy-14"
+    targets:
+      - environmentSelector:
+          type: name
+          operator: equals
+          value: "{{ prefix }}-b"
+      - deploymentSelector:
+          type: name
+          operator: equals
+          value: "{{ prefix }}-deployment-b"
+  - name: "{{ prefix }}-policy-15"
+    targets:
+      - environmentSelector:
+          type: name
+          operator: equals
+          value: "{{ prefix }}-a"
+      - deploymentSelector:
+          type: name
+          operator: equals
+          value: "{{ prefix }}-deployment-a"
+  - name: "{{ prefix }}-policy-16"
+    targets:
+      - environmentSelector:
+          type: name
+          operator: equals
+          value: "{{ prefix }}-b"
+      - deploymentSelector:
+          type: name
+          operator: equals
+          value: "{{ prefix }}-deployment-b"
+  - name: "{{ prefix }}-policy-17"
+    targets:
+      - environmentSelector:
+          type: name
+          operator: equals
+          value: "{{ prefix }}-a"
+      - deploymentSelector:
+          type: name
+          operator: equals
+          value: "{{ prefix }}-deployment-a"
+  - name: "{{ prefix }}-policy-18"
+    targets:
+      - environmentSelector:
+          type: name
+          operator: equals
+          value: "{{ prefix }}-b"
+      - deploymentSelector:
+          type: name
+          operator: equals
+          value: "{{ prefix }}-deployment-b"
+  - name: "{{ prefix }}-policy-19"
+    targets:
+      - environmentSelector:
+          type: name
+          operator: equals
+          value: "{{ prefix }}-a"
+      - deploymentSelector:
+          type: name
+          operator: equals
+          value: "{{ prefix }}-deployment-a"
+  - name: "{{ prefix }}-policy-20"
+    targets:
+      - environmentSelector:
+          type: name
+          operator: equals
+          value: "{{ prefix }}-b"
+      - deploymentSelector:
+          type: name
+          operator: equals
+          value: "{{ prefix }}-deployment-b"
+  - name: "{{ prefix }}-policy-21"
+    targets:
+      - environmentSelector:
+          type: name
+          operator: equals
+          value: "{{ prefix }}-a"
+      - deploymentSelector:
+          type: name
+          operator: equals
+          value: "{{ prefix }}-deployment-a"
+  - name: "{{ prefix }}-policy-22"
+    targets:
+      - environmentSelector:
+          type: name
+          operator: equals
+          value: "{{ prefix }}-b"
+      - deploymentSelector:
+          type: name
+          operator: equals
+          value: "{{ prefix }}-deployment-b"
+  - name: "{{ prefix }}-policy-23"
+    targets:
+      - environmentSelector:
+          type: name
+          operator: equals
+          value: "{{ prefix }}-a"
+      - deploymentSelector:
+          type: name
+          operator: equals
+          value: "{{ prefix }}-deployment-a"
+  - name: "{{ prefix }}-policy-24"
+    targets:
+      - environmentSelector:
+          type: name
+          operator: equals
+          value: "{{ prefix }}-b"
+      - deploymentSelector:
+          type: name
+          operator: equals
+          value: "{{ prefix }}-deployment-b"
+  - name: "{{ prefix }}-policy-25"
+    targets:
+      - environmentSelector:
+          type: name
+          operator: equals
+          value: "{{ prefix }}-a"
+      - deploymentSelector:
+          type: name
+          operator: equals
+          value: "{{ prefix }}-deployment-a"
+  - name: "{{ prefix }}-policy-26"
+    targets:
+      - environmentSelector:
+          type: name
+          operator: equals
+          value: "{{ prefix }}-b"
+      - deploymentSelector:
+          type: name
+          operator: equals
+          value: "{{ prefix }}-deployment-b"
+  - name: "{{ prefix }}-policy-27"
+    targets:
+      - environmentSelector:
+          type: name
+          operator: equals
+          value: "{{ prefix }}-a"
+      - deploymentSelector:
+          type: name
+          operator: equals
+          value: "{{ prefix }}-deployment-a"
+  - name: "{{ prefix }}-policy-28"
+    targets:
+      - environmentSelector:
+          type: name
+          operator: equals
+          value: "{{ prefix }}-b"
+      - deploymentSelector:
+          type: name
+          operator: equals
+          value: "{{ prefix }}-deployment-b"
+  - name: "{{ prefix }}-policy-29"
+    targets:
+      - environmentSelector:
+          type: name
+          operator: equals
+          value: "{{ prefix }}-a"
+      - deploymentSelector:
+          type: name
+          operator: equals
+          value: "{{ prefix }}-deployment-a"
+  - name: "{{ prefix }}-policy-30"
+    targets:
+      - environmentSelector:
+          type: name
+          operator: equals
+          value: "{{ prefix }}-b"
+      - deploymentSelector:
+          type: name
+          operator: equals
+          value: "{{ prefix }}-deployment-b"
+  - name: "{{ prefix }}-policy-31"
+    targets:
+      - environmentSelector:
+          type: name
+          operator: equals
+          value: "{{ prefix }}-a"
+      - deploymentSelector:
+          type: name
+          operator: equals
+          value: "{{ prefix }}-deployment-a"
+  - name: "{{ prefix }}-policy-32"
+    targets:
+      - environmentSelector:
+          type: name
+          operator: equals
+          value: "{{ prefix }}-b"
+      - deploymentSelector:
+          type: name
+          operator: equals
+          value: "{{ prefix }}-deployment-b"
+  - name: "{{ prefix }}-policy-33"
+    targets:
+      - environmentSelector:
+          type: name
+          operator: equals
+          value: "{{ prefix }}-a"
+      - deploymentSelector:
+          type: name
+          operator: equals
+          value: "{{ prefix }}-deployment-a"
+  - name: "{{ prefix }}-policy-34"
+    targets:
+      - environmentSelector:
+          type: name
+          operator: equals
+          value: "{{ prefix }}-b"
+      - deploymentSelector:
+          type: name
+          operator: equals
+          value: "{{ prefix }}-deployment-b"
+  - name: "{{ prefix }}-policy-35"
+    targets:
+      - environmentSelector:
+          type: name
+          operator: equals
+          value: "{{ prefix }}-a"
+      - deploymentSelector:
+          type: name
+          operator: equals
+          value: "{{ prefix }}-deployment-a"
+  - name: "{{ prefix }}-policy-36"
+    targets:
+      - environmentSelector:
+          type: name
+          operator: equals
+          value: "{{ prefix }}-b"
+      - deploymentSelector:
+          type: name
+          operator: equals
+          value: "{{ prefix }}-deployment-b"
+  - name: "{{ prefix }}-policy-37"
+    targets:
+      - environmentSelector:
+          type: name
+          operator: equals
+          value: "{{ prefix }}-a"
+      - deploymentSelector:
+          type: name
+          operator: equals
+          value: "{{ prefix }}-deployment-a"
+  - name: "{{ prefix }}-policy-38"
+    targets:
+      - environmentSelector:
+          type: name
+          operator: equals
+          value: "{{ prefix }}-b"
+      - deploymentSelector:
+          type: name
+          operator: equals
+          value: "{{ prefix }}-deployment-a"
+  - name: "{{ prefix }}-policy-39"
+    targets:
+      - environmentSelector:
+          type: name
+          operator: equals
+          value: "{{ prefix }}-a"
+      - deploymentSelector:
+          type: name
+          operator: equals
+          value: "{{ prefix }}-deployment-a"
+  - name: "{{ prefix }}-policy-40"
+    targets:
+      - environmentSelector:
+          type: name
+          operator: equals
+          value: "{{ prefix }}-b"
+      - deploymentSelector:
+          type: name
+          operator: equals
+          value: "{{ prefix }}-deployment-b"
+  - name: "{{ prefix }}-policy-41"
+    targets:
+      - environmentSelector:
+          type: name
+          operator: equals
+          value: "{{ prefix }}-a"
+      - deploymentSelector:
+          type: name
+          operator: equals
+          value: "{{ prefix }}-deployment-b"
+  - name: "{{ prefix }}-policy-42"
+    targets:
+      - environmentSelector:
+          type: name
+          operator: equals
+          value: "{{ prefix }}-b"
+      - deploymentSelector:
+          type: name
+          operator: equals
+          value: "{{ prefix }}-deployment-a"
+  - name: "{{ prefix }}-policy-43"
+    targets:
+      - environmentSelector:
+          type: name
+          operator: equals
+          value: "{{ prefix }}-a"
+      - deploymentSelector:
+          type: name
+          operator: equals
+          value: "{{ prefix }}-deployment-a"
+  - name: "{{ prefix }}-policy-44"
+    targets:
+      - environmentSelector:
+          type: name
+          operator: equals
+          value: "{{ prefix }}-b"
+      - deploymentSelector:
+          type: name
+          operator: equals
+          value: "{{ prefix }}-deployment-b"
+  - name: "{{ prefix }}-policy-45"
+    targets:
+      - environmentSelector:
+          type: name
+          operator: equals
+          value: "{{ prefix }}-a"
+      - deploymentSelector:
+          type: name
+          operator: equals
+          value: "{{ prefix }}-deployment-b"
+  - name: "{{ prefix }}-policy-46"
+    targets:
+      - environmentSelector:
+          type: name
+          operator: equals
+          value: "{{ prefix }}-b"
+      - deploymentSelector:
+          type: name
+          operator: equals
+          value: "{{ prefix }}-deployment-a"
+  - name: "{{ prefix }}-policy-47"
+    targets:
+      - environmentSelector:
+          type: name
+          operator: equals
+          value: "{{ prefix }}-a"
+      - deploymentSelector:
+          type: name
+          operator: equals
+          value: "{{ prefix }}-deployment-a"
+  - name: "{{ prefix }}-policy-48"
+    targets:
+      - environmentSelector:
+          type: name
+          operator: equals
+          value: "{{ prefix }}-b"
+      - deploymentSelector:
+          type: name
+          operator: equals
+          value: "{{ prefix }}-deployment-b"
+  - name: "{{ prefix }}-policy-49"
+    targets:
+      - environmentSelector:
+          type: name
+          operator: equals
+          value: "{{ prefix }}-a"
+      - deploymentSelector:
+          type: name
+          operator: equals
+          value: "{{ prefix }}-deployment-b"
+  - name: "{{ prefix }}-policy-50"
+    targets:
+      - environmentSelector:
+          type: name
+          operator: equals
+          value: "{{ prefix }}-b"
+      - deploymentSelector:
+          type: name
+          operator: equals
+          value: "{{ prefix }}-deployment-a"
+  - name: "{{ prefix }}-policy-51"
+    targets:
+      - environmentSelector:
+          type: name
+          operator: equals
+          value: "{{ prefix }}-a"
+      - deploymentSelector:
+          type: name
+          operator: equals
+          value: "{{ prefix }}-deployment-a"
+  - name: "{{ prefix }}-policy-52"
+    targets:
+      - environmentSelector:
+          type: name
+          operator: equals
+          value: "{{ prefix }}-b"
+      - deploymentSelector:
+          type: name
+          operator: equals
+          value: "{{ prefix }}-deployment-b"
+  - name: "{{ prefix }}-policy-53"
+    targets:
+      - environmentSelector:
+          type: name
+          operator: equals
+          value: "{{ prefix }}-a"
+      - deploymentSelector:
+          type: name
+          operator: equals
+          value: "{{ prefix }}-deployment-b"
+  - name: "{{ prefix }}-policy-54"
+    targets:
+      - environmentSelector:
+          type: name
+          operator: equals
+          value: "{{ prefix }}-b"
+      - deploymentSelector:
+          type: name
+          operator: equals
+          value: "{{ prefix }}-deployment-a"
+  - name: "{{ prefix }}-policy-55"
+    targets:
+      - environmentSelector:
+          type: name
+          operator: equals
+          value: "{{ prefix }}-a"
+      - deploymentSelector:
+          type: name
+          operator: equals
+          value: "{{ prefix }}-deployment-a"
+  - name: "{{ prefix }}-policy-56"
+    targets:
+      - environmentSelector:
+          type: name
+          operator: equals
+          value: "{{ prefix }}-b"
+      - deploymentSelector:
+          type: name
+          operator: equals
+          value: "{{ prefix }}-deployment-b"
+  - name: "{{ prefix }}-policy-57"
+    targets:
+      - environmentSelector:
+          type: name
+          operator: equals
+          value: "{{ prefix }}-a"
+      - deploymentSelector:
+          type: name
+          operator: equals
+          value: "{{ prefix }}-deployment-b"
+  - name: "{{ prefix }}-policy-58"
+    targets:
+      - environmentSelector:
+          type: name
+          operator: equals
+          value: "{{ prefix }}-b"
+      - deploymentSelector:
+          type: name
+          operator: equals
+          value: "{{ prefix }}-deployment-a"
+  - name: "{{ prefix }}-policy-59"
+    targets:
+      - environmentSelector:
+          type: name
+          operator: equals
+          value: "{{ prefix }}-a"
+      - deploymentSelector:
+          type: name
+          operator: equals
+          value: "{{ prefix }}-deployment-a"
+  - name: "{{ prefix }}-policy-60"
+    targets:
+      - environmentSelector:
+          type: name
+          operator: equals
+          value: "{{ prefix }}-b"
+      - deploymentSelector:
+          type: name
+          operator: equals
+          value: "{{ prefix }}-deployment-b"
+  - name: "{{ prefix }}-policy-61"
+    targets:
+      - environmentSelector:
+          type: name
+          operator: equals
+          value: "{{ prefix }}-a"
+      - deploymentSelector:
+          type: name
+          operator: equals
+          value: "{{ prefix }}-deployment-b"
+  - name: "{{ prefix }}-policy-62"
+    targets:
+      - environmentSelector:
+          type: name
+          operator: equals
+          value: "{{ prefix }}-b"
+      - deploymentSelector:
+          type: name
+          operator: equals
+          value: "{{ prefix }}-deployment-a"
+  - name: "{{ prefix }}-policy-63"
+    targets:
+      - environmentSelector:
+          type: name
+          operator: equals
+          value: "{{ prefix }}-a"
+      - deploymentSelector:
+          type: name
+          operator: equals
+          value: "{{ prefix }}-deployment-a"
+  - name: "{{ prefix }}-policy-64"
+    targets:
+      - environmentSelector:
+          type: name
+          operator: equals
+          value: "{{ prefix }}-b"
+      - deploymentSelector:
+          type: name
+          operator: equals
+          value: "{{ prefix }}-deployment-b"
+  - name: "{{ prefix }}-policy-65"
+    targets:
+      - environmentSelector:
+          type: name
+          operator: equals
+          value: "{{ prefix }}-a"
+      - deploymentSelector:
+          type: name
+          operator: equals
+          value: "{{ prefix }}-deployment-b"
+  - name: "{{ prefix }}-policy-66"
+    targets:
+      - environmentSelector:
+          type: name
+          operator: equals
+          value: "{{ prefix }}-b"
+      - deploymentSelector:
+          type: name
+          operator: equals
+          value: "{{ prefix }}-deployment-a"
+  - name: "{{ prefix }}-policy-67"
+    targets:
+      - environmentSelector:
+          type: name
+          operator: equals
+          value: "{{ prefix }}-a"
+      - deploymentSelector:
+          type: name
+          operator: equals
+          value: "{{ prefix }}-deployment-a"
+  - name: "{{ prefix }}-policy-68"
+    targets:
+      - environmentSelector:
+          type: name
+          operator: equals
+          value: "{{ prefix }}-b"
+      - deploymentSelector:
+          type: name
+          operator: equals
+          value: "{{ prefix }}-deployment-b"
+  - name: "{{ prefix }}-policy-69"
+    targets:
+      - environmentSelector:
+          type: name
+          operator: equals
+          value: "{{ prefix }}-a"
+      - deploymentSelector:
+          type: name
+          operator: equals
+          value: "{{ prefix }}-deployment-a"
+  - name: "{{ prefix }}-policy-70"
+    targets:
+      - environmentSelector:
+          type: name
+          operator: equals
+          value: "{{ prefix }}-b"
+      - deploymentSelector:
+          type: name
+          operator: equals
+          value: "{{ prefix }}-deployment-b"
+  - name: "{{ prefix }}-policy-71"
+    targets:
+      - environmentSelector:
+          type: name
+          operator: equals
+          value: "{{ prefix }}-a"
+      - deploymentSelector:
+          type: name
+          operator: equals
+          value: "{{ prefix }}-deployment-b"
+  - name: "{{ prefix }}-policy-72"
+    targets:
+      - environmentSelector:
+          type: name
+          operator: equals
+          value: "{{ prefix }}-b"
+      - deploymentSelector:
+          type: name
+          operator: equals
+          value: "{{ prefix }}-deployment-a"
+  - name: "{{ prefix }}-policy-73"
+    targets:
+      - environmentSelector:
+          type: name
+          operator: equals
+          value: "{{ prefix }}-a"
+      - deploymentSelector:
+          type: name
+          operator: equals
+          value: "{{ prefix }}-deployment-a"
+  - name: "{{ prefix }}-policy-74"
+    targets:
+      - environmentSelector:
+          type: name
+          operator: equals
+          value: "{{ prefix }}-b"
+      - deploymentSelector:
+          type: name
+          operator: equals
+          value: "{{ prefix }}-deployment-b"
+  - name: "{{ prefix }}-policy-75"
+    targets:
+      - environmentSelector:
+          type: name
+          operator: equals
+          value: "{{ prefix }}-a"
+      - deploymentSelector:
+          type: name
+          operator: equals
+          value: "{{ prefix }}-deployment-b"
+  - name: "{{ prefix }}-policy-76"
+    targets:
+      - environmentSelector:
+          type: name
+          operator: equals
+          value: "{{ prefix }}-b"
+      - deploymentSelector:
+          type: name
+          operator: equals
+          value: "{{ prefix }}-deployment-a"
+  - name: "{{ prefix }}-policy-77"
+    targets:
+      - environmentSelector:
+          type: name
+          operator: equals
+          value: "{{ prefix }}-a"
+      - deploymentSelector:
+          type: name
+          operator: equals
+          value: "{{ prefix }}-deployment-a"
+  - name: "{{ prefix }}-policy-78"
+    targets:
+      - environmentSelector:
+          type: name
+          operator: equals
+          value: "{{ prefix }}-b"
+      - deploymentSelector:
+          type: name
+          operator: equals
+          value: "{{ prefix }}-deployment-b"
+  - name: "{{ prefix }}-policy-79"
+    targets:
+      - environmentSelector:
+          type: name
+          operator: equals
+          value: "{{ prefix }}-a"
+      - deploymentSelector:
+          type: name
+          operator: equals
+          value: "{{ prefix }}-deployment-b"
+  - name: "{{ prefix }}-policy-80"
+    targets:
+      - environmentSelector:
+          type: name
+          operator: equals
+          value: "{{ prefix }}-b"
+      - deploymentSelector:
+          type: name
+          operator: equals
+          value: "{{ prefix }}-deployment-a"
+  - name: "{{ prefix }}-policy-81"
+    targets:
+      - environmentSelector:
+          type: name
+          operator: equals
+          value: "{{ prefix }}-a"
+      - deploymentSelector:
+          type: name
+          operator: equals
+          value: "{{ prefix }}-deployment-a"
+  - name: "{{ prefix }}-policy-82"
+    targets:
+      - environmentSelector:
+          type: name
+          operator: equals
+          value: "{{ prefix }}-b"
+      - deploymentSelector:
+          type: name
+          operator: equals
+          value: "{{ prefix }}-deployment-b"
+  - name: "{{ prefix }}-policy-83"
+    targets:
+      - environmentSelector:
+          type: name
+          operator: equals
+          value: "{{ prefix }}-a"
+      - deploymentSelector:
+          type: name
+          operator: equals
+          value: "{{ prefix }}-deployment-b"
+  - name: "{{ prefix }}-policy-84"
+    targets:
+      - environmentSelector:
+          type: name
+          operator: equals
+          value: "{{ prefix }}-b"
+      - deploymentSelector:
+          type: name
+          operator: equals
+          value: "{{ prefix }}-deployment-a"
+  - name: "{{ prefix }}-policy-85"
+    targets:
+      - environmentSelector:
+          type: name
+          operator: equals
+          value: "{{ prefix }}-a"
+      - deploymentSelector:
+          type: name
+          operator: equals
+          value: "{{ prefix }}-deployment-a"
+  - name: "{{ prefix }}-policy-86"
+    targets:
+      - environmentSelector:
+          type: name
+          operator: equals
+          value: "{{ prefix }}-b"
+      - deploymentSelector:
+          type: name
+          operator: equals
+          value: "{{ prefix }}-deployment-b"
+  - name: "{{ prefix }}-policy-87"
+    targets:
+      - environmentSelector:
+          type: name
+          operator: equals
+          value: "{{ prefix }}-a"
+      - deploymentSelector:
+          type: name
+          operator: equals
+          value: "{{ prefix }}-deployment-b"
+  - name: "{{ prefix }}-policy-88"
+    targets:
+      - environmentSelector:
+          type: name
+          operator: equals
+          value: "{{ prefix }}-b"
+      - deploymentSelector:
+          type: name
+          operator: equals
+          value: "{{ prefix }}-deployment-a"
+  - name: "{{ prefix }}-policy-89"
+    targets:
+      - environmentSelector:
+          type: name
+          operator: equals
+          value: "{{ prefix }}-a"
+      - deploymentSelector:
+          type: name
+          operator: equals
+          value: "{{ prefix }}-deployment-a"
+  - name: "{{ prefix }}-policy-90"
+    targets:
+      - environmentSelector:
+          type: name
+          operator: equals
+          value: "{{ prefix }}-b"
+      - deploymentSelector:
+          type: name
+          operator: equals
+          value: "{{ prefix }}-deployment-b"
+  - name: "{{ prefix }}-policy-91"
+    targets:
+      - environmentSelector:
+          type: name
+          operator: equals
+          value: "{{ prefix }}-a"
+      - deploymentSelector:
+          type: name
+          operator: equals
+          value: "{{ prefix }}-deployment-b"
+  - name: "{{ prefix }}-policy-92"
+    targets:
+      - environmentSelector:
+          type: name
+          operator: equals
+          value: "{{ prefix }}-b"
+      - deploymentSelector:
+          type: name
+          operator: equals
+          value: "{{ prefix }}-deployment-a"
+  - name: "{{ prefix }}-policy-93"
+    targets:
+      - environmentSelector:
+          type: name
+          operator: equals
+          value: "{{ prefix }}-a"
+      - deploymentSelector:
+          type: name
+          operator: equals
+          value: "{{ prefix }}-deployment-a"
+  - name: "{{ prefix }}-policy-94"
+    targets:
+      - environmentSelector:
+          type: name
+          operator: equals
+          value: "{{ prefix }}-b"
+      - deploymentSelector:
+          type: name
+          operator: equals
+          value: "{{ prefix }}-deployment-b"
+  - name: "{{ prefix }}-policy-95"
+    targets:
+      - environmentSelector:
+          type: name
+          operator: equals
+          value: "{{ prefix }}-a"
+      - deploymentSelector:
+          type: name
+          operator: equals
+          value: "{{ prefix }}-deployment-b"
+  - name: "{{ prefix }}-policy-96"
+    targets:
+      - environmentSelector:
+          type: name
+          operator: equals
+          value: "{{ prefix }}-b"
+      - deploymentSelector:
+          type: name
+          operator: equals
+          value: "{{ prefix }}-deployment-a"
+  - name: "{{ prefix }}-policy-97"
+    targets:
+      - environmentSelector:
+          type: name
+          operator: equals
+          value: "{{ prefix }}-a"
+      - deploymentSelector:
+          type: name
+          operator: equals
+          value: "{{ prefix }}-deployment-a"
+  - name: "{{ prefix }}-policy-98"
+    targets:
+      - environmentSelector:
+          type: name
+          operator: equals
+          value: "{{ prefix }}-b"
+      - deploymentSelector:
+          type: name
+          operator: equals
+          value: "{{ prefix }}-deployment-b"
+  - name: "{{ prefix }}-policy-99"
+    targets:
+      - environmentSelector:
+          type: name
+          operator: equals
+          value: "{{ prefix }}-a"
+      - deploymentSelector:
+          type: name
+          operator: equals
+          value: "{{ prefix }}-deployment-a"
+  - name: "{{ prefix }}-policy-100"
+    targets:
+      - environmentSelector:
+          type: name
+          operator: equals
+          value: "{{ prefix }}-b"
+      - deploymentSelector:
+          type: name
+          operator: equals
+          value: "{{ prefix }}-deployment-b"

--- a/packages/events/src/types.ts
+++ b/packages/events/src/types.ts
@@ -75,5 +75,9 @@ export type ChannelMap = {
   [Channel.ComputeEnvironmentResourceSelector]: { id: string };
   [Channel.ComputeDeploymentResourceSelector]: { id: string };
   [Channel.ComputePolicyTargetReleaseTargetSelector]: { id: string };
-  [Channel.ComputeSystemsReleaseTargets]: { id: string; redeployAll?: boolean };
+  [Channel.ComputeSystemsReleaseTargets]: {
+    id: string;
+    redeployAll?: boolean;
+    processedPolicyTargetIds?: string[];
+  };
 };


### PR DESCRIPTION
…argets worker

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Improved handling of policy target processing to avoid reprocessing already handled targets.
  - Enhanced worker reliability by retrying jobs only for unprocessed policy targets in case of database row lock errors.
  - Added support for tracking processed policy targets during system release target computation.

- **Tests**
  - Expanded test coverage with additional policy definitions and more detailed assertions for release version matching.

- **Chores**
  - Updated internal data structures to support new job parameters for processed policy targets.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->