### PR TITLE
feat: ui showing policies preventing a job from being dispatched

### DIFF
--- a/apps/webservice/src/app/[workspaceSlug]/(app)/(deploy)/(raw)/systems/[systemSlug]/(raw)/deployments/[deploymentSlug]/(raw)/releases/[releaseId]/checks/_components/flow-diagram/checks/Approval.tsx
+++ b/apps/webservice/src/app/[workspaceSlug]/(app)/(deploy)/(raw)/systems/[systemSlug]/(raw)/deployments/[deploymentSlug]/(raw)/releases/[releaseId]/checks/_components/flow-diagram/checks/Approval.tsx
@@ -11,9 +11,9 @@ export const ApprovalCheck: React.FC<{
   versionId: string;
   versionTag: string;
 }> = (props) => {
-  const { data, isLoading } = api.policy.evaluate.useQuery(props);
+  const { data, isLoading } = api.policy.evaluate.environment.useQuery(props);
   const utils = api.useUtils();
-  const invalidate = () => utils.policy.evaluate.invalidate(props);
+  const invalidate = () => utils.policy.evaluate.environment.invalidate(props);
 
   const isAnyApprovalSatisfied = Object.values(
     data?.rules.anyApprovals ?? {},

--- a/apps/webservice/src/app/[workspaceSlug]/(app)/(deploy)/(raw)/systems/[systemSlug]/(raw)/deployments/[deploymentSlug]/(raw)/releases/[releaseId]/checks/_components/flow-diagram/checks/VersionSelector.tsx
+++ b/apps/webservice/src/app/[workspaceSlug]/(app)/(deploy)/(raw)/systems/[systemSlug]/(raw)/deployments/[deploymentSlug]/(raw)/releases/[releaseId]/checks/_components/flow-diagram/checks/VersionSelector.tsx
@@ -5,7 +5,7 @@ export const VersionSelectorCheck: React.FC<{
   versionId: string;
   environmentId: string;
 }> = ({ versionId, environmentId }) => {
-  const { data, isLoading } = api.policy.evaluate.useQuery({
+  const { data, isLoading } = api.policy.evaluate.environment.useQuery({
     environmentId,
     versionId,
   });

--- a/apps/webservice/src/app/[workspaceSlug]/(app)/(deploy)/(raw)/systems/[systemSlug]/(raw)/deployments/[deploymentSlug]/(raw)/releases/[releaseId]/jobs/_components/DeploymentVersionJobsTable.tsx
+++ b/apps/webservice/src/app/[workspaceSlug]/(app)/(deploy)/(raw)/systems/[systemSlug]/(raw)/deployments/[deploymentSlug]/(raw)/releases/[releaseId]/jobs/_components/DeploymentVersionJobsTable.tsx
@@ -230,6 +230,7 @@ export const DeploymentVersionJobsTable: React.FC<
                       environment={environment}
                       deployment={deployment}
                       jobs={jobs}
+                      version={deploymentVersion}
                     />
                   );
                 })}

--- a/apps/webservice/src/app/[workspaceSlug]/(app)/(deploy)/(raw)/systems/[systemSlug]/(raw)/deployments/[deploymentSlug]/(raw)/releases/[releaseId]/jobs/_components/PolicyEvaluationHover.tsx
+++ b/apps/webservice/src/app/[workspaceSlug]/(app)/(deploy)/(raw)/systems/[systemSlug]/(raw)/deployments/[deploymentSlug]/(raw)/releases/[releaseId]/jobs/_components/PolicyEvaluationHover.tsx
@@ -1,5 +1,5 @@
 import type { RouterOutputs } from "@ctrlplane/api";
-import React, { useMemo } from "react";
+import React from "react";
 import { IconCheck } from "@tabler/icons-react";
 import { formatDistanceToNowStrict } from "date-fns";
 
@@ -73,10 +73,24 @@ const VersionSelectorCheck: React.FC<{
 };
 
 const RolloutCheck: React.FC<{
-  policyEvaluations: PolicyEvaluation;
-}> = ({ policyEvaluations }) => {
-  const rolloutTime = policyEvaluations.rules.rolloutInfo.rolloutTime;
-  const now = useMemo(() => new Date(), []);
+  releaseTargetId: string;
+  versionId: string;
+}> = ({ releaseTargetId, versionId }) => {
+  const { data: policyEvaluations, isLoading } =
+    api.policy.evaluate.releaseTarget.useQuery(
+      { releaseTargetId, versionId },
+      { refetchInterval: 5_000 },
+    );
+
+  const rolloutTime = policyEvaluations?.rules.rolloutInfo.rolloutTime;
+  const now = new Date();
+
+  if (isLoading)
+    return (
+      <div className="flex items-center gap-2">
+        <Waiting /> Loading rollout information
+      </div>
+    );
 
   if (rolloutTime == null)
     return (
@@ -143,9 +157,7 @@ export const PolicyEvaluationHover: React.FC<{
             {hasVersionSelectorRule && (
               <VersionSelectorCheck policyEvaluations={policyEvaluations} />
             )}
-            {hasRolloutRule && (
-              <RolloutCheck policyEvaluations={policyEvaluations} />
-            )}
+            {hasRolloutRule && <RolloutCheck {...props} />}
           </div>
         )}
       </HoverCardContent>

--- a/apps/webservice/src/app/[workspaceSlug]/(app)/(deploy)/(raw)/systems/[systemSlug]/(raw)/deployments/[deploymentSlug]/(raw)/releases/[releaseId]/jobs/_components/PolicyEvaluationHover.tsx
+++ b/apps/webservice/src/app/[workspaceSlug]/(app)/(deploy)/(raw)/systems/[systemSlug]/(raw)/deployments/[deploymentSlug]/(raw)/releases/[releaseId]/jobs/_components/PolicyEvaluationHover.tsx
@@ -1,0 +1,154 @@
+import type { RouterOutputs } from "@ctrlplane/api";
+import React, { useMemo } from "react";
+import { IconCheck } from "@tabler/icons-react";
+import { formatDistanceToNowStrict } from "date-fns";
+
+import {
+  HoverCard,
+  HoverCardContent,
+  HoverCardTrigger,
+} from "@ctrlplane/ui/hover-card";
+
+import { api } from "~/trpc/react";
+import {
+  Failing,
+  Waiting,
+} from "../../checks/_components/flow-diagram/StatusIcons";
+
+type PolicyEvaluation = RouterOutputs["policy"]["evaluate"]["releaseTarget"];
+
+const ApprovalCheck: React.FC<{
+  policyEvaluations: PolicyEvaluation;
+}> = ({ policyEvaluations }) => {
+  const isAnyApprovalSatisfied = Object.values(
+    policyEvaluations.rules.anyApprovals,
+  ).every((reasons) => reasons.length === 0);
+
+  const isUserApprovalSatisfied = Object.values(
+    policyEvaluations.rules.userApprovals,
+  ).every((reasons) => reasons.length === 0);
+
+  const isRoleApprovalSatisfied = Object.values(
+    policyEvaluations.rules.roleApprovals,
+  ).every((reasons) => reasons.length === 0);
+
+  const isApproved =
+    isAnyApprovalSatisfied &&
+    isUserApprovalSatisfied &&
+    isRoleApprovalSatisfied;
+
+  if (isApproved)
+    return (
+      <div className="flex items-center gap-2">
+        <IconCheck className="h-4 w-4 text-green-400" /> Approved
+      </div>
+    );
+
+  return (
+    <div className="flex items-center gap-2">
+      <Waiting /> Not enough approvals
+    </div>
+  );
+};
+
+const VersionSelectorCheck: React.FC<{
+  policyEvaluations: PolicyEvaluation;
+}> = ({ policyEvaluations }) => {
+  const isPassingVersionSelector = Object.values(
+    policyEvaluations.rules.versionSelector,
+  ).every((isPassing) => isPassing);
+
+  if (isPassingVersionSelector)
+    return (
+      <div className="flex items-center gap-2">
+        <IconCheck className="h-4 w-4 text-green-400" /> Version selector passed
+      </div>
+    );
+
+  return (
+    <div className="flex items-center gap-2">
+      <Failing /> Version selector failed
+    </div>
+  );
+};
+
+const RolloutCheck: React.FC<{
+  policyEvaluations: PolicyEvaluation;
+}> = ({ policyEvaluations }) => {
+  const rolloutTime = policyEvaluations.rules.rolloutInfo.rolloutTime;
+  const now = useMemo(() => new Date(), []);
+
+  if (rolloutTime == null)
+    return (
+      <div className="flex items-center gap-2">
+        <Failing /> Rollout not started
+      </div>
+    );
+
+  const isAfterOrOnRolloutTime = rolloutTime <= now;
+  if (isAfterOrOnRolloutTime)
+    return (
+      <div className="flex items-center gap-2">
+        <IconCheck className="h-4 w-4 text-green-400" /> Rollout passed
+      </div>
+    );
+
+  const timeTillRollout = formatDistanceToNowStrict(rolloutTime, {
+    addSuffix: true,
+  });
+
+  return (
+    <div className="flex items-center gap-2">
+      <Waiting /> Job will roll out {timeTillRollout}
+    </div>
+  );
+};
+
+export const PolicyEvaluationHover: React.FC<{
+  releaseTargetId: string;
+  versionId: string;
+  children: React.ReactNode;
+}> = (props) => {
+  const { data: policyEvaluations, isLoading } =
+    api.policy.evaluate.releaseTarget.useQuery({
+      releaseTargetId: props.releaseTargetId,
+      versionId: props.versionId,
+    });
+
+  const hasApprovalRules = policyEvaluations?.policies.some(
+    (p) =>
+      p.versionAnyApprovals != null ||
+      p.versionUserApprovals.length > 0 ||
+      p.versionRoleApprovals.length > 0,
+  );
+  const hasVersionSelectorRule = policyEvaluations?.policies.some(
+    (p) => p.deploymentVersionSelector != null,
+  );
+  const hasRolloutRule = policyEvaluations?.policies.some(
+    (p) => p.environmentVersionRollout != null,
+  );
+
+  return (
+    <HoverCard>
+      <HoverCardTrigger asChild onMouseEnter={(e) => e.stopPropagation()}>
+        {props.children}
+      </HoverCardTrigger>
+      <HoverCardContent side="right" className="p-2">
+        {isLoading && <div>Loading...</div>}
+        {!isLoading && policyEvaluations != null && (
+          <div className="flex flex-col gap-2">
+            {hasApprovalRules && (
+              <ApprovalCheck policyEvaluations={policyEvaluations} />
+            )}
+            {hasVersionSelectorRule && (
+              <VersionSelectorCheck policyEvaluations={policyEvaluations} />
+            )}
+            {hasRolloutRule && (
+              <RolloutCheck policyEvaluations={policyEvaluations} />
+            )}
+          </div>
+        )}
+      </HoverCardContent>
+    </HoverCard>
+  );
+};

--- a/apps/webservice/src/app/[workspaceSlug]/(app)/(deploy)/(raw)/systems/[systemSlug]/(raw)/deployments/[deploymentSlug]/(raw)/releases/[releaseId]/jobs/_components/ReleaseTargetRow.tsx
+++ b/apps/webservice/src/app/[workspaceSlug]/(app)/(deploy)/(raw)/systems/[systemSlug]/(raw)/deployments/[deploymentSlug]/(raw)/releases/[releaseId]/jobs/_components/ReleaseTargetRow.tsx
@@ -9,6 +9,7 @@ import {
   IconDots,
   IconExternalLink,
   IconReload,
+  IconShieldFilled,
   IconSwitch,
 } from "@tabler/icons-react";
 import { capitalCase } from "change-case";
@@ -32,6 +33,7 @@ import { ForceDeployVersionDialog } from "~/app/[workspaceSlug]/(app)/(deploy)/_
 import { RedeployVersionDialog } from "~/app/[workspaceSlug]/(app)/(deploy)/_components/deployment-version/RedeployVersionDialog";
 import { api } from "~/trpc/react";
 import { CollapsibleRow } from "./CollapsibleRow";
+import { PolicyEvaluationHover } from "./PolicyEvaluationHover";
 
 const ReleaseTargetActionsDropdownMenu: React.FC<{
   environment: { id: string; name: string };
@@ -172,6 +174,7 @@ export const ReleaseTargetRow: React.FC<{
   resource: { id: string; name: string };
   environment: { id: string; name: string };
   deployment: { id: string; name: string };
+  version: { id: string };
   jobs: Array<{
     id: string;
     status: SCHEMA.JobStatus;
@@ -179,7 +182,7 @@ export const ReleaseTargetRow: React.FC<{
     links: Record<string, string>;
     createdAt: Date;
   }>;
-}> = ({ id, resource, environment, deployment, jobs }) => {
+}> = ({ id, resource, environment, deployment, jobs, version }) => {
   const latestJob = jobs.at(0);
 
   return (
@@ -218,7 +221,15 @@ export const ReleaseTargetRow: React.FC<{
           {latestJob == null && (
             <>
               <TableCell>
-                <span className="text-sm text-muted-foreground">No jobs</span>
+                <PolicyEvaluationHover
+                  releaseTargetId={id}
+                  versionId={version.id}
+                >
+                  <div className="flex w-fit cursor-pointer items-center gap-1">
+                    <IconShieldFilled className="h-3 w-3 text-muted-foreground" />
+                    <span className="text-sm">Blocked by policy</span>
+                  </div>
+                </PolicyEvaluationHover>
               </TableCell>
               <TableCell />
               <TableCell />

--- a/apps/webservice/src/app/[workspaceSlug]/(app)/(deploy)/(raw)/systems/[systemSlug]/(raw)/deployments/[deploymentSlug]/(sidebar)/_components/release-cell/_hooks/useIsBlockedByPolicyVersionSelector.ts
+++ b/apps/webservice/src/app/[workspaceSlug]/(app)/(deploy)/(raw)/systems/[systemSlug]/(raw)/deployments/[deploymentSlug]/(sidebar)/_components/release-cell/_hooks/useIsBlockedByPolicyVersionSelector.ts
@@ -10,7 +10,7 @@ export const usePolicyEvaluations = () => {
     useDeploymentVersionEnvironmentContext();
 
   const { data: policyEvaluations, isLoading: isPolicyEvaluationsLoading } =
-    api.policy.evaluate.useQuery({
+    api.policy.evaluate.environment.useQuery({
       environmentId: environment.id,
       versionId: deploymentVersion.id,
     });

--- a/packages/api/src/router/policy/router.ts
+++ b/packages/api/src/router/policy/router.ts
@@ -21,14 +21,14 @@ import { Permission } from "@ctrlplane/validators/auth";
 import { createTRPCRouter, protectedProcedure } from "../../trpc";
 import { policyAiRouter } from "./ai";
 import { policyDenyWindowRouter } from "./deny-window";
-import { evaluate } from "./evaluate";
+import { evaluateRouter } from "./evaluate";
 import { policyTargetRouter } from "./target";
 
 export const policyRouter = createTRPCRouter({
   ai: policyAiRouter,
   target: policyTargetRouter,
   denyWindow: policyDenyWindowRouter,
-  evaluate,
+  evaluate: evaluateRouter,
 
   list: protectedProcedure
     .meta({


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a hoverable policy evaluation summary for deployment releases, displaying approval, version selector, and rollout status.
  * "Blocked by policy" indicators now appear when no jobs are available, with detailed policy information on hover.

* **Improvements**
  * Policy evaluation data is now fetched with more specific environment and release target context, enhancing accuracy and relevance of displayed policy statuses.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->