### PR TITLE
perf: reduce deployment version selector sql call count

### DIFF
--- a/e2e/api/entity-fixtures.ts
+++ b/e2e/api/entity-fixtures.ts
@@ -133,6 +133,13 @@ export const PolicyFixture = z.object({
     })
     .optional(),
   maxRetries: z.number().optional(),
+  deploymentVersionSelector: z
+    .object({
+      name: z.string(),
+      description: z.string().optional(),
+      deploymentVersionSelector: z.object({}).passthrough(),
+    })
+    .optional(),
 });
 
 export const AgentFixture = z.object({

--- a/e2e/tests/api/policies/version-selector-policy.spec.ts
+++ b/e2e/tests/api/policies/version-selector-policy.spec.ts
@@ -1,0 +1,160 @@
+import path from "path";
+import { faker } from "@faker-js/faker";
+import { expect } from "@playwright/test";
+import { Client } from "openapi-fetch";
+
+import { EntitiesBuilder } from "../../../api";
+import { paths } from "../../../api/schema";
+import { test } from "../../fixtures";
+
+const yamlPath = path.join(__dirname, "version-selector-policy.spec.yaml");
+
+const initDeployment = async (
+  api: Client<paths, `${string}/${string}`>,
+  builder: EntitiesBuilder,
+) => {
+  const systemId = builder.refs.system.id;
+  const deploymentName = faker.string.alphanumeric(10);
+  const deploymentResponse = await api.POST("/v1/deployments", {
+    body: {
+      name: deploymentName,
+      slug: deploymentName,
+      systemId,
+    },
+  });
+  expect(deploymentResponse.data?.id).toBeDefined();
+  return deploymentResponse.data!.id;
+};
+
+const initVersion = async (
+  api: Client<paths, `${string}/${string}`>,
+  versionTag: string,
+  deploymentId: string,
+) => {
+  const versionResponse = await api.POST("/v1/deployment-versions", {
+    body: {
+      deploymentId,
+      tag: versionTag,
+    },
+  });
+  expect(versionResponse.data?.id).toBeDefined();
+};
+
+const getTestReleaseTarget = async (
+  api: Client<paths, `${string}/${string}`>,
+  builder: EntitiesBuilder,
+  deploymentId: string,
+) => {
+  const resourceRef = builder.refs.takeResources(1)[0]!;
+  const workspaceId = builder.workspace.id;
+
+  const resourceResponse = await api.GET(
+    "/v1/workspaces/{workspaceId}/resources/identifier/{identifier}",
+    {
+      params: {
+        path: {
+          workspaceId,
+          identifier: resourceRef.identifier,
+        },
+      },
+    },
+  );
+  expect(resourceResponse.data?.id).toBeDefined();
+  const resourceId = resourceResponse.data!.id;
+
+  const releaseTargetsForResource = await api.GET(
+    "/v1/resources/{resourceId}/release-targets",
+    {
+      params: {
+        path: {
+          resourceId,
+        },
+      },
+    },
+  );
+
+  const environmentRef = builder.refs.takeEnvironments(1)[0]!;
+  const environmentId = environmentRef.id;
+
+  const releaseTarget = releaseTargetsForResource.data?.find(
+    (rt) =>
+      rt.environment.id === environmentId &&
+      rt.deployment.id === deploymentId &&
+      rt.resource.id === resourceId,
+  );
+
+  expect(releaseTarget).toBeDefined();
+  return releaseTarget!;
+};
+
+const getReleasesForTarget = async (
+  api: Client<paths, `${string}/${string}`>,
+  releaseTargetId: string,
+) => {
+  const releasesResponse = await api.GET(
+    "/v1/release-targets/{releaseTargetId}/releases",
+    {
+      params: {
+        path: {
+          releaseTargetId,
+        },
+      },
+    },
+  );
+
+  return releasesResponse.data ?? [];
+};
+
+test.describe("Version selector policy", () => {
+  let builder: EntitiesBuilder;
+
+  test.beforeEach(async ({ api, workspace }) => {
+    builder = new EntitiesBuilder(api, workspace, yamlPath);
+    await builder.upsertSystemFixture();
+    await builder.upsertEnvironmentFixtures();
+    await builder.upsertResourcesFixtures();
+    await builder.upsertPolicyFixtures();
+  });
+
+  test("should create release for version matching policy selector", async ({
+    api,
+    page,
+  }) => {
+    const deploymentId = await initDeployment(api, builder);
+    const versionTag = `${faker.string.alphanumeric(10)}-${builder.refs.prefix}`;
+    await initVersion(api, versionTag, deploymentId);
+    const releaseTarget = await getTestReleaseTarget(
+      api,
+      builder,
+      deploymentId,
+    );
+    await page.waitForTimeout(10_000);
+    const releases = await getReleasesForTarget(api, releaseTarget.id);
+
+    const releaseForVersion = releases.find(
+      ({ version }) => version.tag === versionTag,
+    );
+    expect(releaseForVersion).toBeDefined();
+  });
+
+  test("should not create release for version failing policy selector", async ({
+    api,
+    page,
+  }) => {
+    const deploymentId = await initDeployment(api, builder);
+    const versionTag = faker.string.alphanumeric(10);
+    await initVersion(api, versionTag, deploymentId);
+    const releaseTarget = await getTestReleaseTarget(
+      api,
+      builder,
+      deploymentId,
+    );
+    await page.waitForTimeout(10_000);
+    const releases = await getReleasesForTarget(api, releaseTarget.id);
+
+    const releaseForVersion = releases.find(
+      ({ version }) => version.tag === versionTag,
+    );
+    expect(releaseForVersion).toBeUndefined();
+  });
+});

--- a/e2e/tests/api/policies/version-selector-policy.spec.yaml
+++ b/e2e/tests/api/policies/version-selector-policy.spec.yaml
@@ -1,0 +1,36 @@
+system:
+  name: "{{ prefix }}-version-selector-policy"
+  slug: "{{ prefix }}-version-selector-policy"
+  description: System for testing version selector policy
+
+environments:
+  - name: "{{ prefix }}"
+    description: Prod environment
+    systemId: "{{ prefix }}-version-selector-policy"
+    resourceSelector:
+      type: identifier
+      operator: contains
+      value: "{{ prefix }}"
+
+resources:
+  - name: "{{ prefix }}-resource"
+    kind: service
+    identifier: "{{ prefix }}-resource"
+    version: "1.0.0"
+    config: {}
+    metadata:
+      env: prod
+
+policies:
+  - name: "{{ prefix }}-version-selector-policy"
+    targets:
+      - environmentSelector:
+          type: name
+          operator: contains
+          value: "{{ prefix }}"
+    deploymentVersionSelector:
+      name: "{{ prefix }}-version-selector"
+      deploymentVersionSelector:
+        type: tag
+        operator: contains
+        value: "{{ prefix }}"


### PR DESCRIPTION
this is responsible for most of the query load per the cloudsql insights

<img width="1612" alt="Screenshot 2025-07-09 at 11 52 16 PM" src="https://github.com/user-attachments/assets/fbb64def-879a-427c-b118-a1dbe16c166d" />
