### PR TITLE
chore: only taint target on successful job

### DIFF
--- a/apps/workspace-engine/pkg/workspace/releasemanager/policy/evaluator/skipdeployed/skipdeplyed.go
+++ b/apps/workspace-engine/pkg/workspace/releasemanager/policy/evaluator/skipdeployed/skipdeplyed.go
@@ -3,7 +3,6 @@ package skipdeployed
 import (
 	"context"
 	"fmt"
-	"slices"
 	"time"
 	"workspace-engine/pkg/oapi"
 	"workspace-engine/pkg/workspace/releasemanager/policy/evaluator"
@@ -23,12 +22,6 @@ func NewSkipDeployedEvaluator(store *store.Store) *SkipDeployedEvaluator {
 	return &SkipDeployedEvaluator{
 		store: store,
 	}
-}
-
-var validJobStatuses = []oapi.JobStatus{
-	oapi.Pending,
-	oapi.InProgress,
-	oapi.Successful,
 }
 
 // Evaluate checks if the release has already been attempted.
@@ -56,10 +49,6 @@ func (e *SkipDeployedEvaluator) Evaluate(
 		// If the job was created before the target was created, ignore it
 		if job.CreatedAt.Before(target.CreatedAt) {
 			// resource might be added, then deleted and readded, so we need to ignore jobs created before the target was created
-			continue
-		}
-
-		if !slices.Contains(validJobStatuses, job.Status) {
 			continue
 		}
 

--- a/apps/workspace-engine/pkg/workspace/releasemanager/targets/taint.go
+++ b/apps/workspace-engine/pkg/workspace/releasemanager/targets/taint.go
@@ -90,15 +90,6 @@ func (tp *TaintProcessor) processChanges(changeSet *changeset.ChangeSet[any]) {
 			tp.taintByResourceId(entity.Id)
 
 		case *oapi.Job:
-			oapiJob, ok := oapi.ConvertToOapiJob(entity)
-			if !ok {
-				continue
-			}
-
-			if oapiJob.Status != oapi.Successful {
-				continue
-			}
-
 			rel, ok := tp.store.Releases.Get(entity.ReleaseId)
 			if !ok {
 				continue


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed deployment policy to consider all previous job statuses, including failed and cancelled states, when evaluating redeployment eligibility.
  * Redeployments for releases with prior failed or cancelled deployments are now correctly denied.
  * Updated job recency detection to use creation time instead of completion time.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->