### PR TITLE
fix: stale version does not evict newer version

### DIFF
--- a/e2e/tests/api/releases/release.spec.yaml
+++ b/e2e/tests/api/releases/release.spec.yaml
@@ -22,3 +22,7 @@ environments:
       type: identifier
       operator: contains
       value: "{{ prefix }}"
+
+agents:
+  - name: "{{ prefix }}-agent"
+    type: "{{ prefix }}-agent-type"

--- a/e2e/tests/api/releases/version-release.spec.ts
+++ b/e2e/tests/api/releases/version-release.spec.ts
@@ -15,6 +15,7 @@ test.describe("Version Release Creation", () => {
     await builder.upsertSystemFixture();
     await builder.upsertResourcesFixtures();
     await builder.upsertEnvironmentFixtures();
+    await builder.upsertAgentFixtures();
     await new Promise((resolve) => setTimeout(resolve, 1_000));
   });
 
@@ -101,5 +102,139 @@ test.describe("Version Release Creation", () => {
     const releases = releaseResponse.data ?? [];
     const release = releases.find((rel) => rel.version.tag === versionTag);
     expect(release).toBeDefined();
+  });
+
+  test("should not create a release when a new version is created but is older than the current version deployed to a target", async ({
+    api,
+    page,
+    workspace,
+  }) => {
+    const systemPrefix = builder.refs.system.slug.split("-")[0]!;
+    const { id: agentId } = builder.refs.oneAgent();
+    const deploymentName = `${systemPrefix}-${faker.string.alphanumeric(10)}`;
+    const deploymentCreateResponse = await api.POST("/v1/deployments", {
+      body: {
+        name: deploymentName,
+        slug: deploymentName,
+        systemId: builder.refs.system.id,
+        jobAgentId: agentId,
+      },
+    });
+    expect(deploymentCreateResponse.response.status).toBe(201);
+    const deploymentId = deploymentCreateResponse.data?.id ?? "";
+
+    const newerVersionTag = faker.string.alphanumeric(10);
+    const olderVersionTag = faker.string.alphanumeric(10);
+
+    const newerCreatedAtDate = new Date(Date.now() - 1000);
+    const olderCreatedAtDate = new Date(Date.now() - 2000);
+
+    const versionResponse = await api.POST("/v1/deployment-versions", {
+      body: {
+        deploymentId,
+        tag: newerVersionTag,
+        metadata: { e2e: "true" },
+        createdAt: newerCreatedAtDate.toISOString(),
+      },
+    });
+    expect(versionResponse.response.status).toBe(201);
+
+    const importedResource = builder.refs.resources.at(0)!;
+    const resourceResponse = await api.GET(
+      "/v1/workspaces/{workspaceId}/resources/identifier/{identifier}",
+      {
+        params: {
+          path: {
+            workspaceId: workspace.id,
+            identifier: importedResource.identifier,
+          },
+        },
+      },
+    );
+    const resourceId = resourceResponse.data?.id ?? "";
+
+    const releaseTargetResponse = await api.GET(
+      "/v1/resources/{resourceId}/release-targets",
+      {
+        params: {
+          path: {
+            resourceId,
+          },
+        },
+      },
+    );
+    expect(releaseTargetResponse.response.status).toBe(200);
+    const releaseTargets = releaseTargetResponse.data ?? [];
+    const releaseTarget = releaseTargets.find(
+      (rt) => rt.deployment.id === deploymentId,
+    );
+    expect(releaseTarget).toBeDefined();
+
+    await page.waitForTimeout(12_000);
+
+    const releaseResponse = await api.GET(
+      "/v1/release-targets/{releaseTargetId}/releases",
+      {
+        params: {
+          path: {
+            releaseTargetId: releaseTarget?.id ?? "",
+          },
+        },
+      },
+    );
+    expect(releaseResponse.response.status).toBe(200);
+    const releases = releaseResponse.data ?? [];
+    const newerRelease = releases.find(
+      (rel) => rel.version.tag === newerVersionTag,
+    );
+    expect(newerRelease).toBeDefined();
+
+    const nextJobResponse = await api.GET(
+      "/v1/job-agents/{agentId}/queue/next",
+      {
+        params: {
+          path: { agentId },
+        },
+      },
+    );
+    expect(nextJobResponse.response.status).toBe(200);
+    const nextJobId = nextJobResponse.data?.jobs?.[0]?.id;
+    expect(nextJobId).toBeDefined();
+
+    const successfulJobResponse = await api.PATCH("/v1/jobs/{jobId}", {
+      params: { path: { jobId: nextJobId ?? "" } },
+      body: { status: "successful" },
+    });
+
+    expect(successfulJobResponse.response.status).toBe(200);
+
+    const olderVersionResponse = await api.POST("/v1/deployment-versions", {
+      body: {
+        deploymentId,
+        tag: olderVersionTag,
+        metadata: { e2e: "true" },
+        createdAt: olderCreatedAtDate.toISOString(),
+      },
+    });
+    expect(olderVersionResponse.response.status).toBe(201);
+
+    await page.waitForTimeout(12_000);
+
+    const nextReleaseResponse = await api.GET(
+      "/v1/release-targets/{releaseTargetId}/releases",
+      {
+        params: {
+          path: {
+            releaseTargetId: releaseTarget?.id ?? "",
+          },
+        },
+      },
+    );
+    expect(nextReleaseResponse.response.status).toBe(200);
+    const nextReleases = nextReleaseResponse.data ?? [];
+    const nextRelease = nextReleases.find(
+      (rel) => rel.version.tag === olderVersionTag,
+    );
+    expect(nextRelease).toBeUndefined();
   });
 });


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for defining agents in the release system configuration.

* **Bug Fixes**
  * Improved release creation logic to prevent releases for versions older than the currently deployed version.
  * Enhanced validation to ensure only newer versions are considered for deployment.

* **Tests**
  * Added a test case verifying that releases are not created for older versions than those already deployed.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->