### PR TITLE
chore: selector methods assume single entity or selector

### DIFF
--- a/apps/event-queue/package.json
+++ b/apps/event-queue/package.json
@@ -18,6 +18,7 @@
     "@t3-oss/env-core": "catalog:",
     "dotenv": "^16.4.5",
     "kafkajs": "^2.2.4",
+    "ts-is-present": "catalog:",
     "zod": "catalog:"
   },
   "devDependencies": {

--- a/apps/event-queue/src/selector/db-environment-resource.ts
+++ b/apps/event-queue/src/selector/db-environment-resource.ts
@@ -1,0 +1,378 @@
+import type { Tx } from "@ctrlplane/db";
+import { isPresent } from "ts-is-present";
+
+import {
+  and,
+  buildConflictUpdateColumns,
+  eq,
+  inArray,
+  isNotNull,
+  isNull,
+  selector,
+  takeFirstOrNull,
+} from "@ctrlplane/db";
+import { db as dbClient } from "@ctrlplane/db/client";
+import * as schema from "@ctrlplane/db/schema";
+
+import type { MatchChange, Selector } from "./selector.js";
+import { MatchChangeType } from "./selector.js";
+
+type DbEnvironmentResourceSelectorOptions = {
+  workspaceId: string;
+  db?: Tx;
+};
+
+export class DbEnvironmentResourceSelector
+  implements Selector<schema.Environment, schema.Resource>
+{
+  private db: Tx;
+  private workspaceId: string;
+
+  constructor(opts: DbEnvironmentResourceSelectorOptions) {
+    this.db = opts.db ?? dbClient;
+    this.workspaceId = opts.workspaceId;
+  }
+
+  private async upsertResource(resource: schema.Resource) {
+    await this.db
+      .insert(schema.resource)
+      .values({ ...resource, deletedAt: null })
+      .onConflictDoUpdate({
+        target: [schema.resource.id],
+        set: buildConflictUpdateColumns(schema.resource, [
+          "name",
+          "kind",
+          "version",
+          "identifier",
+          "providerId",
+          "config",
+          "lockedAt",
+          "deletedAt",
+        ]),
+      });
+  }
+
+  private async getPreviouslyMatchedEnvironments(resource: schema.Resource) {
+    return this.db
+      .select()
+      .from(schema.computedEnvironmentResource)
+      .innerJoin(
+        schema.environment,
+        eq(
+          schema.computedEnvironmentResource.environmentId,
+          schema.environment.id,
+        ),
+      )
+      .innerJoin(
+        schema.system,
+        eq(schema.environment.systemId, schema.system.id),
+      )
+      .where(eq(schema.computedEnvironmentResource.resourceId, resource.id))
+      .then((results) => results.map(({ environment }) => environment));
+  }
+
+  private async getMatchableEnvironments() {
+    return this.db
+      .select()
+      .from(schema.environment)
+      .innerJoin(
+        schema.system,
+        eq(schema.environment.systemId, schema.system.id),
+      )
+      .where(
+        and(
+          eq(schema.system.workspaceId, this.workspaceId),
+          isNotNull(schema.environment.resourceSelector),
+        ),
+      );
+  }
+
+  private async getResourceMatchesEnvironment(
+    resource: schema.Resource,
+    environment: schema.Environment,
+  ) {
+    const { resourceSelector } = environment;
+    const resourceMatch = await this.db
+      .select()
+      .from(schema.resource)
+      .where(
+        and(
+          eq(schema.resource.id, resource.id),
+          selector().query().resources().where(resourceSelector).sql(),
+        ),
+      )
+      .then(takeFirstOrNull);
+
+    return resourceMatch != null ? environment : null;
+  }
+
+  private async getCurrentlyMatchingEnvironments(resource: schema.Resource) {
+    const wsEnvironments = await this.getMatchableEnvironments();
+
+    const matchingEnvsPromise = wsEnvironments.map(({ environment }) =>
+      this.getResourceMatchesEnvironment(resource, environment),
+    );
+
+    return Promise.all(matchingEnvsPromise).then((results) =>
+      results.filter(isPresent),
+    );
+  }
+
+  async upsertEntity(
+    entity: schema.Resource,
+  ): Promise<MatchChange<schema.Resource, schema.Environment>[]> {
+    await this.upsertResource(entity);
+    const [previouslyMatchedEnvironments, currentlyMatchingEnvironments] =
+      await Promise.all([
+        this.getPreviouslyMatchedEnvironments(entity),
+        this.getCurrentlyMatchingEnvironments(entity),
+      ]);
+
+    const removedMatchChanges = previouslyMatchedEnvironments
+      .filter((env) => !currentlyMatchingEnvironments.includes(env))
+      .map((env) => ({
+        entity,
+        selector: env,
+        changeType: MatchChangeType.Removed,
+      }));
+
+    const newlyMatchedChanges = currentlyMatchingEnvironments
+      .filter((env) => !previouslyMatchedEnvironments.includes(env))
+      .map((env) => ({
+        entity,
+        selector: env,
+        changeType: MatchChangeType.Added,
+      }));
+
+    await Promise.all([
+      this.db.delete(schema.computedEnvironmentResource).where(
+        and(
+          eq(schema.computedEnvironmentResource.resourceId, entity.id),
+          inArray(
+            schema.computedEnvironmentResource.environmentId,
+            removedMatchChanges.map(({ selector }) => selector.id),
+          ),
+        ),
+      ),
+      this.db.insert(schema.computedEnvironmentResource).values(
+        newlyMatchedChanges.map(({ selector }) => ({
+          environmentId: selector.id,
+          resourceId: entity.id,
+        })),
+      ),
+    ]);
+
+    return [...removedMatchChanges, ...newlyMatchedChanges];
+  }
+
+  async removeEntity(
+    entity: schema.Resource,
+  ): Promise<MatchChange<schema.Resource, schema.Environment>[]> {
+    const previouslyMatchedEnvironments =
+      await this.getPreviouslyMatchedEnvironments(entity);
+
+    const removedMatchChanges = previouslyMatchedEnvironments.map((env) => ({
+      entity,
+      selector: env,
+      changeType: MatchChangeType.Removed,
+    }));
+
+    await Promise.all([
+      this.db.delete(schema.computedEnvironmentResource).where(
+        and(
+          eq(schema.computedEnvironmentResource.resourceId, entity.id),
+          inArray(
+            schema.computedEnvironmentResource.environmentId,
+            removedMatchChanges.map(({ selector }) => selector.id),
+          ),
+        ),
+      ),
+      this.db
+        .update(schema.resource)
+        .set({ deletedAt: new Date() })
+        .where(eq(schema.resource.id, entity.id)),
+    ]);
+
+    return removedMatchChanges;
+  }
+
+  private async upsertEnvironment(environment: schema.Environment) {
+    await this.db
+      .insert(schema.environment)
+      .values(environment)
+      .onConflictDoUpdate({
+        target: [schema.environment.id],
+        set: buildConflictUpdateColumns(schema.environment, [
+          "resourceSelector",
+        ]),
+      });
+  }
+
+  private async getPreviouslyMatchedResources(environment: schema.Environment) {
+    return this.db
+      .select()
+      .from(schema.computedEnvironmentResource)
+      .innerJoin(
+        schema.resource,
+        eq(schema.computedEnvironmentResource.resourceId, schema.resource.id),
+      )
+      .where(
+        eq(schema.computedEnvironmentResource.environmentId, environment.id),
+      )
+      .then((results) => results.map(({ resource }) => resource));
+  }
+
+  private async getCurrentlyMatchingResources(environment: schema.Environment) {
+    const { resourceSelector } = environment;
+    if (resourceSelector == null) return [];
+
+    return this.db
+      .select()
+      .from(schema.resource)
+      .where(
+        and(
+          eq(schema.resource.workspaceId, this.workspaceId),
+          selector().query().resources().where(resourceSelector).sql(),
+          isNull(schema.resource.deletedAt),
+        ),
+      );
+  }
+
+  async upsertSelector(
+    selector: schema.Environment,
+  ): Promise<MatchChange<schema.Resource, schema.Environment>[]> {
+    const previouslyMatchedResources =
+      await this.getPreviouslyMatchedResources(selector);
+    await this.upsertEnvironment(selector);
+    const currentlyMatchingResources =
+      await this.getCurrentlyMatchingResources(selector);
+
+    const removedMatchChanges = previouslyMatchedResources
+      .filter((resource) => !currentlyMatchingResources.includes(resource))
+      .map((resource) => ({
+        entity: resource,
+        selector,
+        changeType: MatchChangeType.Removed,
+      }));
+
+    const newlyMatchedChanges = currentlyMatchingResources
+      .filter((resource) => !previouslyMatchedResources.includes(resource))
+      .map((resource) => ({
+        entity: resource,
+        selector,
+        changeType: MatchChangeType.Added,
+      }));
+
+    await Promise.all([
+      this.db.delete(schema.computedEnvironmentResource).where(
+        and(
+          eq(schema.computedEnvironmentResource.environmentId, selector.id),
+          inArray(
+            schema.computedEnvironmentResource.resourceId,
+            removedMatchChanges.map(({ entity }) => entity.id),
+          ),
+        ),
+      ),
+      this.db.insert(schema.computedEnvironmentResource).values(
+        newlyMatchedChanges.map(({ entity }) => ({
+          environmentId: selector.id,
+          resourceId: entity.id,
+        })),
+      ),
+    ]);
+
+    return [...removedMatchChanges, ...newlyMatchedChanges];
+  }
+
+  async removeSelector(
+    selector: schema.Environment,
+  ): Promise<MatchChange<schema.Resource, schema.Environment>[]> {
+    const previouslyMatchedResources =
+      await this.getPreviouslyMatchedResources(selector);
+
+    const removedMatchChanges = previouslyMatchedResources.map((resource) => ({
+      entity: resource,
+      selector,
+      changeType: MatchChangeType.Removed,
+    }));
+
+    await this.db
+      .delete(schema.environment)
+      .where(eq(schema.environment.id, selector.id));
+
+    return removedMatchChanges;
+  }
+
+  getEntitiesForSelector(
+    selector: schema.Environment,
+  ): Promise<schema.Resource[]> {
+    return this.db
+      .select()
+      .from(schema.computedEnvironmentResource)
+      .innerJoin(
+        schema.resource,
+        eq(schema.computedEnvironmentResource.resourceId, schema.resource.id),
+      )
+      .where(eq(schema.computedEnvironmentResource.environmentId, selector.id))
+      .then((rows) => rows.map(({ resource }) => resource));
+  }
+
+  getSelectorsForEntity(
+    entity: schema.Resource,
+  ): Promise<schema.Environment[]> {
+    return this.db
+      .select()
+      .from(schema.computedEnvironmentResource)
+      .innerJoin(
+        schema.environment,
+        eq(
+          schema.computedEnvironmentResource.environmentId,
+          schema.environment.id,
+        ),
+      )
+      .where(eq(schema.computedEnvironmentResource.resourceId, entity.id))
+      .then((rows) => rows.map(({ environment }) => environment));
+  }
+
+  getAllEntities(): Promise<schema.Resource[]> {
+    return this.db
+      .select()
+      .from(schema.resource)
+      .where(
+        and(
+          eq(schema.resource.workspaceId, this.workspaceId),
+          isNull(schema.resource.deletedAt),
+        ),
+      );
+  }
+
+  getAllSelectors(): Promise<schema.Environment[]> {
+    return this.db
+      .select()
+      .from(schema.environment)
+      .innerJoin(
+        schema.system,
+        eq(schema.environment.systemId, schema.system.id),
+      )
+      .where(eq(schema.system.workspaceId, this.workspaceId))
+      .then((rows) => rows.map(({ environment }) => environment));
+  }
+
+  async isMatch(
+    entity: schema.Resource,
+    selector: schema.Environment,
+  ): Promise<boolean> {
+    const matchResult = await this.db
+      .select()
+      .from(schema.computedEnvironmentResource)
+      .where(
+        and(
+          eq(schema.computedEnvironmentResource.resourceId, entity.id),
+          eq(schema.computedEnvironmentResource.environmentId, selector.id),
+        ),
+      )
+      .then(takeFirstOrNull);
+
+    return matchResult != null;
+  }
+}

--- a/apps/event-queue/src/selector/selector.ts
+++ b/apps/event-queue/src/selector/selector.ts
@@ -6,12 +6,19 @@ import type {
   Workspace,
 } from "@ctrlplane/db/schema";
 
-export interface Selector<S, E> {
-  upsertEntity(...entity: E[]): Promise<void>;
-  removeEntity(...entity: E[]): Promise<void>;
+type MatchChangeType = "added" | "removed";
+export type MatchChange<E, S> = {
+  entity: E;
+  selector: S;
+  changeType: MatchChangeType;
+};
 
-  upsertSelector(...selector: S[]): Promise<void>;
-  removeSelector(...selector: S[]): Promise<void>;
+export interface Selector<S, E> {
+  upsertEntity(entity: E): Promise<MatchChange<E, S>[]>;
+  removeEntity(entity: E): Promise<MatchChange<E, S>[]>;
+
+  upsertSelector(selector: S): Promise<MatchChange<E, S>[]>;
+  removeSelector(selector: S): Promise<MatchChange<E, S>[]>;
 
   getEntitiesForSelector(selector: S): Promise<E[]>;
   getSelectorsForEntity(entity: E): Promise<S[]>;
@@ -33,49 +40,49 @@ export class SelectorManager {
 
   constructor(private opts: SelectorManagerOptions) {}
 
-  async updateResources(resources: Resource[]) {
+  async updateResource(resource: Resource) {
     await Promise.all([
-      this.environmentResources.upsertEntity(...resources),
-      this.deploymentResources.upsertEntity(...resources),
-      this.policyTargetResources.upsertEntity(...resources),
+      this.environmentResources.upsertEntity(resource),
+      this.deploymentResources.upsertEntity(resource),
+      this.policyTargetResources.upsertEntity(resource),
     ]);
   }
 
-  async updateEnvironments(environments: Environment[]) {
-    await this.policyTargetEnvironments.upsertEntity(...environments);
-    await this.environmentResources.upsertSelector(...environments);
+  async updateEnvironment(environment: Environment) {
+    await this.policyTargetEnvironments.upsertEntity(environment);
+    await this.environmentResources.upsertSelector(environment);
   }
 
-  async updateDeployments(deployments: Deployment[]) {
-    await this.policyTargetDeployments.upsertEntity(...deployments);
-    await this.deploymentResources.upsertSelector(...deployments);
+  async updateDeployment(deployment: Deployment) {
+    await this.policyTargetDeployments.upsertEntity(deployment);
+    await this.deploymentResources.upsertSelector(deployment);
   }
 
-  async removeResources(resources: Resource[]) {
-    await this.environmentResources.removeEntity(...resources);
-    await this.deploymentResources.removeEntity(...resources);
-    await this.policyTargetResources.removeEntity(...resources);
+  async removeResource(resource: Resource) {
+    await this.environmentResources.removeEntity(resource);
+    await this.deploymentResources.removeEntity(resource);
+    await this.policyTargetResources.removeEntity(resource);
   }
 
-  async removeEnvironments(environments: Environment[]) {
-    await this.policyTargetEnvironments.removeEntity(...environments);
-    await this.environmentResources.removeSelector(...environments);
+  async removeEnvironment(environment: Environment) {
+    await this.policyTargetEnvironments.removeEntity(environment);
+    await this.environmentResources.removeSelector(environment);
   }
 
-  async removeDeployments(deployments: Deployment[]) {
-    await this.policyTargetDeployments.removeEntity(...deployments);
-    await this.deploymentResources.removeSelector(...deployments);
+  async removeDeployment(deployment: Deployment) {
+    await this.policyTargetDeployments.removeEntity(deployment);
+    await this.deploymentResources.removeSelector(deployment);
   }
 
-  async upsertPolicyTargets(policyTargets: PolicyTarget[]) {
-    await this.policyTargetResources.upsertSelector(...policyTargets);
-    await this.policyTargetEnvironments.upsertSelector(...policyTargets);
-    await this.policyTargetDeployments.upsertSelector(...policyTargets);
+  async upsertPolicyTargets(policyTarget: PolicyTarget) {
+    await this.policyTargetResources.upsertSelector(policyTarget);
+    await this.policyTargetEnvironments.upsertSelector(policyTarget);
+    await this.policyTargetDeployments.upsertSelector(policyTarget);
   }
 
-  async removePolicyTargets(policyTargets: PolicyTarget[]) {
-    await this.policyTargetResources.removeSelector(...policyTargets);
-    await this.policyTargetEnvironments.removeSelector(...policyTargets);
-    await this.policyTargetDeployments.removeSelector(...policyTargets);
+  async removePolicyTargets(policyTarget: PolicyTarget) {
+    await this.policyTargetResources.removeSelector(policyTarget);
+    await this.policyTargetEnvironments.removeSelector(policyTarget);
+    await this.policyTargetDeployments.removeSelector(policyTarget);
   }
 }

--- a/apps/event-queue/src/selector/selector.ts
+++ b/apps/event-queue/src/selector/selector.ts
@@ -6,7 +6,11 @@ import type {
   Workspace,
 } from "@ctrlplane/db/schema";
 
-type MatchChangeType = "added" | "removed";
+export enum MatchChangeType {
+  Added = "added",
+  Removed = "removed",
+}
+
 export type MatchChange<E, S> = {
   entity: E;
   selector: S;

--- a/apps/event-queue/src/workspace/pipeline.ts
+++ b/apps/event-queue/src/workspace/pipeline.ts
@@ -7,13 +7,13 @@ type WorkspaceOptions = {
 
   operation: "update" | "delete";
 
-  resources?: schema.Resource[];
-  environments?: schema.Environment[];
-  deployments?: schema.Deployment[];
-  deploymentVersions?: schema.DeploymentVersion[];
-  policies?: schema.Policy[];
-  jobs?: schema.Job[];
-  jobAgents?: schema.JobAgent[];
+  resource?: schema.Resource;
+  environment?: schema.Environment;
+  deployment?: schema.Deployment;
+  deploymentVersion?: schema.DeploymentVersion;
+  policy?: schema.Policy;
+  job?: schema.Job;
+  jobAgent?: schema.JobAgent;
 
   releaseTargets?: {
     new: schema.ReleaseTarget[];
@@ -36,47 +36,46 @@ export class OperationPipeline {
     return new OperationPipeline({ workspace, operation: "delete" });
   }
 
-  resources(...resources: schema.Resource[]) {
-    this.opts.resources = resources;
+  resource(resource: schema.Resource) {
+    this.opts.resource = resource;
     return this;
   }
 
-  environments(...environments: schema.Environment[]) {
-    this.opts.environments = environments;
+  environment(environment: schema.Environment) {
+    this.opts.environment = environment;
     return this;
   }
 
-  deployments(...deployments: schema.Deployment[]) {
-    this.opts.deployments = deployments;
+  deployment(deployment: schema.Deployment) {
+    this.opts.deployment = deployment;
     return this;
   }
 
   getReleaseTargetChanges() {}
 
   async dispatch() {
-    const {
-      operation,
-      workspace,
-      resources = [],
-      environments = [],
-      deployments = [],
-    } = this.opts;
+    const { operation, workspace, resource, environment, deployment } =
+      this.opts;
 
     const manager = workspace.selectorManager;
 
     switch (operation) {
       case "update":
         await Promise.all([
-          manager.updateResources(resources),
-          manager.updateEnvironments(environments),
-          manager.updateDeployments(deployments),
+          resource ? manager.updateResource(resource) : Promise.resolve(),
+          environment
+            ? manager.updateEnvironment(environment)
+            : Promise.resolve(),
+          deployment ? manager.updateDeployment(deployment) : Promise.resolve(),
         ]);
         break;
       case "delete":
         await Promise.all([
-          manager.removeResources(resources),
-          manager.removeEnvironments(environments),
-          manager.removeDeployments(deployments),
+          resource ? manager.removeResource(resource) : Promise.resolve(),
+          environment
+            ? manager.removeEnvironment(environment)
+            : Promise.resolve(),
+          deployment ? manager.removeDeployment(deployment) : Promise.resolve(),
         ]);
         break;
     }

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -154,6 +154,9 @@ importers:
       kafkajs:
         specifier: ^2.2.4
         version: 2.2.4
+      ts-is-present:
+        specifier: 'catalog:'
+        version: 1.2.2
       zod:
         specifier: 'catalog:'
         version: 3.24.2


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- New Features
  - Update/remove operations now return detailed match changes (added/removed) so callers see which relationships changed.
  - Added a database-backed environment↔resource selector for workspace-scoped matching.

- Refactor
  - Public APIs shifted from batch to single-item operations.
  - Builder methods and workspace options now use singular fields (resource, environment, deployment, etc.) instead of arrays.
  - Dispatch/delete flows now call optional single-item manager methods rather than batch calls.

- Chore
  - Added new dependency: ts-is-present.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->