### PR TITLE
chore: use common context for cells

### DIFF
--- a/apps/webservice/src/app/[workspaceSlug]/(app)/(deploy)/(raw)/systems/[systemSlug]/(raw)/deployments/[deploymentSlug]/(sidebar)/_components/release-cell/ActiveJobsCell.tsx
+++ b/apps/webservice/src/app/[workspaceSlug]/(app)/(deploy)/(raw)/systems/[systemSlug]/(raw)/deployments/[deploymentSlug]/(sidebar)/_components/release-cell/ActiveJobsCell.tsx
@@ -1,7 +1,6 @@
 "use client";
 
 import type * as SCHEMA from "@ctrlplane/db/schema";
-import { useParams } from "next/navigation";
 import {
   IconAlertTriangle,
   IconDotsVertical,
@@ -23,101 +22,75 @@ import { DropdownAction } from "~/app/[workspaceSlug]/(app)/(deploy)/_components
 import { ForceDeployVersionDialog } from "~/app/[workspaceSlug]/(app)/(deploy)/_components/deployment-version/ForceDeployVersion";
 import { RedeployVersionDialog } from "~/app/[workspaceSlug]/(app)/(deploy)/_components/deployment-version/RedeployVersionDialog";
 import { StatusIcon } from "~/app/[workspaceSlug]/(app)/(deploy)/_components/deployments/environment-cell/StatusIcon";
-import { urls } from "~/app/urls";
 import { PinEnvToVersionDialog } from "../version-pinning/PinEnvToVersionDialog";
 import { Cell } from "./Cell";
+import { useDeploymentVersionEnvironmentContext } from "./DeploymentVersionEnvironmentContext";
 
 const ActiveJobsDropdown: React.FC<{
-  deployment: { id: string; name: string; slug: string };
-  environment: { id: string; name: string };
-  version: { id: string; tag: string };
   hasActiveJobs: boolean;
-  isVersionPinned?: boolean;
-}> = ({ deployment, environment, version, hasActiveJobs, isVersionPinned }) => (
-  <DropdownMenu>
-    <DropdownMenuTrigger asChild>
-      <Button
-        variant="ghost"
-        size="icon"
-        className="h-7 w-7 shrink-0 text-muted-foreground"
-      >
-        <IconDotsVertical className="h-4 w-4" />
-      </Button>
-    </DropdownMenuTrigger>
-    <DropdownMenuContent>
-      {!isVersionPinned && (
-        <PinEnvToVersionDialog environment={environment} version={version}>
-          <DropdownMenuItem
-            onSelect={(e) => e.preventDefault()}
-            className="flex items-center gap-2"
+}> = ({ hasActiveJobs }) => {
+  const { deployment, environment, deploymentVersion, isVersionPinned } =
+    useDeploymentVersionEnvironmentContext();
+
+  return (
+    <DropdownMenu>
+      <DropdownMenuTrigger asChild>
+        <Button
+          variant="ghost"
+          size="icon"
+          className="h-7 w-7 shrink-0 text-muted-foreground"
+        >
+          <IconDotsVertical className="h-4 w-4" />
+        </Button>
+      </DropdownMenuTrigger>
+      <DropdownMenuContent>
+        {!isVersionPinned && (
+          <PinEnvToVersionDialog
+            environment={environment}
+            version={deploymentVersion}
           >
-            <IconPin className="h-4 w-4" />
-            Pin version
-          </DropdownMenuItem>
-        </PinEnvToVersionDialog>
-      )}
-      {!hasActiveJobs && (
+            <DropdownMenuItem
+              onSelect={(e) => e.preventDefault()}
+              className="flex items-center gap-2"
+            >
+              <IconPin className="h-4 w-4" />
+              Pin version
+            </DropdownMenuItem>
+          </PinEnvToVersionDialog>
+        )}
+        {!hasActiveJobs && (
+          <DropdownAction
+            deployment={deployment}
+            environment={environment}
+            icon={<IconReload className="h-4 w-4" />}
+            label="Redeploy"
+            Dialog={RedeployVersionDialog}
+          />
+        )}
         <DropdownAction
           deployment={deployment}
           environment={environment}
-          icon={<IconReload className="h-4 w-4" />}
-          label="Redeploy"
-          Dialog={RedeployVersionDialog}
+          icon={<IconAlertTriangle className="h-4 w-4" />}
+          label="Force deploy"
+          Dialog={ForceDeployVersionDialog}
         />
-      )}
-      <DropdownAction
-        deployment={deployment}
-        environment={environment}
-        icon={<IconAlertTriangle className="h-4 w-4" />}
-        label="Force deploy"
-        Dialog={ForceDeployVersionDialog}
-      />
-    </DropdownMenuContent>
-  </DropdownMenu>
-);
+      </DropdownMenuContent>
+    </DropdownMenu>
+  );
+};
 
 export const ActiveJobsCell: React.FC<{
   statuses: SCHEMA.JobStatus[];
-  deploymentVersion: { id: string; tag: string; createdAt: Date };
-  deployment: { id: string; name: string; slug: string };
-  environment: { id: string; name: string };
-  system: { slug: string };
-  isVersionPinned?: boolean;
-}> = ({
-  statuses,
-  deploymentVersion,
-  deployment,
-  environment,
-  system,
-  isVersionPinned,
-}) => {
-  const { workspaceSlug } = useParams<{ workspaceSlug: string }>();
-
-  const versionUrl = urls
-    .workspace(workspaceSlug)
-    .system(system.slug)
-    .deployment(deployment.slug)
-    .release(deploymentVersion.id)
-    .jobs();
+}> = ({ statuses }) => {
+  const { deploymentVersion } = useDeploymentVersionEnvironmentContext();
 
   const hasActiveJobs = statuses.some((s) => s === JobStatus.InProgress);
 
   return (
     <Cell
       Icon={<StatusIcon statuses={statuses} />}
-      url={versionUrl}
-      tag={deploymentVersion.tag}
       label={format(deploymentVersion.createdAt, "MMM d, hh:mm aa")}
-      isVersionPinned={isVersionPinned}
-      Dropdown={
-        <ActiveJobsDropdown
-          deployment={deployment}
-          environment={environment}
-          version={deploymentVersion}
-          hasActiveJobs={hasActiveJobs}
-          isVersionPinned={isVersionPinned}
-        />
-      }
+      Dropdown={<ActiveJobsDropdown hasActiveJobs={hasActiveJobs} />}
     />
   );
 };

--- a/apps/webservice/src/app/[workspaceSlug]/(app)/(deploy)/(raw)/systems/[systemSlug]/(raw)/deployments/[deploymentSlug]/(sidebar)/_components/release-cell/ApprovalRequiredCell.tsx
+++ b/apps/webservice/src/app/[workspaceSlug]/(app)/(deploy)/(raw)/systems/[systemSlug]/(raw)/deployments/[deploymentSlug]/(sidebar)/_components/release-cell/ApprovalRequiredCell.tsx
@@ -29,6 +29,7 @@ import { DropdownAction } from "~/app/[workspaceSlug]/(app)/(deploy)/_components
 import { ForceDeployVersionDialog } from "~/app/[workspaceSlug]/(app)/(deploy)/_components/deployment-version/ForceDeployVersion";
 import { urls } from "~/app/urls";
 import { Cell } from "./Cell";
+import { useDeploymentVersionEnvironmentContext } from "./DeploymentVersionEnvironmentContext";
 
 export const getPoliciesWithApprovalRequired = (
   policyEvaluations: PolicyEvaluationResult,
@@ -78,29 +79,17 @@ const YellowShieldIcon: React.FC = () => (
 
 export const ApprovalRequiredCell: React.FC<{
   policies: { id: string; name: string }[];
-  deploymentVersion: { id: string; tag: string };
-  deployment: { id: string; name: string; slug: string };
-  environment: { id: string; name: string };
-  system: { id: string; slug: string };
-}> = ({ policies, deploymentVersion, deployment, environment, system }) => {
+}> = ({ policies }) => {
   const { workspaceSlug } = useParams<{ workspaceSlug: string }>();
 
-  const versionUrl = urls
-    .workspace(workspaceSlug)
-    .system(system.slug)
-    .deployment(deployment.slug)
-    .release(deploymentVersion.id)
-    .jobs();
+  const { deploymentVersion, deployment, environment, system } =
+    useDeploymentVersionEnvironmentContext();
+
   return (
     <>
       <HoverCard>
         <HoverCardTrigger asChild>
-          <Cell
-            Icon={<YellowShieldIcon />}
-            url={versionUrl}
-            tag={deploymentVersion.tag}
-            label="Approval required"
-          />
+          <Cell Icon={<YellowShieldIcon />} label="Approval required" />
         </HoverCardTrigger>
         <HoverCardContent className="w-80">
           <div className="flex flex-col gap-2 text-sm">

--- a/apps/webservice/src/app/[workspaceSlug]/(app)/(deploy)/(raw)/systems/[systemSlug]/(raw)/deployments/[deploymentSlug]/(sidebar)/_components/release-cell/BlockedByVersionSelectorCell.tsx
+++ b/apps/webservice/src/app/[workspaceSlug]/(app)/(deploy)/(raw)/systems/[systemSlug]/(raw)/deployments/[deploymentSlug]/(sidebar)/_components/release-cell/BlockedByVersionSelectorCell.tsx
@@ -26,6 +26,7 @@ import { DropdownAction } from "~/app/[workspaceSlug]/(app)/(deploy)/_components
 import { ForceDeployVersionDialog } from "~/app/[workspaceSlug]/(app)/(deploy)/_components/deployment-version/ForceDeployVersion";
 import { urls } from "~/app/urls";
 import { Cell } from "./Cell";
+import { useDeploymentVersionEnvironmentContext } from "./DeploymentVersionEnvironmentContext";
 
 export const getPoliciesBlockingByVersionSelector = (
   policyEvaluations: PolicyEvaluationResult,
@@ -45,29 +46,16 @@ const GreyFilterIcon: React.FC = () => (
 
 export const BlockedByVersionSelectorCell: React.FC<{
   policies: { id: string; name: string }[];
-  deploymentVersion: { id: string; tag: string };
-  deployment: { id: string; name: string; slug: string };
-  environment: { id: string; name: string };
-  system: { slug: string };
-}> = ({ policies, deploymentVersion, deployment, environment, system }) => {
+}> = ({ policies }) => {
+  const { deployment, environment } = useDeploymentVersionEnvironmentContext();
+
   const { workspaceSlug } = useParams<{ workspaceSlug: string }>();
 
-  const versionUrl = urls
-    .workspace(workspaceSlug)
-    .system(system.slug)
-    .deployment(deployment.slug)
-    .release(deploymentVersion.id)
-    .checks();
   return (
     <>
       <HoverCard>
         <HoverCardTrigger asChild>
-          <Cell
-            Icon={<GreyFilterIcon />}
-            url={versionUrl}
-            tag={deploymentVersion.tag}
-            label="Blocked by policy"
-          />
+          <Cell Icon={<GreyFilterIcon />} label="Blocked by policy" />
         </HoverCardTrigger>
         <HoverCardContent className="w-80">
           <div className="flex flex-col gap-2 text-sm">

--- a/apps/webservice/src/app/[workspaceSlug]/(app)/(deploy)/(raw)/systems/[systemSlug]/(raw)/deployments/[deploymentSlug]/(sidebar)/_components/release-cell/Cell.tsx
+++ b/apps/webservice/src/app/[workspaceSlug]/(app)/(deploy)/(raw)/systems/[systemSlug]/(raw)/deployments/[deploymentSlug]/(sidebar)/_components/release-cell/Cell.tsx
@@ -2,27 +2,37 @@ import React from "react";
 import Link from "next/link";
 import { IconPinFilled } from "@tabler/icons-react";
 
+import { useDeploymentVersionEnvironmentContext } from "./DeploymentVersionEnvironmentContext";
+
 export const Cell: React.FC<{
   Icon: React.ReactNode;
-  url: string;
-  tag: string;
   label: string;
-  isVersionPinned?: boolean;
+  url?: string;
   Dropdown?: React.ReactNode;
-}> = ({ Icon, url, tag, label, isVersionPinned = false, Dropdown }) => (
-  <div className="flex h-full w-full items-center justify-center p-1">
-    <Link href={url} className="flex w-full items-center gap-2 rounded-md p-2">
-      {Icon}
-      <div className="flex flex-col">
-        <div className="flex max-w-36 items-center gap-1 truncate font-semibold">
-          {isVersionPinned && (
-            <IconPinFilled className="h-4 w-4 flex-shrink-0 text-muted-foreground" />
-          )}
-          <span className="truncate">{tag}</span>
+}> = ({ Icon, label, url, Dropdown }) => {
+  const { deploymentVersion, versionUrl, isVersionPinned } =
+    useDeploymentVersionEnvironmentContext();
+
+  const { tag } = deploymentVersion;
+
+  return (
+    <div className="flex h-full w-full items-center justify-center p-1">
+      <Link
+        href={url ?? versionUrl}
+        className="flex w-full items-center gap-2 rounded-md p-2"
+      >
+        {Icon}
+        <div className="flex flex-col">
+          <div className="flex max-w-36 items-center gap-1 truncate font-semibold">
+            {isVersionPinned && (
+              <IconPinFilled className="h-4 w-4 flex-shrink-0 text-muted-foreground" />
+            )}
+            <span className="truncate">{tag}</span>
+          </div>
+          <div className="text-xs text-muted-foreground">{label}</div>
         </div>
-        <div className="text-xs text-muted-foreground">{label}</div>
-      </div>
-    </Link>
-    {Dropdown != null && Dropdown}
-  </div>
-);
+      </Link>
+      {Dropdown != null && Dropdown}
+    </div>
+  );
+};

--- a/apps/webservice/src/app/[workspaceSlug]/(app)/(deploy)/(raw)/systems/[systemSlug]/(raw)/deployments/[deploymentSlug]/(sidebar)/_components/release-cell/DeploymentVersionEnvironmentCell.tsx
+++ b/apps/webservice/src/app/[workspaceSlug]/(app)/(deploy)/(raw)/systems/[systemSlug]/(raw)/deployments/[deploymentSlug]/(sidebar)/_components/release-cell/DeploymentVersionEnvironmentCell.tsx
@@ -9,17 +9,18 @@ import { useInView } from "react-intersection-observer";
 import { Skeleton } from "@ctrlplane/ui/skeleton";
 
 import { urls } from "~/app/urls";
-import { api } from "~/trpc/react";
+import { useActiveJobs } from "./_hooks/useActiveJobs";
+import { useHasReleaseTargets } from "./_hooks/useHasReleaseTargets";
+import { usePolicyEvaluations } from "./_hooks/useIsBlockedByPolicyVersionSelector";
+import { useIsWaitingOnAnotherRelease } from "./_hooks/useIsWaitingOnAnotherRelease";
 import { ActiveJobsCell } from "./ActiveJobsCell";
-import {
-  ApprovalRequiredCell,
-  getPoliciesWithApprovalRequired,
-} from "./ApprovalRequiredCell";
-import {
-  BlockedByVersionSelectorCell,
-  getPoliciesBlockingByVersionSelector,
-} from "./BlockedByVersionSelectorCell";
+import { ApprovalRequiredCell } from "./ApprovalRequiredCell";
+import { BlockedByVersionSelectorCell } from "./BlockedByVersionSelectorCell";
 import { Cell } from "./Cell";
+import {
+  DeploymentVersionEnvironmentProvider,
+  useDeploymentVersionEnvironmentContext,
+} from "./DeploymentVersionEnvironmentContext";
 import { VersionStatusCell } from "./VersionStatusCell";
 
 const SkeletonCell: React.FC = () => (
@@ -32,29 +33,29 @@ const SkeletonCell: React.FC = () => (
   </div>
 );
 
-const NoReleaseTargetsCell: React.FC<{
-  tag: string;
-}> = ({ tag }) => (
-  <div className="flex h-full w-full items-center justify-center p-1">
-    <div className="flex w-full items-center gap-2 rounded-md p-2">
-      <div className="rounded-full bg-neutral-400 p-1 dark:text-black">
-        <IconCubeOff className="h-4 w-4" strokeWidth={2} />
-      </div>
-      <div className="flex flex-col">
-        <div className="max-w-36 truncate font-semibold">{tag}</div>
-        <div className="text-xs text-muted-foreground">No resources</div>
+const NoReleaseTargetsCell: React.FC = () => {
+  const { deploymentVersion } = useDeploymentVersionEnvironmentContext();
+  const { tag } = deploymentVersion;
+
+  return (
+    <div className="flex h-full w-full items-center justify-center p-1">
+      <div className="flex w-full items-center gap-2 rounded-md p-2">
+        <div className="rounded-full bg-neutral-400 p-1 dark:text-black">
+          <IconCubeOff className="h-4 w-4" strokeWidth={2} />
+        </div>
+        <div className="flex flex-col">
+          <div className="max-w-36 truncate font-semibold">{tag}</div>
+          <div className="text-xs text-muted-foreground">No resources</div>
+        </div>
       </div>
     </div>
-  </div>
-);
+  );
+};
 
-const BlockedByActiveJobsCell: React.FC<{
-  deploymentVersion: { id: string; tag: string };
-  deployment: { id: string; name: string; slug: string };
-  system: { slug: string };
-  isVersionPinned?: boolean;
-}> = ({ deploymentVersion, deployment, system, isVersionPinned }) => {
+const BlockedByActiveJobsCell: React.FC = () => {
   const { workspaceSlug } = useParams<{ workspaceSlug: string }>();
+
+  const { deployment, system } = useDeploymentVersionEnvironmentContext();
 
   const deploymentUrl = urls
     .workspace(workspaceSlug)
@@ -70,18 +71,14 @@ const BlockedByActiveJobsCell: React.FC<{
         </div>
       }
       url={deploymentUrl}
-      tag={deploymentVersion.tag}
       label="Waiting on another release"
-      isVersionPinned={isVersionPinned}
     />
   );
 };
 
-const NoJobAgentCell: React.FC<{
-  tag: string;
-  system: { slug: string };
-  deployment: { slug: string };
-}> = ({ tag, system, deployment }) => {
+const NoJobAgentCell: React.FC = () => {
+  const { deployment, system } = useDeploymentVersionEnvironmentContext();
+
   const { workspaceSlug } = useParams<{ workspaceSlug: string }>();
 
   const workflowConfigUrl = urls
@@ -98,145 +95,72 @@ const NoJobAgentCell: React.FC<{
         </div>
       }
       url={workflowConfigUrl}
-      tag={tag}
       label="No job agent"
     />
   );
 };
 
-type DeploymentVersionEnvironmentCellProps = {
+const DeploymentVersionEnvironmentCell: React.FC = () => {
+  const { deployment, deploymentVersion } =
+    useDeploymentVersionEnvironmentContext();
+
+  const { hasNoReleaseTargets, isReleaseTargetsLoading } =
+    useHasReleaseTargets();
+  const { isWaitingOnAnotherRelease, isWaitingOnAnotherReleaseLoading } =
+    useIsWaitingOnAnotherRelease();
+
+  const { isPolicyEvaluationsLoading, versionSelector, approvalRequired } =
+    usePolicyEvaluations();
+
+  const { statuses, isStatusesLoading } = useActiveJobs();
+
+  const isLoading =
+    isReleaseTargetsLoading ||
+    isPolicyEvaluationsLoading ||
+    isStatusesLoading ||
+    isWaitingOnAnotherReleaseLoading;
+
+  if (isLoading) return <SkeletonCell />;
+
+  if (statuses.length > 0) return <ActiveJobsCell statuses={statuses} />;
+
+  if (versionSelector.isBlocking)
+    return <BlockedByVersionSelectorCell policies={versionSelector.policies} />;
+
+  const isNotReady = deploymentVersion.status !== "ready";
+  if (isNotReady) return <VersionStatusCell />;
+
+  if (hasNoReleaseTargets) return <NoReleaseTargetsCell />;
+
+  if (approvalRequired.isRequired)
+    return <ApprovalRequiredCell policies={approvalRequired.policies} />;
+
+  if (isWaitingOnAnotherRelease) return <BlockedByActiveJobsCell />;
+
+  const hasNoJobAgent = deployment.jobAgentId == null;
+  if (hasNoJobAgent) return <NoJobAgentCell />;
+
+  return <VersionStatusCell />;
+};
+
+type LazyDeploymentVersionEnvironmentCellProps = {
   system: { id: string; slug: string };
   environment: SCHEMA.Environment;
   deployment: SCHEMA.Deployment;
   deploymentVersion: SCHEMA.DeploymentVersion;
 };
 
-const useIsPinned = (environmentId: string, versionId: string) => {
-  const { data, isLoading } =
-    api.environment.versionPinning.pinnedVersions.useQuery({
-      environmentId,
-    });
-
-  const isPinned = data != null && data.length === 1 && data[0] === versionId;
-
-  return { isPinned, isPinnedVersionsLoading: isLoading };
-};
-
-const DeploymentVersionEnvironmentCell: React.FC<
-  DeploymentVersionEnvironmentCellProps
-> = (props) => {
-  const { environment, deployment, deploymentVersion } = props;
-  const { data: releaseTargetsResult, isLoading: isReleaseTargetsLoading } =
-    api.releaseTarget.list.useQuery({
-      environmentId: environment.id,
-      deploymentId: deployment.id,
-      limit: 0,
-    });
-  const numReleaseTargets = releaseTargetsResult?.total ?? 0;
-
-  const {
-    data: targetsWithActiveJobs,
-    isLoading: isTargetsWithActiveJobsLoading,
-  } = api.releaseTarget.activeJobs.useQuery({
-    environmentId: environment.id,
-    deploymentId: deployment.id,
-  });
-
-  const { data: policyEvaluations, isLoading: isPolicyEvaluationsLoading } =
-    api.policy.evaluate.useQuery({
-      environmentId: environment.id,
-      versionId: deploymentVersion.id,
-    });
-
-  const { data: jobs, isLoading: isJobsLoading } =
-    api.deployment.version.job.byEnvironment.useQuery({
-      versionId: deploymentVersion.id,
-      environmentId: environment.id,
-    });
-
-  const { isPinned, isPinnedVersionsLoading } = useIsPinned(
-    environment.id,
-    deploymentVersion.id,
-  );
-
-  const isLoading =
-    isReleaseTargetsLoading ||
-    isPolicyEvaluationsLoading ||
-    isJobsLoading ||
-    isTargetsWithActiveJobsLoading ||
-    isPinnedVersionsLoading;
-  if (isLoading) return <SkeletonCell />;
-
-  const hasJobs = jobs != null && jobs.length > 0;
-  if (hasJobs)
-    return (
-      <ActiveJobsCell
-        isVersionPinned={isPinned}
-        statuses={jobs.map((j) => j.status)}
-        {...props}
-      />
-    );
-
-  const policiesWithBlockingVersionSelector =
-    policyEvaluations != null
-      ? getPoliciesBlockingByVersionSelector(policyEvaluations)
-      : [];
-
-  const isBlockedByVersionSelector =
-    policiesWithBlockingVersionSelector.length > 0;
-  if (isBlockedByVersionSelector)
-    return (
-      <BlockedByVersionSelectorCell
-        policies={policiesWithBlockingVersionSelector}
-        {...props}
-      />
-    );
-
-  const isNotReady = deploymentVersion.status !== "ready";
-  if (isNotReady)
-    return <VersionStatusCell isVersionPinned={isPinned} {...props} />;
-
-  const hasNoReleaseTargets = numReleaseTargets === 0;
-  if (hasNoReleaseTargets)
-    return <NoReleaseTargetsCell tag={deploymentVersion.tag} />;
-
-  const policiesWithApprovalRequired =
-    policyEvaluations != null
-      ? getPoliciesWithApprovalRequired(policyEvaluations)
-      : [];
-
-  const isApprovalRequired = policiesWithApprovalRequired.length > 0;
-  if (isApprovalRequired)
-    return (
-      <ApprovalRequiredCell
-        policies={policiesWithApprovalRequired}
-        {...props}
-      />
-    );
-
-  const allActiveJobs = (targetsWithActiveJobs ?? []).flatMap((t) => t.jobs);
-  const isWaitingOnActiveJobs = allActiveJobs.some(
-    ({ versionId }) => versionId !== deploymentVersion.id,
-  );
-  if (isWaitingOnActiveJobs)
-    return <BlockedByActiveJobsCell isVersionPinned={isPinned} {...props} />;
-
-  const hasNoJobAgent = deployment.jobAgentId == null;
-  if (hasNoJobAgent)
-    return <NoJobAgentCell tag={deploymentVersion.tag} {...props} />;
-
-  return <VersionStatusCell isVersionPinned={isPinned} {...props} />;
-};
-
 export const LazyDeploymentVersionEnvironmentCell: React.FC<
-  DeploymentVersionEnvironmentCellProps
+  LazyDeploymentVersionEnvironmentCellProps
 > = (props) => {
   const { ref, inView } = useInView();
 
   return (
-    <div className="flex h-full w-full items-center justify-center" ref={ref}>
-      {!inView && <p className="text-xs text-muted-foreground">Loading...</p>}
-      {inView && <DeploymentVersionEnvironmentCell {...props} />}
-    </div>
+    <DeploymentVersionEnvironmentProvider {...props}>
+      <div className="flex h-full w-full items-center justify-center" ref={ref}>
+        {!inView && <p className="text-xs text-muted-foreground">Loading...</p>}
+        {inView && <DeploymentVersionEnvironmentCell />}
+      </div>
+    </DeploymentVersionEnvironmentProvider>
   );
 };

--- a/apps/webservice/src/app/[workspaceSlug]/(app)/(deploy)/(raw)/systems/[systemSlug]/(raw)/deployments/[deploymentSlug]/(sidebar)/_components/release-cell/DeploymentVersionEnvironmentContext.tsx
+++ b/apps/webservice/src/app/[workspaceSlug]/(app)/(deploy)/(raw)/systems/[systemSlug]/(raw)/deployments/[deploymentSlug]/(sidebar)/_components/release-cell/DeploymentVersionEnvironmentContext.tsx
@@ -1,0 +1,72 @@
+import type * as schema from "@ctrlplane/db/schema";
+import { createContext, useContext } from "react";
+import { useParams } from "next/navigation";
+
+import { urls } from "~/app/urls";
+import { api } from "~/trpc/react";
+
+type DeploymentVersionEnvironmentContextType = {
+  system: { id: string; slug: string };
+  environment: schema.Environment;
+  deployment: schema.Deployment;
+  deploymentVersion: schema.DeploymentVersion;
+  isVersionPinned: boolean;
+  versionUrl: string;
+};
+
+const DeploymentVersionEnvironmentContext =
+  createContext<DeploymentVersionEnvironmentContextType | null>(null);
+
+export const useDeploymentVersionEnvironmentContext = () => {
+  const ctx = useContext(DeploymentVersionEnvironmentContext);
+  if (ctx == null)
+    throw new Error(
+      "useDeploymentVersionEnvironmentContext must be used within a DeploymentVersionEnvironmentContext.Provider",
+    );
+  return ctx;
+};
+
+const useIsPinned = (environmentId: string, versionId: string) => {
+  const { data, isLoading } =
+    api.environment.versionPinning.pinnedVersions.useQuery({
+      environmentId,
+    });
+
+  const isPinned = data != null && data.length === 1 && data[0] === versionId;
+
+  return { isPinned, isPinnedVersionsLoading: isLoading };
+};
+
+export const DeploymentVersionEnvironmentProvider: React.FC<{
+  system: { id: string; slug: string };
+  environment: schema.Environment;
+  deployment: schema.Deployment;
+  deploymentVersion: schema.DeploymentVersion;
+  children: React.ReactNode;
+}> = ({ children, system, environment, deployment, deploymentVersion }) => {
+  const { workspaceSlug } = useParams<{ workspaceSlug: string }>();
+
+  const versionUrl = urls
+    .workspace(workspaceSlug)
+    .system(system.slug)
+    .deployment(deployment.slug)
+    .release(deploymentVersion.id)
+    .jobs();
+
+  const { isPinned } = useIsPinned(environment.id, deploymentVersion.id);
+
+  return (
+    <DeploymentVersionEnvironmentContext.Provider
+      value={{
+        system,
+        environment,
+        deployment,
+        deploymentVersion,
+        isVersionPinned: isPinned,
+        versionUrl,
+      }}
+    >
+      {children}
+    </DeploymentVersionEnvironmentContext.Provider>
+  );
+};

--- a/apps/webservice/src/app/[workspaceSlug]/(app)/(deploy)/(raw)/systems/[systemSlug]/(raw)/deployments/[deploymentSlug]/(sidebar)/_components/release-cell/VersionStatusCell.tsx
+++ b/apps/webservice/src/app/[workspaceSlug]/(app)/(deploy)/(raw)/systems/[systemSlug]/(raw)/deployments/[deploymentSlug]/(sidebar)/_components/release-cell/VersionStatusCell.tsx
@@ -2,7 +2,7 @@
 
 import type * as SCHEMA from "@ctrlplane/db/schema";
 import React, { useState } from "react";
-import { useParams, useRouter } from "next/navigation";
+import { useRouter } from "next/navigation";
 import {
   IconAlertTriangle,
   IconBolt,
@@ -42,9 +42,9 @@ import { DeploymentVersionStatus } from "@ctrlplane/validators/releases";
 import { DropdownAction } from "~/app/[workspaceSlug]/(app)/(deploy)/_components/deployment-version/DeploymentVersionDropdownMenu";
 import { ForceDeployVersionDialog } from "~/app/[workspaceSlug]/(app)/(deploy)/_components/deployment-version/ForceDeployVersion";
 import { RedeployVersionDialog } from "~/app/[workspaceSlug]/(app)/(deploy)/_components/deployment-version/RedeployVersionDialog";
-import { urls } from "~/app/urls";
 import { api } from "~/trpc/react";
 import { Cell } from "./Cell";
+import { useDeploymentVersionEnvironmentContext } from "./DeploymentVersionEnvironmentContext";
 
 const OverrideStatusDialog: React.FC<{
   deploymentVersion: SCHEMA.DeploymentVersion;
@@ -118,11 +118,10 @@ const OverrideStatusDialog: React.FC<{
   );
 };
 
-const VersionStatusDropdown: React.FC<{
-  deploymentVersion: SCHEMA.DeploymentVersion;
-  deployment: { id: string; name: string; slug: string };
-  environment: { id: string; name: string };
-}> = ({ deploymentVersion, deployment, environment }) => {
+const VersionStatusDropdown: React.FC = () => {
+  const { deploymentVersion, deployment, environment } =
+    useDeploymentVersionEnvironmentContext();
+
   const [open, setOpen] = useState(false);
   const isReady = deploymentVersion.status === "ready";
 
@@ -205,29 +204,14 @@ const StatusIcon: React.FC<{
   );
 };
 
-export const VersionStatusCell: React.FC<{
-  system: { id: string; slug: string };
-  deployment: { id: string; name: string; slug: string };
-  environment: { id: string; name: string };
-  deploymentVersion: SCHEMA.DeploymentVersion;
-  isVersionPinned?: boolean;
-}> = (props) => {
-  const { workspaceSlug } = useParams<{ workspaceSlug: string }>();
-  const versionUrl = urls
-    .workspace(workspaceSlug)
-    .system(props.system.slug)
-    .deployment(props.deployment.slug)
-    .release(props.deploymentVersion.id)
-    .jobs();
+export const VersionStatusCell: React.FC = () => {
+  const { deploymentVersion } = useDeploymentVersionEnvironmentContext();
 
   return (
     <Cell
-      Icon={<StatusIcon versionStatus={props.deploymentVersion.status} />}
-      url={versionUrl}
-      tag={props.deploymentVersion.tag}
-      label={props.deploymentVersion.status}
-      isVersionPinned={props.isVersionPinned}
-      Dropdown={<VersionStatusDropdown {...props} />}
+      Icon={<StatusIcon versionStatus={deploymentVersion.status} />}
+      label={deploymentVersion.status}
+      Dropdown={<VersionStatusDropdown />}
     />
   );
 };

--- a/apps/webservice/src/app/[workspaceSlug]/(app)/(deploy)/(raw)/systems/[systemSlug]/(raw)/deployments/[deploymentSlug]/(sidebar)/_components/release-cell/_hooks/useActiveJobs.tsx
+++ b/apps/webservice/src/app/[workspaceSlug]/(app)/(deploy)/(raw)/systems/[systemSlug]/(raw)/deployments/[deploymentSlug]/(sidebar)/_components/release-cell/_hooks/useActiveJobs.tsx
@@ -1,0 +1,22 @@
+"use client";
+
+import { api } from "~/trpc/react";
+import { useDeploymentVersionEnvironmentContext } from "../DeploymentVersionEnvironmentContext";
+
+export const useActiveJobs = () => {
+  const { environment, deploymentVersion } =
+    useDeploymentVersionEnvironmentContext();
+
+  const { data: jobs, isLoading: isJobsLoading } =
+    api.deployment.version.job.byEnvironment.useQuery({
+      versionId: deploymentVersion.id,
+      environmentId: environment.id,
+    });
+
+  const statuses = jobs?.map((j) => j.status) ?? [];
+
+  return {
+    statuses,
+    isStatusesLoading: isJobsLoading,
+  };
+};

--- a/apps/webservice/src/app/[workspaceSlug]/(app)/(deploy)/(raw)/systems/[systemSlug]/(raw)/deployments/[deploymentSlug]/(sidebar)/_components/release-cell/_hooks/useHasReleaseTargets.ts
+++ b/apps/webservice/src/app/[workspaceSlug]/(app)/(deploy)/(raw)/systems/[systemSlug]/(raw)/deployments/[deploymentSlug]/(sidebar)/_components/release-cell/_hooks/useHasReleaseTargets.ts
@@ -1,0 +1,23 @@
+"use client";
+
+import { api } from "~/trpc/react";
+import { useDeploymentVersionEnvironmentContext } from "../DeploymentVersionEnvironmentContext";
+
+export const useHasReleaseTargets = () => {
+  const { environment, deployment } = useDeploymentVersionEnvironmentContext();
+
+  const environmentId = environment.id;
+  const deploymentId = deployment.id;
+  const { data, isLoading } = api.releaseTarget.list.useQuery({
+    environmentId,
+    deploymentId,
+    limit: 0,
+  });
+
+  const numReleaseTargets = data?.total ?? 0;
+
+  return {
+    hasNoReleaseTargets: numReleaseTargets === 0,
+    isReleaseTargetsLoading: isLoading,
+  };
+};

--- a/apps/webservice/src/app/[workspaceSlug]/(app)/(deploy)/(raw)/systems/[systemSlug]/(raw)/deployments/[deploymentSlug]/(sidebar)/_components/release-cell/_hooks/useIsBlockedByPolicyVersionSelector.ts
+++ b/apps/webservice/src/app/[workspaceSlug]/(app)/(deploy)/(raw)/systems/[systemSlug]/(raw)/deployments/[deploymentSlug]/(sidebar)/_components/release-cell/_hooks/useIsBlockedByPolicyVersionSelector.ts
@@ -1,0 +1,44 @@
+"use client";
+
+import { api } from "~/trpc/react";
+import { getPoliciesWithApprovalRequired } from "../ApprovalRequiredCell";
+import { getPoliciesBlockingByVersionSelector } from "../BlockedByVersionSelectorCell";
+import { useDeploymentVersionEnvironmentContext } from "../DeploymentVersionEnvironmentContext";
+
+export const usePolicyEvaluations = () => {
+  const { environment, deploymentVersion } =
+    useDeploymentVersionEnvironmentContext();
+
+  const { data: policyEvaluations, isLoading: isPolicyEvaluationsLoading } =
+    api.policy.evaluate.useQuery({
+      environmentId: environment.id,
+      versionId: deploymentVersion.id,
+    });
+
+  const policiesWithBlockingVersionSelector =
+    policyEvaluations != null
+      ? getPoliciesBlockingByVersionSelector(policyEvaluations)
+      : [];
+
+  const isBlockedByVersionSelector =
+    policiesWithBlockingVersionSelector.length > 0;
+
+  const policiesWithApprovalRequired =
+    policyEvaluations != null
+      ? getPoliciesWithApprovalRequired(policyEvaluations)
+      : [];
+
+  const isApprovalRequired = policiesWithApprovalRequired.length > 0;
+
+  return {
+    isPolicyEvaluationsLoading,
+    versionSelector: {
+      isBlocking: isBlockedByVersionSelector,
+      policies: policiesWithBlockingVersionSelector,
+    },
+    approvalRequired: {
+      isRequired: isApprovalRequired,
+      policies: policiesWithApprovalRequired,
+    },
+  };
+};

--- a/apps/webservice/src/app/[workspaceSlug]/(app)/(deploy)/(raw)/systems/[systemSlug]/(raw)/deployments/[deploymentSlug]/(sidebar)/_components/release-cell/_hooks/useIsWaitingOnAnotherRelease.ts
+++ b/apps/webservice/src/app/[workspaceSlug]/(app)/(deploy)/(raw)/systems/[systemSlug]/(raw)/deployments/[deploymentSlug]/(sidebar)/_components/release-cell/_hooks/useIsWaitingOnAnotherRelease.ts
@@ -1,0 +1,26 @@
+"use client";
+
+import { api } from "~/trpc/react";
+import { useDeploymentVersionEnvironmentContext } from "../DeploymentVersionEnvironmentContext";
+
+export const useIsWaitingOnAnotherRelease = () => {
+  const { environment, deployment, deploymentVersion } =
+    useDeploymentVersionEnvironmentContext();
+
+  const environmentId = environment.id;
+  const deploymentId = deployment.id;
+  const {
+    data: targetsWithActiveJobs,
+    isLoading: isTargetsWithActiveJobsLoading,
+  } = api.releaseTarget.activeJobs.useQuery({ environmentId, deploymentId });
+
+  const allActiveJobs = (targetsWithActiveJobs ?? []).flatMap((t) => t.jobs);
+  const isWaitingOnAnotherRelease = allActiveJobs.some(
+    ({ versionId }) => versionId !== deploymentVersion.id,
+  );
+
+  return {
+    isWaitingOnAnotherRelease,
+    isWaitingOnAnotherReleaseLoading: isTargetsWithActiveJobsLoading,
+  };
+};


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Introduced a shared context for deployment version and environment data, enabling components to access necessary deployment information without explicit prop passing.
  * Added new hooks for active job status, release target checks, policy evaluations, and release waiting state to streamline deployment-related insights.

* **Refactor**
  * Simplified and unified deployment-related sidebar cells and dropdowns to consume context rather than props, reducing redundancy and improving maintainability.
  * Updated component signatures and logic to centralize state management and data access via context and hooks.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->