### PR TITLE
feat: add resource policies page with configurable policy cards

### DIFF
--- a/apps/webservice/src/app/[workspaceSlug]/(app)/resources/(raw)/[resourceId]/layout.tsx
+++ b/apps/webservice/src/app/[workspaceSlug]/(app)/resources/(raw)/[resourceId]/layout.tsx
@@ -6,6 +6,7 @@ import {
   IconHistory,
   IconLock,
   IconSettings,
+  IconShieldCheck,
   IconTopologyComplex,
   IconVariable,
 } from "@tabler/icons-react";
@@ -116,6 +117,12 @@ export default async function Layout(props: {
                   icon={<IconSettings className="size-4" />}
                 >
                   Properties
+                </SidebarLink>
+                <SidebarLink
+                  href={resourcePageUrls.policies()}
+                  icon={<IconShieldCheck className="size-4" />}
+                >
+                  Policies
                 </SidebarLink>
               </SidebarMenu>
             </SidebarGroup>

--- a/apps/webservice/src/app/[workspaceSlug]/(app)/resources/(raw)/[resourceId]/policies/_components/PolicyCard.tsx
+++ b/apps/webservice/src/app/[workspaceSlug]/(app)/resources/(raw)/[resourceId]/policies/_components/PolicyCard.tsx
@@ -1,0 +1,217 @@
+import type { RouterOutputs } from "@ctrlplane/api";
+import Link from "next/link";
+import {
+  IconShieldCheck,
+  IconClock,
+  IconShield,
+  IconAdjustments,
+  IconHelpCircle,
+  IconArrowUpRight,
+} from "@tabler/icons-react";
+import { Badge } from "@ctrlplane/ui/badge";
+import { Button } from "@ctrlplane/ui/button";
+import {
+  Tooltip,
+  TooltipContent,
+  TooltipProvider,
+  TooltipTrigger,
+} from "@ctrlplane/ui/tooltip";
+
+import { urls } from "~/app/urls";
+
+type Policy = RouterOutputs["policy"]["byResourceId"][number];
+
+type PolicySummaryCardConfig = {
+  id: string;
+  title: string;
+  icon: React.ComponentType<{ className?: string }>;
+  iconColor: string;
+  tooltip: string;
+  badgeConfig: {
+    activeText: string;
+    inactiveText: string;
+    activeColor: string;
+  };
+  countLabel: string;
+  dataSelector: (policies: Policy[]) => {
+    isActive: boolean;
+    count: number;
+  };
+};
+
+type PolicySummaryCardProps = {
+  config: PolicySummaryCardConfig;
+  workspaceSlug: string;
+};
+
+const PolicySummaryCard: React.FC<PolicySummaryCardProps & { data: { isActive: boolean; count: number } }> = ({ config, workspaceSlug, data }) => {
+  const { isActive, count } = data;
+  const Icon = config.icon;
+
+  return (
+    <div className="flex h-full flex-col overflow-hidden rounded-md border bg-neutral-900/50">
+      <div className="border-b p-4 pb-3">
+        <div className="flex items-center justify-between">
+          <h3 className="flex items-center gap-2 text-sm font-medium text-neutral-100">
+            <Icon className={`h-5 w-5 ${config.iconColor}`} />
+            {config.title}
+            <TooltipProvider>
+              <Tooltip>
+                <TooltipTrigger>
+                  <IconHelpCircle className="h-3.5 w-3.5 text-neutral-500 hover:text-neutral-300" />
+                </TooltipTrigger>
+                <TooltipContent className="max-w-[350px]">
+                  <p>{config.tooltip}</p>
+                </TooltipContent>
+              </Tooltip>
+            </TooltipProvider>
+          </h3>
+        </div>
+      </div>
+      <div className="flex-1 p-4">
+        <div className="grid grid-cols-2 gap-3 text-sm">
+          <div className="flex items-center gap-2 text-neutral-400">
+            {config.countLabel}
+          </div>
+          <div className="text-right font-medium">
+            <Badge
+              variant={isActive ? "default" : "secondary"}
+              className={isActive 
+                ? `${config.badgeConfig.activeColor} text-white` 
+                : "text-muted-foreground"
+              }
+            >
+              {isActive ? config.badgeConfig.activeText : config.badgeConfig.inactiveText}
+            </Badge>
+          </div>
+          <div className="flex items-center gap-2 text-neutral-400">
+            Policies Count
+          </div>
+          <div className="text-right font-medium text-neutral-100">
+            {count}
+          </div>
+        </div>
+      </div>
+      <div className="mt-auto border-t bg-neutral-900/60 p-2 text-right">
+        <Button
+          variant="ghost"
+          size="sm"
+          className="flex items-center gap-1.5 text-xs text-neutral-400 hover:text-neutral-200"
+          asChild
+        >
+          <Link href={urls.workspace(workspaceSlug).policies().baseUrl()}>
+            View Policies <IconArrowUpRight className="h-3 w-3" />
+          </Link>
+        </Button>
+      </div>
+    </div>
+  );
+};
+
+type PolicyCardProps = {
+  policies: RouterOutputs["policy"]["byResourceId"];
+  workspaceSlug: string;
+  cardConfigs: PolicySummaryCardConfig[];
+};
+
+export const PolicyCard: React.FC<PolicyCardProps> = ({ policies, workspaceSlug, cardConfigs }) => {
+  return (
+    <div className="grid grid-cols-1 gap-4 md:grid-cols-2 lg:grid-cols-2">
+      {cardConfigs.map(config => (
+        <PolicySummaryCard
+          key={config.id}
+          config={config}
+          workspaceSlug={workspaceSlug}
+          data={config.dataSelector(policies)}
+        />
+      ))}
+    </div>
+  );
+};
+
+export const policyCardConfigs: PolicySummaryCardConfig[] = [
+  {
+    id: "approval",
+    title: "Approval & Governance",
+    icon: IconShieldCheck,
+    iconColor: "text-blue-400",
+    tooltip: "Shows policies that require manual approvals or have governance rules for deployments to this resource.",
+    badgeConfig: {
+      activeText: "Yes",
+      inactiveText: "No",
+      activeColor: "bg-blue-500",
+    },
+    countLabel: "Approval Required",
+    dataSelector: (policies: Policy[]) => {
+      const approvalPolicies = policies.filter(p => 
+        p.versionAnyApprovals != null ||
+        p.versionUserApprovals.length > 0 ||
+        p.versionRoleApprovals.length > 0
+      );
+      return {
+        isActive: approvalPolicies.length > 0,
+        count: approvalPolicies.length,
+      };
+    },
+  },
+  {
+    id: "deny-windows",
+    title: "Deny Windows",
+    icon: IconClock,
+    iconColor: "text-red-400",
+    tooltip: "Time-based restrictions that prevent deployments during specific periods, like maintenance windows or business hours.",
+    badgeConfig: {
+      activeText: "Active",
+      inactiveText: "None",
+      activeColor: "bg-red-500",
+    },
+    countLabel: "Time Restrictions",
+    dataSelector: (policies: Policy[]) => {
+      const denyWindowPolicies = policies.filter(p => p.denyWindows.length > 0);
+      return {
+        isActive: denyWindowPolicies.length > 0,
+        count: denyWindowPolicies.length,
+      };
+    },
+  },
+  {
+    id: "version-conditions",
+    title: "Version Conditions",
+    icon: IconShield,
+    iconColor: "text-purple-400",
+    tooltip: "Rules that control which deployment versions are allowed based on version criteria, tags, or other metadata.",
+    badgeConfig: {
+      activeText: "Active",
+      inactiveText: "None",
+      activeColor: "bg-purple-500",
+    },
+    countLabel: "Version Rules",
+    dataSelector: (policies: Policy[]) => {
+      const versionConditionPolicies = policies.filter(p => p.deploymentVersionSelector != null);
+      return {
+        isActive: versionConditionPolicies.length > 0,
+        count: versionConditionPolicies.length,
+      };
+    },
+  },
+  {
+    id: "concurrency",
+    title: "Concurrency Control",
+    icon: IconAdjustments,
+    iconColor: "text-yellow-400",
+    tooltip: "Limits on how many deployments can run simultaneously for this resource, helping to control system load and deployment conflicts.",
+    badgeConfig: {
+      activeText: "Yes",
+      inactiveText: "Unlimited",
+      activeColor: "bg-yellow-500",
+    },
+    countLabel: "Limits Configured",
+    dataSelector: (policies: Policy[]) => {
+      const concurrencyPolicies = policies.filter(p => p.concurrency != null);
+      return {
+        isActive: concurrencyPolicies.length > 0,
+        count: concurrencyPolicies.length,
+      };
+    },
+  },
+];

--- a/apps/webservice/src/app/[workspaceSlug]/(app)/resources/(raw)/[resourceId]/policies/_components/PolicyCard.tsx
+++ b/apps/webservice/src/app/[workspaceSlug]/(app)/resources/(raw)/[resourceId]/policies/_components/PolicyCard.tsx
@@ -1,13 +1,14 @@
 import type { RouterOutputs } from "@ctrlplane/api";
 import Link from "next/link";
 import {
-  IconShieldCheck,
-  IconClock,
-  IconShield,
   IconAdjustments,
-  IconHelpCircle,
   IconArrowUpRight,
+  IconClock,
+  IconHelpCircle,
+  IconShield,
+  IconShieldCheck,
 } from "@tabler/icons-react";
+
 import { Badge } from "@ctrlplane/ui/badge";
 import { Button } from "@ctrlplane/ui/button";
 import {
@@ -44,7 +45,9 @@ type PolicySummaryCardProps = {
   workspaceSlug: string;
 };
 
-const PolicySummaryCard: React.FC<PolicySummaryCardProps & { data: { isActive: boolean; count: number } }> = ({ config, workspaceSlug, data }) => {
+const PolicySummaryCard: React.FC<
+  PolicySummaryCardProps & { data: { isActive: boolean; count: number } }
+> = ({ config, workspaceSlug, data }) => {
   const { isActive, count } = data;
   const Icon = config.icon;
 
@@ -76,20 +79,21 @@ const PolicySummaryCard: React.FC<PolicySummaryCardProps & { data: { isActive: b
           <div className="text-right font-medium">
             <Badge
               variant={isActive ? "default" : "secondary"}
-              className={isActive 
-                ? `${config.badgeConfig.activeColor} text-white` 
-                : "text-muted-foreground"
+              className={
+                isActive
+                  ? `${config.badgeConfig.activeColor} text-white`
+                  : "text-muted-foreground"
               }
             >
-              {isActive ? config.badgeConfig.activeText : config.badgeConfig.inactiveText}
+              {isActive
+                ? config.badgeConfig.activeText
+                : config.badgeConfig.inactiveText}
             </Badge>
           </div>
           <div className="flex items-center gap-2 text-neutral-400">
             Policies Count
           </div>
-          <div className="text-right font-medium text-neutral-100">
-            {count}
-          </div>
+          <div className="text-right font-medium text-neutral-100">{count}</div>
         </div>
       </div>
       <div className="mt-auto border-t bg-neutral-900/60 p-2 text-right">
@@ -114,10 +118,14 @@ type PolicyCardProps = {
   cardConfigs: PolicySummaryCardConfig[];
 };
 
-export const PolicyCard: React.FC<PolicyCardProps> = ({ policies, workspaceSlug, cardConfigs }) => {
+export const PolicyCard: React.FC<PolicyCardProps> = ({
+  policies,
+  workspaceSlug,
+  cardConfigs,
+}) => {
   return (
     <div className="grid grid-cols-1 gap-4 md:grid-cols-2 lg:grid-cols-2">
-      {cardConfigs.map(config => (
+      {cardConfigs.map((config) => (
         <PolicySummaryCard
           key={config.id}
           config={config}
@@ -135,7 +143,8 @@ export const policyCardConfigs: PolicySummaryCardConfig[] = [
     title: "Approval & Governance",
     icon: IconShieldCheck,
     iconColor: "text-blue-400",
-    tooltip: "Shows policies that require manual approvals or have governance rules for deployments to this resource.",
+    tooltip:
+      "Shows policies that require manual approvals or have governance rules for deployments to this resource.",
     badgeConfig: {
       activeText: "Yes",
       inactiveText: "No",
@@ -143,10 +152,11 @@ export const policyCardConfigs: PolicySummaryCardConfig[] = [
     },
     countLabel: "Approval Required",
     dataSelector: (policies: Policy[]) => {
-      const approvalPolicies = policies.filter(p => 
-        p.versionAnyApprovals != null ||
-        p.versionUserApprovals.length > 0 ||
-        p.versionRoleApprovals.length > 0
+      const approvalPolicies = policies.filter(
+        (p) =>
+          p.versionAnyApprovals != null ||
+          p.versionUserApprovals.length > 0 ||
+          p.versionRoleApprovals.length > 0,
       );
       return {
         isActive: approvalPolicies.length > 0,
@@ -159,7 +169,8 @@ export const policyCardConfigs: PolicySummaryCardConfig[] = [
     title: "Deny Windows",
     icon: IconClock,
     iconColor: "text-red-400",
-    tooltip: "Time-based restrictions that prevent deployments during specific periods, like maintenance windows or business hours.",
+    tooltip:
+      "Time-based restrictions that prevent deployments during specific periods, like maintenance windows or business hours.",
     badgeConfig: {
       activeText: "Active",
       inactiveText: "None",
@@ -167,7 +178,9 @@ export const policyCardConfigs: PolicySummaryCardConfig[] = [
     },
     countLabel: "Time Restrictions",
     dataSelector: (policies: Policy[]) => {
-      const denyWindowPolicies = policies.filter(p => p.denyWindows.length > 0);
+      const denyWindowPolicies = policies.filter(
+        (p) => p.denyWindows.length > 0,
+      );
       return {
         isActive: denyWindowPolicies.length > 0,
         count: denyWindowPolicies.length,
@@ -179,7 +192,8 @@ export const policyCardConfigs: PolicySummaryCardConfig[] = [
     title: "Version Conditions",
     icon: IconShield,
     iconColor: "text-purple-400",
-    tooltip: "Rules that control which deployment versions are allowed based on version criteria, tags, or other metadata.",
+    tooltip:
+      "Rules that control which deployment versions are allowed based on version criteria, tags, or other metadata.",
     badgeConfig: {
       activeText: "Active",
       inactiveText: "None",
@@ -187,7 +201,9 @@ export const policyCardConfigs: PolicySummaryCardConfig[] = [
     },
     countLabel: "Version Rules",
     dataSelector: (policies: Policy[]) => {
-      const versionConditionPolicies = policies.filter(p => p.deploymentVersionSelector != null);
+      const versionConditionPolicies = policies.filter(
+        (p) => p.deploymentVersionSelector != null,
+      );
       return {
         isActive: versionConditionPolicies.length > 0,
         count: versionConditionPolicies.length,
@@ -199,7 +215,8 @@ export const policyCardConfigs: PolicySummaryCardConfig[] = [
     title: "Concurrency Control",
     icon: IconAdjustments,
     iconColor: "text-yellow-400",
-    tooltip: "Limits on how many deployments can run simultaneously for this resource, helping to control system load and deployment conflicts.",
+    tooltip:
+      "Limits on how many deployments can run simultaneously for this resource, helping to control system load and deployment conflicts.",
     badgeConfig: {
       activeText: "Yes",
       inactiveText: "Unlimited",
@@ -207,7 +224,7 @@ export const policyCardConfigs: PolicySummaryCardConfig[] = [
     },
     countLabel: "Limits Configured",
     dataSelector: (policies: Policy[]) => {
-      const concurrencyPolicies = policies.filter(p => p.concurrency != null);
+      const concurrencyPolicies = policies.filter((p) => p.concurrency != null);
       return {
         isActive: concurrencyPolicies.length > 0,
         count: concurrencyPolicies.length,

--- a/apps/webservice/src/app/[workspaceSlug]/(app)/resources/(raw)/[resourceId]/policies/page.tsx
+++ b/apps/webservice/src/app/[workspaceSlug]/(app)/resources/(raw)/[resourceId]/policies/page.tsx
@@ -1,0 +1,174 @@
+import { notFound } from "next/navigation";
+import Link from "next/link";
+import {
+  IconInfoCircle,
+  IconShield,
+  IconTarget,
+  IconChevronRight,
+  
+} from "@tabler/icons-react";
+
+import { Badge } from "@ctrlplane/ui/badge";
+import { Card, CardContent, CardHeader, CardTitle } from "@ctrlplane/ui/card";
+import { Button } from "@ctrlplane/ui/button";
+
+
+import { api } from "~/trpc/server";
+import { urls } from "~/app/urls";
+import { PolicyCard, policyCardConfigs } from "./_components/PolicyCard";
+
+export default async function ResourcePoliciesPage(props: {
+  params: Promise<{ workspaceSlug: string; resourceId: string }>;
+}) {
+  const { workspaceSlug, resourceId } = await props.params;
+
+  const resource = await api.resource.byId(resourceId);
+  if (resource == null) notFound();
+
+  const policies = await api.policy.byResourceId({ resourceId });
+
+  return (
+    <div className="space-y-8">
+      <Card>
+        <CardHeader>
+          <CardTitle className="flex items-center gap-2">
+            <IconTarget className="h-5 w-5" />
+            Resource Policies
+          </CardTitle>
+          <p className="text-sm text-muted-foreground">
+            Policy rules and governance controls that apply to resource "{resource.name}"
+          </p>
+        </CardHeader>
+        <CardContent>
+          {policies.length === 0 ? (
+            <div className="text-center py-8">
+              <IconInfoCircle className="h-12 w-12 text-muted-foreground mx-auto mb-4" />
+              <h3 className="text-lg font-medium text-foreground mb-2">
+                No Matching Policies
+              </h3>
+              <p className="text-muted-foreground max-w-md mx-auto">
+                This resource is not currently targeted by any policies. Policies control deployment behavior, approvals, and release gates.
+              </p>
+              <div className="mt-6">
+                <Button asChild>
+                  <Link href={urls.workspace(workspaceSlug).policies().baseUrl()}>
+                    <IconShield className="h-4 w-4 mr-2" />
+                    View All Policies
+                  </Link>
+                </Button>
+              </div>
+            </div>
+          ) : (
+            <div className="space-y-6">
+              <div className="flex items-center gap-2 text-sm text-muted-foreground">
+                <IconInfoCircle className="h-4 w-4" />
+                <span>
+                  Found {policies.length} {policies.length === 1 ? 'policy' : 'policies'} that {policies.length === 1 ? 'applies' : 'apply'} to this resource
+                </span>
+              </div>
+              
+              <PolicyCard policies={policies} workspaceSlug={workspaceSlug} cardConfigs={policyCardConfigs} />
+              
+              {/* Individual Policy List */}
+              <div className="space-y-4">
+                <h3 className="text-lg font-medium">Individual Policies</h3>
+                <div className="space-y-3">
+                  {policies.map((policy) => {
+                    const hasDenyWindows = policy.denyWindows.length > 0;
+                    const hasApprovals =
+                      policy.versionAnyApprovals != null ||
+                      policy.versionUserApprovals.length > 0 ||
+                      policy.versionRoleApprovals.length > 0;
+                    const hasDeploymentVersionSelector = policy.deploymentVersionSelector != null;
+                    const hasConcurrency = policy.concurrency != null;
+
+                    return (
+                      <Card key={policy.id} className="hover:shadow-md transition-shadow">
+                        <CardContent className="p-4">
+                          <div className="flex items-start justify-between">
+                            <div className="flex-1 min-w-0">
+                              <div className="flex items-center gap-3 mb-2">
+                                <IconShield className="h-5 w-5 text-blue-500 flex-shrink-0" />
+                                <div className="flex items-center gap-2 min-w-0">
+                                  <Link 
+                                    href={urls.workspace(workspaceSlug).policies().byId(policy.id)}
+                                    className="font-medium text-foreground hover:text-blue-600 transition-colors truncate"
+                                  >
+                                    {policy.name}
+                                  </Link>
+                                  <div className="flex items-center gap-2 flex-shrink-0">
+                                    <Badge variant={policy.enabled ? "default" : "secondary"}>
+                                      {policy.enabled ? "Enabled" : "Disabled"}
+                                    </Badge>
+                                    <Badge variant="outline">Priority: {policy.priority}</Badge>
+                                  </div>
+                                </div>
+                              </div>
+                              
+                              {policy.description && (
+                                <p className="text-sm text-muted-foreground mb-3 line-clamp-2">
+                                  {policy.description}
+                                </p>
+                              )}
+
+                              <div className="flex flex-wrap gap-2">
+                                <Badge
+                                  variant={hasApprovals ? "default" : "outline"}
+                                  className={hasApprovals 
+                                    ? "bg-blue-500 text-white border-blue-500" 
+                                    : "border-muted-foreground text-muted-foreground"
+                                  }
+                                >
+                                  Approval Gate
+                                </Badge>
+                                <Badge
+                                  variant={hasDenyWindows ? "default" : "outline"}
+                                  className={hasDenyWindows 
+                                    ? "bg-red-500 text-white border-red-500" 
+                                    : "border-muted-foreground text-muted-foreground"
+                                  }
+                                >
+                                  Deny Window
+                                </Badge>
+                                <Badge
+                                  variant={hasDeploymentVersionSelector ? "default" : "outline"}
+                                  className={hasDeploymentVersionSelector 
+                                    ? "bg-purple-500 text-white border-purple-500" 
+                                    : "border-muted-foreground text-muted-foreground"
+                                  }
+                                >
+                                  Version Conditions
+                                </Badge>
+                                <Badge
+                                  variant={hasConcurrency ? "default" : "outline"}
+                                  className={hasConcurrency 
+                                    ? "bg-yellow-500 text-white border-yellow-500" 
+                                    : "border-muted-foreground text-muted-foreground"
+                                  }
+                                >
+                                  Concurrency
+                                </Badge>
+                              </div>
+                            </div>
+                            
+                            <div className="flex-shrink-0 ml-4">
+                              <Button variant="ghost" size="sm" asChild>
+                                <Link href={urls.workspace(workspaceSlug).policies().byId(policy.id)}>
+                                  <IconChevronRight className="h-4 w-4" />
+                                </Link>
+                              </Button>
+                            </div>
+                          </div>
+                        </CardContent>
+                      </Card>
+                    );
+                  })}
+                </div>
+              </div>
+            </div>
+          )}
+        </CardContent>
+      </Card>
+    </div>
+  );
+}

--- a/apps/webservice/src/app/[workspaceSlug]/(app)/resources/(raw)/[resourceId]/policies/page.tsx
+++ b/apps/webservice/src/app/[workspaceSlug]/(app)/resources/(raw)/[resourceId]/policies/page.tsx
@@ -1,20 +1,17 @@
-import { notFound } from "next/navigation";
 import Link from "next/link";
+import { notFound } from "next/navigation";
 import {
+  IconChevronRight,
   IconInfoCircle,
   IconShield,
-  IconTarget,
-  IconChevronRight,
-  
 } from "@tabler/icons-react";
 
 import { Badge } from "@ctrlplane/ui/badge";
-import { Card, CardContent, CardHeader, CardTitle } from "@ctrlplane/ui/card";
 import { Button } from "@ctrlplane/ui/button";
+import { Card, CardContent } from "@ctrlplane/ui/card";
 
-
-import { api } from "~/trpc/server";
 import { urls } from "~/app/urls";
+import { api } from "~/trpc/server";
 import { PolicyCard, policyCardConfigs } from "./_components/PolicyCard";
 
 export default async function ResourcePoliciesPage(props: {
@@ -32,23 +29,25 @@ export default async function ResourcePoliciesPage(props: {
       <div className="space-y-2">
         <div className="text-sm">Policies</div>
         <p className="text-xs text-muted-foreground">
-          Policy rules and governance controls that apply to resource "{resource.name}"
+          Policy rules and governance controls that apply to resource "
+          {resource.name}"
         </p>
       </div>
 
       {policies.length === 0 ? (
-        <div className="text-center py-8">
-          <IconInfoCircle className="h-12 w-12 text-muted-foreground mx-auto mb-4" />
-          <h3 className="text-lg font-medium text-foreground mb-2">
+        <div className="py-8 text-center">
+          <IconInfoCircle className="mx-auto mb-4 h-12 w-12 text-muted-foreground" />
+          <h3 className="mb-2 text-lg font-medium text-foreground">
             No Matching Policies
           </h3>
-          <p className="text-muted-foreground max-w-md mx-auto">
-            This resource is not currently targeted by any policies. Policies control deployment behavior, approvals, and release gates.
+          <p className="mx-auto max-w-md text-muted-foreground">
+            This resource is not currently targeted by any policies. Policies
+            control deployment behavior, approvals, and release gates.
           </p>
           <div className="mt-6">
             <Button asChild>
               <Link href={urls.workspace(workspaceSlug).policies().baseUrl()}>
-                <IconShield className="h-4 w-4 mr-2" />
+                <IconShield className="mr-2 h-4 w-4" />
                 View All Policies
               </Link>
             </Button>
@@ -59,105 +58,137 @@ export default async function ResourcePoliciesPage(props: {
           <div className="flex items-center gap-2 text-xs text-muted-foreground">
             <IconInfoCircle className="h-4 w-4" />
             <span>
-              Found {policies.length} {policies.length === 1 ? 'policy' : 'policies'} that {policies.length === 1 ? 'applies' : 'apply'} to this resource
+              Found {policies.length}{" "}
+              {policies.length === 1 ? "policy" : "policies"} that{" "}
+              {policies.length === 1 ? "applies" : "apply"} to this resource
             </span>
           </div>
-          
-          <PolicyCard policies={policies} workspaceSlug={workspaceSlug} cardConfigs={policyCardConfigs} />
-          
+
+          <PolicyCard
+            policies={policies}
+            workspaceSlug={workspaceSlug}
+            cardConfigs={policyCardConfigs}
+          />
+
           <div>
             <div className="mb-2 text-sm">Individual Policies</div>
             <div className="space-y-3">
               {policies.map((policy) => {
-                    const hasDenyWindows = policy.denyWindows.length > 0;
-                    const hasApprovals =
-                      policy.versionAnyApprovals != null ||
-                      policy.versionUserApprovals.length > 0 ||
-                      policy.versionRoleApprovals.length > 0;
-                    const hasDeploymentVersionSelector = policy.deploymentVersionSelector != null;
-                    const hasConcurrency = policy.concurrency != null;
+                const hasDenyWindows = policy.denyWindows.length > 0;
+                const hasApprovals =
+                  policy.versionAnyApprovals != null ||
+                  policy.versionUserApprovals.length > 0 ||
+                  policy.versionRoleApprovals.length > 0;
+                const hasDeploymentVersionSelector =
+                  policy.deploymentVersionSelector != null;
+                const hasConcurrency = policy.concurrency != null;
 
-                    return (
-                      <Card key={policy.id} className="hover:shadow-md transition-shadow">
-                        <CardContent className="p-4">
-                          <div className="flex items-start justify-between">
-                            <div className="flex-1 min-w-0">
-                              <div className="flex items-center gap-3 mb-2">
-                                <IconShield className="h-5 w-5 text-blue-500 flex-shrink-0" />
-                                <div className="flex items-center gap-2 min-w-0">
-                                  <Link 
-                                    href={urls.workspace(workspaceSlug).policies().byId(policy.id)}
-                                    className="font-medium text-foreground hover:text-blue-600 transition-colors truncate"
-                                  >
-                                    {policy.name}
-                                  </Link>
-                                  <div className="flex items-center gap-2 flex-shrink-0">
-                                    <Badge variant={policy.enabled ? "default" : "secondary"}>
-                                      {policy.enabled ? "Enabled" : "Disabled"}
-                                    </Badge>
-                                    <Badge variant="outline">Priority: {policy.priority}</Badge>
-                                  </div>
-                                </div>
-                              </div>
-                              
-                              {policy.description && (
-                                <p className="text-sm text-muted-foreground mb-3 line-clamp-2">
-                                  {policy.description}
-                                </p>
-                              )}
-
-                              <div className="flex flex-wrap gap-2">
+                return (
+                  <Card
+                    key={policy.id}
+                    className="transition-shadow hover:shadow-md"
+                  >
+                    <CardContent className="p-4">
+                      <div className="flex items-start justify-between">
+                        <div className="min-w-0 flex-1">
+                          <div className="mb-2 flex items-center gap-3">
+                            <IconShield className="h-5 w-5 flex-shrink-0 text-blue-500" />
+                            <div className="flex min-w-0 items-center gap-2">
+                              <Link
+                                href={urls
+                                  .workspace(workspaceSlug)
+                                  .policies()
+                                  .byId(policy.id)}
+                                className="truncate font-medium text-foreground transition-colors hover:text-blue-600"
+                              >
+                                {policy.name}
+                              </Link>
+                              <div className="flex flex-shrink-0 items-center gap-2">
                                 <Badge
-                                  variant={hasApprovals ? "default" : "outline"}
-                                  className={hasApprovals 
-                                    ? "bg-blue-500 text-white border-blue-500" 
-                                    : "border-muted-foreground text-muted-foreground"
+                                  variant={
+                                    policy.enabled ? "default" : "secondary"
                                   }
                                 >
-                                  Approval Gate
+                                  {policy.enabled ? "Enabled" : "Disabled"}
                                 </Badge>
-                                <Badge
-                                  variant={hasDenyWindows ? "default" : "outline"}
-                                  className={hasDenyWindows 
-                                    ? "bg-red-500 text-white border-red-500" 
-                                    : "border-muted-foreground text-muted-foreground"
-                                  }
-                                >
-                                  Deny Window
-                                </Badge>
-                                <Badge
-                                  variant={hasDeploymentVersionSelector ? "default" : "outline"}
-                                  className={hasDeploymentVersionSelector 
-                                    ? "bg-purple-500 text-white border-purple-500" 
-                                    : "border-muted-foreground text-muted-foreground"
-                                  }
-                                >
-                                  Version Conditions
-                                </Badge>
-                                <Badge
-                                  variant={hasConcurrency ? "default" : "outline"}
-                                  className={hasConcurrency 
-                                    ? "bg-yellow-500 text-white border-yellow-500" 
-                                    : "border-muted-foreground text-muted-foreground"
-                                  }
-                                >
-                                  Concurrency
+                                <Badge variant="outline">
+                                  Priority: {policy.priority}
                                 </Badge>
                               </div>
-                            </div>
-                            
-                            <div className="flex-shrink-0 ml-4">
-                              <Button variant="ghost" size="sm" asChild>
-                                <Link href={urls.workspace(workspaceSlug).policies().byId(policy.id)}>
-                                  <IconChevronRight className="h-4 w-4" />
-                                </Link>
-                              </Button>
                             </div>
                           </div>
-                        </CardContent>
-                      </Card>
-                    );
-                  })}
+
+                          {policy.description && (
+                            <p className="mb-3 line-clamp-2 text-sm text-muted-foreground">
+                              {policy.description}
+                            </p>
+                          )}
+
+                          <div className="flex flex-wrap gap-2">
+                            <Badge
+                              variant={hasApprovals ? "default" : "outline"}
+                              className={
+                                hasApprovals
+                                  ? "border-blue-500 bg-blue-500 text-white"
+                                  : "border-muted-foreground text-muted-foreground"
+                              }
+                            >
+                              Approval Gate
+                            </Badge>
+                            <Badge
+                              variant={hasDenyWindows ? "default" : "outline"}
+                              className={
+                                hasDenyWindows
+                                  ? "border-red-500 bg-red-500 text-white"
+                                  : "border-muted-foreground text-muted-foreground"
+                              }
+                            >
+                              Deny Window
+                            </Badge>
+                            <Badge
+                              variant={
+                                hasDeploymentVersionSelector
+                                  ? "default"
+                                  : "outline"
+                              }
+                              className={
+                                hasDeploymentVersionSelector
+                                  ? "border-purple-500 bg-purple-500 text-white"
+                                  : "border-muted-foreground text-muted-foreground"
+                              }
+                            >
+                              Version Conditions
+                            </Badge>
+                            <Badge
+                              variant={hasConcurrency ? "default" : "outline"}
+                              className={
+                                hasConcurrency
+                                  ? "border-yellow-500 bg-yellow-500 text-white"
+                                  : "border-muted-foreground text-muted-foreground"
+                              }
+                            >
+                              Concurrency
+                            </Badge>
+                          </div>
+                        </div>
+
+                        <div className="ml-4 flex-shrink-0">
+                          <Button variant="ghost" size="sm" asChild>
+                            <Link
+                              href={urls
+                                .workspace(workspaceSlug)
+                                .policies()
+                                .byId(policy.id)}
+                            >
+                              <IconChevronRight className="h-4 w-4" />
+                            </Link>
+                          </Button>
+                        </div>
+                      </div>
+                    </CardContent>
+                  </Card>
+                );
+              })}
             </div>
           </div>
         </>

--- a/apps/webservice/src/app/[workspaceSlug]/(app)/resources/(raw)/[resourceId]/policies/page.tsx
+++ b/apps/webservice/src/app/[workspaceSlug]/(app)/resources/(raw)/[resourceId]/policies/page.tsx
@@ -28,52 +28,47 @@ export default async function ResourcePoliciesPage(props: {
   const policies = await api.policy.byResourceId({ resourceId });
 
   return (
-    <div className="space-y-8">
-      <Card>
-        <CardHeader>
-          <CardTitle className="flex items-center gap-2">
-            <IconTarget className="h-5 w-5" />
-            Resource Policies
-          </CardTitle>
-          <p className="text-sm text-muted-foreground">
-            Policy rules and governance controls that apply to resource "{resource.name}"
+    <div className="container space-y-4 p-8">
+      <div className="space-y-2">
+        <div className="text-sm">Policies</div>
+        <p className="text-xs text-muted-foreground">
+          Policy rules and governance controls that apply to resource "{resource.name}"
+        </p>
+      </div>
+
+      {policies.length === 0 ? (
+        <div className="text-center py-8">
+          <IconInfoCircle className="h-12 w-12 text-muted-foreground mx-auto mb-4" />
+          <h3 className="text-lg font-medium text-foreground mb-2">
+            No Matching Policies
+          </h3>
+          <p className="text-muted-foreground max-w-md mx-auto">
+            This resource is not currently targeted by any policies. Policies control deployment behavior, approvals, and release gates.
           </p>
-        </CardHeader>
-        <CardContent>
-          {policies.length === 0 ? (
-            <div className="text-center py-8">
-              <IconInfoCircle className="h-12 w-12 text-muted-foreground mx-auto mb-4" />
-              <h3 className="text-lg font-medium text-foreground mb-2">
-                No Matching Policies
-              </h3>
-              <p className="text-muted-foreground max-w-md mx-auto">
-                This resource is not currently targeted by any policies. Policies control deployment behavior, approvals, and release gates.
-              </p>
-              <div className="mt-6">
-                <Button asChild>
-                  <Link href={urls.workspace(workspaceSlug).policies().baseUrl()}>
-                    <IconShield className="h-4 w-4 mr-2" />
-                    View All Policies
-                  </Link>
-                </Button>
-              </div>
-            </div>
-          ) : (
-            <div className="space-y-6">
-              <div className="flex items-center gap-2 text-sm text-muted-foreground">
-                <IconInfoCircle className="h-4 w-4" />
-                <span>
-                  Found {policies.length} {policies.length === 1 ? 'policy' : 'policies'} that {policies.length === 1 ? 'applies' : 'apply'} to this resource
-                </span>
-              </div>
-              
-              <PolicyCard policies={policies} workspaceSlug={workspaceSlug} cardConfigs={policyCardConfigs} />
-              
-              {/* Individual Policy List */}
-              <div className="space-y-4">
-                <h3 className="text-lg font-medium">Individual Policies</h3>
-                <div className="space-y-3">
-                  {policies.map((policy) => {
+          <div className="mt-6">
+            <Button asChild>
+              <Link href={urls.workspace(workspaceSlug).policies().baseUrl()}>
+                <IconShield className="h-4 w-4 mr-2" />
+                View All Policies
+              </Link>
+            </Button>
+          </div>
+        </div>
+      ) : (
+        <>
+          <div className="flex items-center gap-2 text-xs text-muted-foreground">
+            <IconInfoCircle className="h-4 w-4" />
+            <span>
+              Found {policies.length} {policies.length === 1 ? 'policy' : 'policies'} that {policies.length === 1 ? 'applies' : 'apply'} to this resource
+            </span>
+          </div>
+          
+          <PolicyCard policies={policies} workspaceSlug={workspaceSlug} cardConfigs={policyCardConfigs} />
+          
+          <div>
+            <div className="mb-2 text-sm">Individual Policies</div>
+            <div className="space-y-3">
+              {policies.map((policy) => {
                     const hasDenyWindows = policy.denyWindows.length > 0;
                     const hasApprovals =
                       policy.versionAnyApprovals != null ||
@@ -163,12 +158,10 @@ export default async function ResourcePoliciesPage(props: {
                       </Card>
                     );
                   })}
-                </div>
-              </div>
             </div>
-          )}
-        </CardContent>
-      </Card>
+          </div>
+        </>
+      )}
     </div>
   );
 }

--- a/apps/webservice/src/app/urls.ts
+++ b/apps/webservice/src/app/urls.ts
@@ -123,6 +123,7 @@ const resource = (workspaceSlug: string, resourceId: string) => {
     variables: () => buildUrl(...base, "variables"),
     properties: () => buildUrl(...base, "properties"),
     visualize: () => buildUrl(...base, "visualize"),
+    policies: () => buildUrl(...base, "policies"),
   };
 };
 

--- a/github/get-job-inputs/index.js
+++ b/github/get-job-inputs/index.js
@@ -27992,129 +27992,130 @@ function removeTrailingSlash(url) {
 }
 
 ;// CONCATENATED MODULE: ../../packages/node-sdk/dist/index.js
-// src/index.ts
 
 function dist_createClient(options) {
-  return createClient({
-    baseUrl: options.baseUrl ?? "https://app.ctrlplane.com",
-    ...options,
-    fetch: (input) => {
-      const url = new URL(input.url);
-      url.pathname = `/api${url.pathname}`;
-      return fetch(new Request(url.toString(), input));
-    },
-    headers: { "x-api-key": options?.apiKey }
-  });
+    return createClient({
+        baseUrl: options.baseUrl ?? "https://app.ctrlplane.com",
+        ...options,
+        fetch: (input) => {
+            const url = new URL(input.url);
+            url.pathname = `/api${url.pathname}`;
+            return fetch(new Request(url.toString(), input));
+        },
+        headers: { "x-api-key": options?.apiKey },
+    });
 }
-var ResourceProvider = class {
-  /**
-   * Creates a new TargetProvider instance
-   * @param options - Configuration options
-   * @param options.workspaceId - ID of the workspace
-   * @param options.name - Name of the target provider
-   * @param client - API client instance
-   */
-  constructor(options, client) {
-    this.options = options;
-    this.client = client;
-  }
-  provider = null;
-  /**
-   * Gets the resource provider details, caching the result
-   * @returns The resource provider details
-   */
-  async get() {
-    if (this.provider != null) {
-      return this.provider;
+/**
+ * Class for managing target providers in the Ctrlplane API
+ */
+class ResourceProvider {
+    options;
+    client;
+    /**
+     * Creates a new TargetProvider instance
+     * @param options - Configuration options
+     * @param options.workspaceId - ID of the workspace
+     * @param options.name - Name of the target provider
+     * @param client - API client instance
+     */
+    constructor(options, client) {
+        this.options = options;
+        this.client = client;
     }
-    const { data } = await this.client.GET(
-      "/v1/workspaces/{workspaceId}/resource-providers/name/{name}",
-      { params: { path: this.options } }
-    );
-    this.provider = data;
-    return this.provider;
-  }
-  /**
-   * Sets the resources for this provider
-   * @param resources - Array of resources to set
-   * @returns The API response
-   * @throws Error if the scanner is not found
-   */
-  async set(resources) {
-    const scanner = await this.get();
-    if (scanner == null) throw new Error("Scanner not found");
-    return this.client.PATCH("/v1/resource-providers/{providerId}/set", {
-      params: { path: { providerId: scanner.id } },
-      body: { resources: uniqBy(resources, (t) => t.identifier) }
-    });
-  }
-};
-var JobAgent = class {
-  constructor(options, client) {
-    this.options = options;
-    this.client = client;
-  }
-  agent = null;
-  async get() {
-    if (this.agent != null) {
-      return this.agent;
+    provider = null;
+    /**
+     * Gets the resource provider details, caching the result
+     * @returns The resource provider details
+     */
+    async get() {
+        if (this.provider != null) {
+            return this.provider;
+        }
+        const { data } = await this.client.GET("/v1/workspaces/{workspaceId}/resource-providers/name/{name}", { params: { path: this.options } });
+        this.provider = data;
+        return this.provider;
     }
-    const { data } = await this.client.PATCH("/v1/job-agents/name", {
-      body: this.options
-    });
-    this.agent = data;
-    return this.agent;
-  }
-  async next() {
-    const { data } = await this.client.GET(
-      "/v1/job-agents/{agentId}/queue/next",
-      { params: { path: { agentId: this.agent.id } } }
-    );
-    return data.jobs.map((job) => new Job(job, this.client)) ?? [];
-  }
-  async running() {
-    const { data } = await this.client.GET(
-      "/v1/job-agents/{agentId}/jobs/running",
-      { params: { path: { agentId: this.agent.id } } }
-    );
-    return data.jobs.map((job) => new Job(job, this.client)) ?? [];
-  }
-};
-var Job = class {
-  constructor(job, client) {
-    this.job = job;
-    this.client = client;
-  }
-  acknowledge() {
-    return this.client.POST("/v1/jobs/{jobId}/acknowledge", {
-      params: { path: { jobId: this.job.id } }
-    });
-  }
-  get() {
-    return this.client.GET("/v1/jobs/{jobId}", {
-      params: { path: { jobId: this.job.id } }
-    }).then(({ data }) => data);
-  }
-  update(update) {
-    return this.client.PATCH("/v1/jobs/{jobId}", {
-      params: { path: { jobId: this.job.id } },
-      body: update
-    });
-  }
-};
+    /**
+     * Sets the resources for this provider
+     * @param resources - Array of resources to set
+     * @returns The API response
+     * @throws Error if the scanner is not found
+     */
+    async set(resources) {
+        const scanner = await this.get();
+        if (scanner == null)
+            throw new Error("Scanner not found");
+        return this.client.PATCH("/v1/resource-providers/{providerId}/set", {
+            params: { path: { providerId: scanner.id } },
+            body: { resources: uniqBy(resources, (t) => t.identifier) },
+        });
+    }
+}
+class JobAgent {
+    options;
+    client;
+    constructor(options, client) {
+        this.options = options;
+        this.client = client;
+    }
+    agent = null;
+    async get() {
+        if (this.agent != null) {
+            return this.agent;
+        }
+        const { data } = await this.client.PATCH("/v1/job-agents/name", {
+            body: this.options,
+        });
+        this.agent = data;
+        return this.agent;
+    }
+    async next() {
+        const { data } = await this.client.GET("/v1/job-agents/{agentId}/queue/next", { params: { path: { agentId: this.agent.id } } });
+        return data.jobs.map((job) => new Job(job, this.client)) ?? [];
+    }
+    async running() {
+        const { data } = await this.client.GET("/v1/job-agents/{agentId}/jobs/running", { params: { path: { agentId: this.agent.id } } });
+        return data.jobs.map((job) => new Job(job, this.client)) ?? [];
+    }
+}
+class Job {
+    job;
+    client;
+    constructor(job, client) {
+        this.job = job;
+        this.client = client;
+    }
+    acknowledge() {
+        return this.client.POST("/v1/jobs/{jobId}/acknowledge", {
+            params: { path: { jobId: this.job.id } },
+        });
+    }
+    get() {
+        return this.client
+            .GET("/v1/jobs/{jobId}", {
+            params: { path: { jobId: this.job.id } },
+        })
+            .then(({ data }) => data);
+    }
+    update(update) {
+        return this.client.PATCH("/v1/jobs/{jobId}", {
+            params: { path: { jobId: this.job.id } },
+            body: update,
+        });
+    }
+}
 function uniqBy(arr, iteratee) {
-  const seen = /* @__PURE__ */ new Map();
-  return arr.filter((item) => {
-    const key = iteratee(item);
-    if (seen.has(key)) {
-      return false;
-    }
-    seen.set(key, true);
-    return true;
-  });
+    const seen = new Map();
+    return arr.filter((item) => {
+        const key = iteratee(item);
+        if (seen.has(key)) {
+            return false;
+        }
+        seen.set(key, true);
+        return true;
+    });
 }
 
-//# sourceMappingURL=index.js.map
 ;// CONCATENATED MODULE: ./src/sdk.ts
 
 
@@ -28169,7 +28170,7 @@ async function run() {
             core.error(`Invalid Job data`);
             return;
         }
-        const { variables, resource, version, environment, runbook, deployment, approval, } = data;
+        const { variables, resource, release, version, environment, runbook, deployment, approval, } = data;
         setOutputsRecursively(null, {
             base: { url: baseUrl },
             variable: variables,

--- a/github/get-job-inputs/index.js
+++ b/github/get-job-inputs/index.js
@@ -27992,130 +27992,129 @@ function removeTrailingSlash(url) {
 }
 
 ;// CONCATENATED MODULE: ../../packages/node-sdk/dist/index.js
+// src/index.ts
 
 function dist_createClient(options) {
-    return createClient({
-        baseUrl: options.baseUrl ?? "https://app.ctrlplane.com",
-        ...options,
-        fetch: (input) => {
-            const url = new URL(input.url);
-            url.pathname = `/api${url.pathname}`;
-            return fetch(new Request(url.toString(), input));
-        },
-        headers: { "x-api-key": options?.apiKey },
+  return createClient({
+    baseUrl: options.baseUrl ?? "https://app.ctrlplane.com",
+    ...options,
+    fetch: (input) => {
+      const url = new URL(input.url);
+      url.pathname = `/api${url.pathname}`;
+      return fetch(new Request(url.toString(), input));
+    },
+    headers: { "x-api-key": options?.apiKey }
+  });
+}
+var ResourceProvider = class {
+  /**
+   * Creates a new TargetProvider instance
+   * @param options - Configuration options
+   * @param options.workspaceId - ID of the workspace
+   * @param options.name - Name of the target provider
+   * @param client - API client instance
+   */
+  constructor(options, client) {
+    this.options = options;
+    this.client = client;
+  }
+  provider = null;
+  /**
+   * Gets the resource provider details, caching the result
+   * @returns The resource provider details
+   */
+  async get() {
+    if (this.provider != null) {
+      return this.provider;
+    }
+    const { data } = await this.client.GET(
+      "/v1/workspaces/{workspaceId}/resource-providers/name/{name}",
+      { params: { path: this.options } }
+    );
+    this.provider = data;
+    return this.provider;
+  }
+  /**
+   * Sets the resources for this provider
+   * @param resources - Array of resources to set
+   * @returns The API response
+   * @throws Error if the scanner is not found
+   */
+  async set(resources) {
+    const scanner = await this.get();
+    if (scanner == null) throw new Error("Scanner not found");
+    return this.client.PATCH("/v1/resource-providers/{providerId}/set", {
+      params: { path: { providerId: scanner.id } },
+      body: { resources: uniqBy(resources, (t) => t.identifier) }
     });
-}
-/**
- * Class for managing target providers in the Ctrlplane API
- */
-class ResourceProvider {
-    options;
-    client;
-    /**
-     * Creates a new TargetProvider instance
-     * @param options - Configuration options
-     * @param options.workspaceId - ID of the workspace
-     * @param options.name - Name of the target provider
-     * @param client - API client instance
-     */
-    constructor(options, client) {
-        this.options = options;
-        this.client = client;
+  }
+};
+var JobAgent = class {
+  constructor(options, client) {
+    this.options = options;
+    this.client = client;
+  }
+  agent = null;
+  async get() {
+    if (this.agent != null) {
+      return this.agent;
     }
-    provider = null;
-    /**
-     * Gets the resource provider details, caching the result
-     * @returns The resource provider details
-     */
-    async get() {
-        if (this.provider != null) {
-            return this.provider;
-        }
-        const { data } = await this.client.GET("/v1/workspaces/{workspaceId}/resource-providers/name/{name}", { params: { path: this.options } });
-        this.provider = data;
-        return this.provider;
-    }
-    /**
-     * Sets the resources for this provider
-     * @param resources - Array of resources to set
-     * @returns The API response
-     * @throws Error if the scanner is not found
-     */
-    async set(resources) {
-        const scanner = await this.get();
-        if (scanner == null)
-            throw new Error("Scanner not found");
-        return this.client.PATCH("/v1/resource-providers/{providerId}/set", {
-            params: { path: { providerId: scanner.id } },
-            body: { resources: uniqBy(resources, (t) => t.identifier) },
-        });
-    }
-}
-class JobAgent {
-    options;
-    client;
-    constructor(options, client) {
-        this.options = options;
-        this.client = client;
-    }
-    agent = null;
-    async get() {
-        if (this.agent != null) {
-            return this.agent;
-        }
-        const { data } = await this.client.PATCH("/v1/job-agents/name", {
-            body: this.options,
-        });
-        this.agent = data;
-        return this.agent;
-    }
-    async next() {
-        const { data } = await this.client.GET("/v1/job-agents/{agentId}/queue/next", { params: { path: { agentId: this.agent.id } } });
-        return data.jobs.map((job) => new Job(job, this.client)) ?? [];
-    }
-    async running() {
-        const { data } = await this.client.GET("/v1/job-agents/{agentId}/jobs/running", { params: { path: { agentId: this.agent.id } } });
-        return data.jobs.map((job) => new Job(job, this.client)) ?? [];
-    }
-}
-class Job {
-    job;
-    client;
-    constructor(job, client) {
-        this.job = job;
-        this.client = client;
-    }
-    acknowledge() {
-        return this.client.POST("/v1/jobs/{jobId}/acknowledge", {
-            params: { path: { jobId: this.job.id } },
-        });
-    }
-    get() {
-        return this.client
-            .GET("/v1/jobs/{jobId}", {
-            params: { path: { jobId: this.job.id } },
-        })
-            .then(({ data }) => data);
-    }
-    update(update) {
-        return this.client.PATCH("/v1/jobs/{jobId}", {
-            params: { path: { jobId: this.job.id } },
-            body: update,
-        });
-    }
-}
+    const { data } = await this.client.PATCH("/v1/job-agents/name", {
+      body: this.options
+    });
+    this.agent = data;
+    return this.agent;
+  }
+  async next() {
+    const { data } = await this.client.GET(
+      "/v1/job-agents/{agentId}/queue/next",
+      { params: { path: { agentId: this.agent.id } } }
+    );
+    return data.jobs.map((job) => new Job(job, this.client)) ?? [];
+  }
+  async running() {
+    const { data } = await this.client.GET(
+      "/v1/job-agents/{agentId}/jobs/running",
+      { params: { path: { agentId: this.agent.id } } }
+    );
+    return data.jobs.map((job) => new Job(job, this.client)) ?? [];
+  }
+};
+var Job = class {
+  constructor(job, client) {
+    this.job = job;
+    this.client = client;
+  }
+  acknowledge() {
+    return this.client.POST("/v1/jobs/{jobId}/acknowledge", {
+      params: { path: { jobId: this.job.id } }
+    });
+  }
+  get() {
+    return this.client.GET("/v1/jobs/{jobId}", {
+      params: { path: { jobId: this.job.id } }
+    }).then(({ data }) => data);
+  }
+  update(update) {
+    return this.client.PATCH("/v1/jobs/{jobId}", {
+      params: { path: { jobId: this.job.id } },
+      body: update
+    });
+  }
+};
 function uniqBy(arr, iteratee) {
-    const seen = new Map();
-    return arr.filter((item) => {
-        const key = iteratee(item);
-        if (seen.has(key)) {
-            return false;
-        }
-        seen.set(key, true);
-        return true;
-    });
+  const seen = /* @__PURE__ */ new Map();
+  return arr.filter((item) => {
+    const key = iteratee(item);
+    if (seen.has(key)) {
+      return false;
+    }
+    seen.set(key, true);
+    return true;
+  });
 }
 
+//# sourceMappingURL=index.js.map
 ;// CONCATENATED MODULE: ./src/sdk.ts
 
 
@@ -28170,7 +28169,7 @@ async function run() {
             core.error(`Invalid Job data`);
             return;
         }
-        const { variables, resource, release, version, environment, runbook, deployment, approval, } = data;
+        const { variables, resource, version, environment, runbook, deployment, approval, } = data;
         setOutputsRecursively(null, {
             base: { url: baseUrl },
             variable: variables,

--- a/packages/api/src/router/policy/router.ts
+++ b/packages/api/src/router/policy/router.ts
@@ -1,7 +1,16 @@
 import _ from "lodash";
 import { z } from "zod";
 
-import { and, asc, desc, eq, ilike, isNull, takeFirst, inArray } from "@ctrlplane/db";
+import {
+  and,
+  asc,
+  desc,
+  eq,
+  ilike,
+  inArray,
+  isNull,
+  takeFirst,
+} from "@ctrlplane/db";
 import { createPolicy, policy, updatePolicy } from "@ctrlplane/db/schema";
 import * as schema from "@ctrlplane/db/schema";
 import { Channel, getQueue } from "@ctrlplane/events";
@@ -99,7 +108,10 @@ export const policyRouter = createTRPCRouter({
     )
     .query(async ({ ctx, input }) => {
       const resource = await ctx.db.query.resource.findFirst({
-        where: and(eq(schema.resource.id, input.resourceId), isNull(schema.resource.deletedAt)),
+        where: and(
+          eq(schema.resource.id, input.resourceId),
+          isNull(schema.resource.deletedAt),
+        ),
       });
 
       if (!resource) return [];
@@ -111,21 +123,27 @@ export const policyRouter = createTRPCRouter({
         .from(schema.policy)
         .innerJoin(
           schema.policyTarget,
-          eq(schema.policy.id, schema.policyTarget.policyId)
+          eq(schema.policy.id, schema.policyTarget.policyId),
         )
         .innerJoin(
           schema.computedPolicyTargetReleaseTarget,
-          eq(schema.policyTarget.id, schema.computedPolicyTargetReleaseTarget.policyTargetId)
+          eq(
+            schema.policyTarget.id,
+            schema.computedPolicyTargetReleaseTarget.policyTargetId,
+          ),
         )
         .innerJoin(
           schema.releaseTarget,
-          eq(schema.computedPolicyTargetReleaseTarget.releaseTargetId, schema.releaseTarget.id)
+          eq(
+            schema.computedPolicyTargetReleaseTarget.releaseTargetId,
+            schema.releaseTarget.id,
+          ),
         )
         .where(
           and(
             eq(schema.releaseTarget.resourceId, input.resourceId),
-            eq(schema.policy.workspaceId, resource.workspaceId)
-          )
+            eq(schema.policy.workspaceId, resource.workspaceId),
+          ),
         );
 
       if (policyIds.length === 0) return [];
@@ -133,7 +151,10 @@ export const policyRouter = createTRPCRouter({
       const policies = await ctx.db.query.policy.findMany({
         where: and(
           eq(schema.policy.workspaceId, resource.workspaceId),
-          inArray(schema.policy.id, policyIds.map(p => p.policyId))
+          inArray(
+            schema.policy.id,
+            policyIds.map((p) => p.policyId),
+          ),
         ),
         with: {
           targets: true,

--- a/packages/api/src/router/policy/router.ts
+++ b/packages/api/src/router/policy/router.ts
@@ -1,7 +1,7 @@
 import _ from "lodash";
 import { z } from "zod";
 
-import { and, asc, desc, eq, ilike, takeFirst } from "@ctrlplane/db";
+import { and, asc, desc, eq, ilike, isNull, takeFirst } from "@ctrlplane/db";
 import { createPolicy, policy, updatePolicy } from "@ctrlplane/db/schema";
 import * as schema from "@ctrlplane/db/schema";
 import { Channel, getQueue } from "@ctrlplane/events";
@@ -84,6 +84,76 @@ export const policyRouter = createTRPCRouter({
         },
       }),
     ),
+
+  byResourceId: protectedProcedure
+    .meta({
+      authorizationCheck: ({ canUser, input }) =>
+        canUser
+          .perform(Permission.ResourceGet)
+          .on({ type: "resource", id: input.resourceId }),
+    })
+    .input(
+      z.object({
+        resourceId: z.string().uuid(),
+      }),
+    )
+    .query(async ({ ctx, input }) => {
+      // Verify resource exists and get workspace info
+      const resource = await ctx.db.query.resource.findFirst({
+        where: and(eq(schema.resource.id, input.resourceId), isNull(schema.resource.deletedAt)),
+      });
+
+      if (!resource) return [];
+
+      // Get all policies in the workspace with their targets
+      const allPolicies = await ctx.db.query.policy.findMany({
+        where: eq(schema.policy.workspaceId, resource.workspaceId),
+        with: {
+          targets: true,
+          denyWindows: true,
+          deploymentVersionSelector: true,
+          versionAnyApprovals: true,
+          versionUserApprovals: true,
+          versionRoleApprovals: true,
+          concurrency: true,
+          environmentVersionRollout: true,
+        },
+      });
+
+      // Filter policies by checking if resource matches any of their targets using built-in logic
+      const matchingPolicies = await Promise.all(
+        allPolicies.map(async (policy) => {
+          const hasMatchingTarget = await Promise.all(
+            policy.targets.map(async (target) => {
+              // Policy with no resource selector applies to all resources
+              if (!target.resourceSelector) return true;
+
+              // Use built-in resource matching logic - check if resource matches the selector
+              const matchingResource = await ctx.db.query.resource.findFirst({
+                where: and(
+                  eq(schema.resource.id, input.resourceId),
+                  schema.resourceMatchesMetadata(ctx.db, target.resourceSelector),
+                  isNull(schema.resource.deletedAt),
+                ),
+              });
+
+              return matchingResource != null;
+            }),
+          );
+
+          return hasMatchingTarget.some(Boolean) ? policy : null;
+        }),
+      );
+
+      return matchingPolicies
+        .filter((p) => p != null)
+        .sort((a, b) => {
+          if (a.priority !== b.priority) {
+            return b.priority - a.priority; // Higher priority first
+          }
+          return a.name.localeCompare(b.name);
+        });
+    }),
 
   releaseTargets: protectedProcedure
     .meta({


### PR DESCRIPTION
- Add new policies page showing policy summary for resources
- Create reusable PolicyCard component with configuration-driven design
- Eliminate code duplication with shared PolicySummaryCard
- Support 4 policy types: Approval, Deny Windows, Version Conditions, Concurrency

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added a "Policies" link to the resource sidebar for quick access.
  - Introduced a new page displaying all policies associated with a specific resource, including detailed policy cards and summaries.
  - Implemented summary cards to highlight key policy aspects such as approval, deny windows, version conditions, and concurrency controls.

- **Bug Fixes**
  - None.

- **Refactor**
  - Internal code cleanup and reformatting for improved maintainability.

- **Chores**
  - Updated backend to support fetching policies by resource for enhanced policy visibility.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->