### PR TITLE
fix: clean up workspace policy targets locking

### DIFF
--- a/apps/event-worker/src/workers/compute-systems-release-targets.ts
+++ b/apps/event-worker/src/workers/compute-systems-release-targets.ts
@@ -188,10 +188,7 @@ export const computeSystemsReleaseTargetsWorker = createWorker(
       await dispatchQueueJob()
         .toCompute()
         .workspace(workspaceId)
-        .policyTargets({
-          processedPolicyTargetIds: [],
-          releaseTargetsToEvaluate: created,
-        });
+        .policyTargets({ releaseTargetsToEvaluate: created });
     } catch (e: any) {
       const isRowLocked = e.code === "55P03";
       if (isRowLocked) {

--- a/apps/event-worker/src/workers/compute-workspace-policy-targets.ts
+++ b/apps/event-worker/src/workers/compute-workspace-policy-targets.ts
@@ -1,76 +1,145 @@
-import { and, eq, notInArray } from "@ctrlplane/db";
+import type { Tx } from "@ctrlplane/db";
+
+import { and, eq, inArray, isNull, selector, sql } from "@ctrlplane/db";
 import { db } from "@ctrlplane/db/client";
-import { computePolicyTargets } from "@ctrlplane/db/queries";
 import * as schema from "@ctrlplane/db/schema";
 import { Channel, createWorker, dispatchQueueJob } from "@ctrlplane/events";
 import { logger } from "@ctrlplane/logger";
 
 const log = logger.child({ module: "compute-workspace-policy-targets" });
 
-const getPolicyTargets = async (
-  workspaceId: string,
-  processedPolicyTargetIds: string[],
-) =>
-  db
+const getPolicyTargets = async (tx: Tx, workspaceId: string) =>
+  tx
     .select()
     .from(schema.policyTarget)
     .innerJoin(
       schema.policy,
       eq(schema.policyTarget.policyId, schema.policy.id),
     )
+    .where(eq(schema.policy.workspaceId, workspaceId));
+
+const findMatchingReleaseTargets = (
+  tx: Tx,
+  policyTarget: schema.PolicyTarget,
+) =>
+  tx
+    .select()
+    .from(schema.releaseTarget)
+    .innerJoin(
+      schema.resource,
+      eq(schema.releaseTarget.resourceId, schema.resource.id),
+    )
+    .innerJoin(
+      schema.deployment,
+      eq(schema.releaseTarget.deploymentId, schema.deployment.id),
+    )
+    .innerJoin(
+      schema.environment,
+      eq(schema.releaseTarget.environmentId, schema.environment.id),
+    )
     .where(
       and(
-        eq(schema.policy.workspaceId, workspaceId),
-        processedPolicyTargetIds.length > 0
-          ? notInArray(schema.policyTarget.id, processedPolicyTargetIds)
-          : undefined,
+        isNull(schema.resource.deletedAt),
+        selector()
+          .query()
+          .resources()
+          .where(policyTarget.resourceSelector)
+          .sql(),
+        selector()
+          .query()
+          .deployments()
+          .where(policyTarget.deploymentSelector)
+          .sql(),
+        selector()
+          .query()
+          .environments()
+          .where(policyTarget.environmentSelector)
+          .sql(),
+      ),
+    )
+    .then((rt) =>
+      rt.map((rt) => ({
+        policyTargetId: policyTarget.id,
+        releaseTargetId: rt.release_target.id,
+      })),
+    );
+
+const acquireWorkspacePolicyTargetsLock = async (tx: Tx, workspaceId: string) =>
+  tx.execute(
+    sql`
+    SELECT * FROM ${schema.policyTarget}
+    INNER JOIN ${schema.policy} ON ${eq(schema.policyTarget.policyId, schema.policy.id)}
+    WHERE ${eq(schema.policy.workspaceId, workspaceId)}
+    FOR UPDATE NOWAIT
+  `,
+  );
+
+const computePolicyTarget = async (
+  tx: Tx,
+  policyTarget: schema.PolicyTarget,
+) => {
+  const previous = await tx
+    .select()
+    .from(schema.computedPolicyTargetReleaseTarget)
+    .where(
+      eq(
+        schema.computedPolicyTargetReleaseTarget.policyTargetId,
+        policyTarget.id,
       ),
     );
+
+  const releaseTargets = await findMatchingReleaseTargets(tx, policyTarget);
+
+  const prevIds = new Set(previous.map((rt) => rt.releaseTargetId));
+  const nextIds = new Set(releaseTargets.map((rt) => rt.releaseTargetId));
+  const deleted = previous.filter((rt) => !nextIds.has(rt.releaseTargetId));
+  const created = releaseTargets.filter(
+    (rt) => !prevIds.has(rt.releaseTargetId),
+  );
+
+  if (deleted.length > 0)
+    await tx.delete(schema.computedPolicyTargetReleaseTarget).where(
+      inArray(
+        schema.computedPolicyTargetReleaseTarget.releaseTargetId,
+        deleted.map((rt) => rt.releaseTargetId),
+      ),
+    );
+
+  if (created.length > 0)
+    await tx
+      .insert(schema.computedPolicyTargetReleaseTarget)
+      .values(created)
+      .onConflictDoNothing();
+
+  return [...created, ...deleted].map((rt) => rt.releaseTargetId);
+};
 
 export const computeWorkspacePolicyTargetsWorker = createWorker(
   Channel.ComputeWorkspacePolicyTargets,
   async (job) => {
-    const { workspaceId, processedPolicyTargetIds, releaseTargetsToEvaluate } =
-      job.data;
+    const { workspaceId, releaseTargetsToEvaluate } = job.data;
 
-    const policyTargets = await getPolicyTargets(
-      workspaceId,
-      processedPolicyTargetIds ?? [],
-    );
+    try {
+      await db.transaction(async (tx) => {
+        await acquireWorkspacePolicyTargetsLock(tx, workspaceId);
 
-    if (policyTargets.length === 0) {
-      if (releaseTargetsToEvaluate != null)
-        await dispatchQueueJob()
-          .toEvaluate()
-          .releaseTargets(releaseTargetsToEvaluate);
-      return;
-    }
+        const policyTargets = await getPolicyTargets(tx, workspaceId);
+        if (policyTargets.length === 0) return;
 
-    const additionalProcessedPolicyTargetIds: string[] = [];
-
-    for (const { policy_target: policyTarget } of policyTargets) {
-      try {
-        await computePolicyTargets(db, policyTarget);
-        additionalProcessedPolicyTargetIds.push(policyTarget.id);
-      } catch (e: any) {
-        const isRowLockError = e.code === "55P03";
-        if (!isRowLockError) {
-          log.error("Failed to compute policy targets", { error: e });
-          throw e;
-        }
-
-        await dispatchQueueJob()
-          .toCompute()
-          .workspace(workspaceId)
-          .policyTargets({
-            releaseTargetsToEvaluate,
-            processedPolicyTargetIds: [
-              ...(processedPolicyTargetIds ?? []),
-              ...additionalProcessedPolicyTargetIds,
-            ],
-          });
+        for (const { policy_target: policyTarget } of policyTargets)
+          await computePolicyTarget(tx, policyTarget);
+      });
+    } catch (e: any) {
+      const isRowLockError = e.code === "55P03";
+      if (isRowLockError) {
+        dispatchQueueJob().toCompute().workspace(workspaceId).policyTargets({
+          releaseTargetsToEvaluate,
+        });
         return;
       }
+
+      log.error("Failed to compute workspace policy targets", { error: e });
+      throw e;
     }
 
     if (releaseTargetsToEvaluate != null)

--- a/apps/event-worker/src/workers/evaluate-release-target.ts
+++ b/apps/event-worker/src/workers/evaluate-release-target.ts
@@ -2,7 +2,7 @@ import type { Tx } from "@ctrlplane/db";
 import type { VersionEvaluateOptions } from "@ctrlplane/rule-engine";
 import _ from "lodash";
 
-import { and, desc, eq, sql, takeFirst } from "@ctrlplane/db";
+import { and, desc, eq, takeFirst } from "@ctrlplane/db";
 import { db } from "@ctrlplane/db/client";
 import { createReleaseJob } from "@ctrlplane/db/queries";
 import * as schema from "@ctrlplane/db/schema";
@@ -84,16 +84,14 @@ const handleVariableRelease = withSpan(
   },
 );
 
-const acquireReleaseTargetLock = async (tx: Tx, releaseTargetId: string) =>
-  tx.execute(
-    sql`
-    SELECT * FROM ${schema.releaseTarget}
-    INNER JOIN ${schema.computedPolicyTargetReleaseTarget} ON ${eq(schema.computedPolicyTargetReleaseTarget.releaseTargetId, schema.releaseTarget.id)}
-    INNER JOIN ${schema.policyTarget} ON ${eq(schema.computedPolicyTargetReleaseTarget.policyTargetId, schema.policyTarget.id)}
-    WHERE ${eq(schema.releaseTarget.id, releaseTargetId)}
-    FOR UPDATE NOWAIT
-  `,
-  );
+// const acquireReleaseTargetLock = async (tx: Tx, releaseTargetId: string) =>
+//   tx.execute(
+//     sql`
+//     SELECT * FROM ${schema.releaseTarget}
+//     WHERE ${eq(schema.releaseTarget.id, releaseTargetId)}
+//     FOR UPDATE NOWAIT
+//   `,
+//   );
 
 /**
  * Gets the latest version release for a specific release target
@@ -138,7 +136,7 @@ export const evaluateReleaseTargetWorker = createWorker(
         if (releaseTarget == null)
           throw new Error("Failed to get release target");
 
-        await acquireReleaseTargetLock(tx, releaseTarget.id);
+        // await acquireReleaseTargetLock(tx, releaseTarget.id);
 
         const latestVersionRelease = await getLatestVersionRelease(
           tx,

--- a/packages/events/src/dispatch-jobs.ts
+++ b/packages/events/src/dispatch-jobs.ts
@@ -94,7 +94,6 @@ const dispatchComputeSystemReleaseTargetsJobs = async (
 
 const dispatchComputeWorkspacePolicyTargetsJobs = async (
   workspaceId: string,
-  processedPolicyTargetIds?: string[],
   releaseTargetsToEvaluate?: ReleaseTargetIdentifier[],
 ) => {
   const q = getQueue(Channel.ComputeWorkspacePolicyTargets);
@@ -102,13 +101,11 @@ const dispatchComputeWorkspacePolicyTargetsJobs = async (
   const isAlreadyQueued = waiting.some(
     (job) =>
       job.data.workspaceId === workspaceId &&
-      _.isEqual(job.data.releaseTargetsToEvaluate, releaseTargetsToEvaluate) &&
-      _.isEqual(job.data.processedPolicyTargetIds, processedPolicyTargetIds),
+      _.isEqual(job.data.releaseTargetsToEvaluate, releaseTargetsToEvaluate),
   );
   if (isAlreadyQueued) return;
   await q.add(workspaceId, {
     workspaceId,
-    processedPolicyTargetIds,
     releaseTargetsToEvaluate,
   });
 };
@@ -141,12 +138,10 @@ const toCompute = () => ({
   }),
   workspace: (workspaceId: string) => ({
     policyTargets: (opts?: {
-      processedPolicyTargetIds?: string[];
       releaseTargetsToEvaluate?: ReleaseTargetIdentifier[];
     }) =>
       dispatchComputeWorkspacePolicyTargetsJobs(
         workspaceId,
-        opts?.processedPolicyTargetIds,
         opts?.releaseTargetsToEvaluate,
       ),
   }),

--- a/packages/events/src/types.ts
+++ b/packages/events/src/types.ts
@@ -89,7 +89,6 @@ export type ChannelMap = {
   [Channel.ComputePolicyTargetReleaseTargetSelector]: { id: string };
   [Channel.ComputeWorkspacePolicyTargets]: {
     workspaceId: string;
-    processedPolicyTargetIds?: string[];
     releaseTargetsToEvaluate?: ReleaseTargetIdentifier[];
   };
   [Channel.ComputeSystemsReleaseTargets]: { id: string };


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Refactor**
  * Improved handling of workspace policy target computations for better consistency and reliability.
  * Introduced transaction-based locking to prevent concurrent modifications during policy target processing.
  * Modularized computation logic for policy targets and release targets.
  * Simplified concurrency handling and retry logic for workspace-level operations.
  * Removed unused imports and disabled explicit row-level locking during release target evaluation.
  * Streamlined job dispatching by removing obsolete parameters related to processed policy targets.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->