### PR TITLE
chore: add rule id to deploydecision and get rules oapi

### DIFF
--- a/apps/workspace-engine/oapi/openapi.json
+++ b/apps/workspace-engine/oapi/openapi.json
@@ -1137,9 +1137,14 @@
                "message": {
                   "description": "Human-readable explanation of the rule result",
                   "type": "string"
+               },
+               "ruleId": {
+                  "description": "The ID of the rule that was evaluated",
+                  "type": "string"
                }
             },
             "required": [
+               "ruleId",
                "allowed",
                "actionRequired",
                "message",
@@ -3134,6 +3139,74 @@
                }
             },
             "summary": "Get release targets for a policy"
+         }
+      },
+      "/v1/workspaces/{workspaceId}/policies/{policyId}/rules/{ruleId}": {
+         "get": {
+            "description": "Returns a specific rule by ID.",
+            "operationId": "getRule",
+            "parameters": [
+               {
+                  "description": "ID of the workspace",
+                  "in": "path",
+                  "name": "workspaceId",
+                  "required": true,
+                  "schema": {
+                     "type": "string"
+                  }
+               },
+               {
+                  "description": "ID of the policy",
+                  "in": "path",
+                  "name": "policyId",
+                  "required": true,
+                  "schema": {
+                     "type": "string"
+                  }
+               },
+               {
+                  "description": "ID of the rule",
+                  "in": "path",
+                  "name": "ruleId",
+                  "required": true,
+                  "schema": {
+                     "type": "string"
+                  }
+               }
+            ],
+            "responses": {
+               "200": {
+                  "content": {
+                     "application/json": {
+                        "schema": {
+                           "$ref": "#/components/schemas/PolicyRule"
+                        }
+                     }
+                  },
+                  "description": "OK response"
+               },
+               "400": {
+                  "content": {
+                     "application/json": {
+                        "schema": {
+                           "$ref": "#/components/schemas/ErrorResponse"
+                        }
+                     }
+                  },
+                  "description": "Invalid request"
+               },
+               "404": {
+                  "content": {
+                     "application/json": {
+                        "schema": {
+                           "$ref": "#/components/schemas/ErrorResponse"
+                        }
+                     }
+                  },
+                  "description": "Resource not found"
+               }
+            },
+            "summary": "Get rule"
          }
       },
       "/v1/workspaces/{workspaceId}/relationship-rules": {

--- a/apps/workspace-engine/oapi/spec/lib/openapi.libsonnet
+++ b/apps/workspace-engine/oapi/spec/lib/openapi.libsonnet
@@ -19,6 +19,7 @@
   // Common parameters
   workspaceIdParam():: self.stringParam('workspaceId', 'ID of the workspace'),
   policyIdParam():: self.stringParam('policyId', 'ID of the policy'),
+  ruleIdParam():: self.stringParam('ruleId', 'ID of the rule'),
   resourceIdParam():: self.stringParam('resourceId', 'ID of the resource'),
   resourceIdentifierParam():: self.stringParam('resourceIdentifier', 'Identifier of the resource'),
   deploymentIdParam():: self.stringParam('deploymentId', 'ID of the deployment'),

--- a/apps/workspace-engine/oapi/spec/paths/policy.jsonnet
+++ b/apps/workspace-engine/oapi/spec/paths/policy.jsonnet
@@ -65,4 +65,20 @@ local openapi = import '../lib/openapi.libsonnet';
       ) + openapi.notFoundResponse(),
     },
   },
+
+  '/v1/workspaces/{workspaceId}/policies/{policyId}/rules/{ruleId}': {
+    get: {
+      summary: 'Get rule',
+      operationId: 'getRule',
+      description: 'Returns a specific rule by ID.',
+      parameters: [
+        openapi.workspaceIdParam(),
+        openapi.policyIdParam(),
+        openapi.ruleIdParam(),
+      ],
+      responses: openapi.okResponse(openapi.schemaRef('PolicyRule'))
+                 + openapi.notFoundResponse()
+                 + openapi.badRequestResponse(),
+    },
+  },
 }

--- a/apps/workspace-engine/oapi/spec/schemas/policy.jsonnet
+++ b/apps/workspace-engine/oapi/spec/schemas/policy.jsonnet
@@ -137,8 +137,12 @@ local openapi = import '../lib/openapi.libsonnet';
 
   RuleEvaluation: {
     type: 'object',
-    required: ['allowed', 'actionRequired', 'message', 'details'],
+    required: ['ruleId', 'allowed', 'actionRequired', 'message', 'details'],
     properties: {
+      ruleId: {
+        type: 'string',
+        description: 'The ID of the rule that was evaluated',
+      },
       allowed: {
         type: 'boolean',
         description: 'Whether the rule allows the deployment',

--- a/apps/workspace-engine/pkg/oapi/evaluation.go
+++ b/apps/workspace-engine/pkg/oapi/evaluation.go
@@ -2,6 +2,7 @@ package oapi
 
 func NewRuleEvaluation() *RuleEvaluation {
 	return &RuleEvaluation{
+		RuleId:         "",
 		Allowed:        false,
 		ActionRequired: false,
 		ActionType:     nil,
@@ -17,6 +18,11 @@ func (r *RuleEvaluation) Allow() *RuleEvaluation {
 
 func (r *RuleEvaluation) Deny() *RuleEvaluation {
 	r.Allowed = false
+	return r
+}
+
+func (r *RuleEvaluation) WithRuleId(ruleId string) *RuleEvaluation {
+	r.RuleId = ruleId
 	return r
 }
 

--- a/apps/workspace-engine/pkg/oapi/oapi.gen.go
+++ b/apps/workspace-engine/pkg/oapi/oapi.gen.go
@@ -484,6 +484,9 @@ type RuleEvaluation struct {
 
 	// Message Human-readable explanation of the rule result
 	Message string `json:"message"`
+
+	// RuleId The ID of the rule that was evaluated
+	RuleId string `json:"ruleId"`
 }
 
 // RuleEvaluationActionType Type of action required
@@ -1373,6 +1376,9 @@ type ServerInterface interface {
 	// Get release targets for a policy
 	// (GET /v1/workspaces/{workspaceId}/policies/{policyId}/release-targets)
 	GetReleaseTargetsForPolicy(c *gin.Context, workspaceId string, policyId string)
+	// Get rule
+	// (GET /v1/workspaces/{workspaceId}/policies/{policyId}/rules/{ruleId})
+	GetRule(c *gin.Context, workspaceId string, policyId string, ruleId string)
 	// Get relationship rules for a given workspace
 	// (GET /v1/workspaces/{workspaceId}/relationship-rules)
 	GetRelationshipRules(c *gin.Context, workspaceId string, params GetRelationshipRulesParams)
@@ -2326,6 +2332,48 @@ func (siw *ServerInterfaceWrapper) GetReleaseTargetsForPolicy(c *gin.Context) {
 	siw.Handler.GetReleaseTargetsForPolicy(c, workspaceId, policyId)
 }
 
+// GetRule operation middleware
+func (siw *ServerInterfaceWrapper) GetRule(c *gin.Context) {
+
+	var err error
+
+	// ------------- Path parameter "workspaceId" -------------
+	var workspaceId string
+
+	err = runtime.BindStyledParameterWithOptions("simple", "workspaceId", c.Param("workspaceId"), &workspaceId, runtime.BindStyledParameterOptions{Explode: false, Required: true})
+	if err != nil {
+		siw.ErrorHandler(c, fmt.Errorf("Invalid format for parameter workspaceId: %w", err), http.StatusBadRequest)
+		return
+	}
+
+	// ------------- Path parameter "policyId" -------------
+	var policyId string
+
+	err = runtime.BindStyledParameterWithOptions("simple", "policyId", c.Param("policyId"), &policyId, runtime.BindStyledParameterOptions{Explode: false, Required: true})
+	if err != nil {
+		siw.ErrorHandler(c, fmt.Errorf("Invalid format for parameter policyId: %w", err), http.StatusBadRequest)
+		return
+	}
+
+	// ------------- Path parameter "ruleId" -------------
+	var ruleId string
+
+	err = runtime.BindStyledParameterWithOptions("simple", "ruleId", c.Param("ruleId"), &ruleId, runtime.BindStyledParameterOptions{Explode: false, Required: true})
+	if err != nil {
+		siw.ErrorHandler(c, fmt.Errorf("Invalid format for parameter ruleId: %w", err), http.StatusBadRequest)
+		return
+	}
+
+	for _, middleware := range siw.HandlerMiddlewares {
+		middleware(c)
+		if c.IsAborted() {
+			return
+		}
+	}
+
+	siw.Handler.GetRule(c, workspaceId, policyId, ruleId)
+}
+
 // GetRelationshipRules operation middleware
 func (siw *ServerInterfaceWrapper) GetRelationshipRules(c *gin.Context) {
 
@@ -2822,6 +2870,7 @@ func RegisterHandlersWithOptions(router gin.IRouter, si ServerInterface, options
 	router.GET(options.BaseURL+"/v1/workspaces/:workspaceId/policies", wrapper.ListPolicies)
 	router.GET(options.BaseURL+"/v1/workspaces/:workspaceId/policies/:policyId", wrapper.GetPolicy)
 	router.GET(options.BaseURL+"/v1/workspaces/:workspaceId/policies/:policyId/release-targets", wrapper.GetReleaseTargetsForPolicy)
+	router.GET(options.BaseURL+"/v1/workspaces/:workspaceId/policies/:policyId/rules/:ruleId", wrapper.GetRule)
 	router.GET(options.BaseURL+"/v1/workspaces/:workspaceId/relationship-rules", wrapper.GetRelationshipRules)
 	router.GET(options.BaseURL+"/v1/workspaces/:workspaceId/relationship-rules/:relationshipRuleId", wrapper.GetRelationshipRule)
 	router.POST(options.BaseURL+"/v1/workspaces/:workspaceId/release-targets/evaluate", wrapper.EvaluateReleaseTarget)

--- a/apps/workspace-engine/pkg/server/openapi/policies/policies.go
+++ b/apps/workspace-engine/pkg/server/openapi/policies/policies.go
@@ -1,6 +1,7 @@
 package policies
 
 import (
+	"fmt"
 	"net/http"
 	"workspace-engine/pkg/oapi"
 	"workspace-engine/pkg/selector"
@@ -98,5 +99,34 @@ func (p *Policies) GetReleaseTargetsForPolicy(c *gin.Context, workspaceId string
 
 	c.JSON(http.StatusOK, gin.H{
 		"releaseTargets": matchingReleaseTargets,
+	})
+}
+
+func (p *Policies) GetRule(c *gin.Context, workspaceId string, policyId string, ruleId string) {
+	ws, err := utils.GetWorkspace(c, workspaceId)
+	if err != nil {
+		c.JSON(http.StatusInternalServerError, gin.H{
+			"error": "Failed to get workspace: " + err.Error(),
+		})
+		return
+	}
+
+	policy, ok := ws.Policies().Get(policyId)
+	if !ok {
+		c.JSON(http.StatusNotFound, gin.H{
+			"error": "Policy not found",
+		})
+		return
+	}
+
+	for _, rule := range policy.Rules {
+		if rule.Id == ruleId {
+			c.JSON(http.StatusOK, rule)
+			return
+		}
+	}
+
+	c.JSON(http.StatusNotFound, gin.H{
+		"error": fmt.Sprintf("Rule %s not found in policy %s", ruleId, policyId),
 	})
 }

--- a/apps/workspace-engine/pkg/workspace/releasemanager/policy/factory.go
+++ b/apps/workspace-engine/pkg/workspace/releasemanager/policy/factory.go
@@ -39,7 +39,7 @@ func (f *EvaluatorFactory) EvaluateEnvironmentAndVersionAndTargetScopedPolicyRul
 			if err != nil {
 				return nil, err
 			}
-			ruleResults = append(ruleResults, result)
+			ruleResults = append(ruleResults, result.WithRuleId(rule.Id))
 		}
 		return ruleResults, nil
 	})
@@ -62,7 +62,7 @@ func (f *EvaluatorFactory) EvaluateEnvironmentAndVersionScopedPolicyRules(
 			if err != nil {
 				return nil, err
 			}
-			ruleResults = append(ruleResults, result)
+			ruleResults = append(ruleResults, result.WithRuleId(rule.Id))
 		}
 		return ruleResults, nil
 	})
@@ -86,7 +86,7 @@ func (f *EvaluatorFactory) EvaluateVersionScopedPolicyRules(
 			if err != nil {
 				return nil, err
 			}
-			ruleResults = append(ruleResults, result)
+			ruleResults = append(ruleResults, result.WithRuleId(rule.Id))
 		}
 		return ruleResults, nil
 	})
@@ -110,7 +110,7 @@ func (f *EvaluatorFactory) EvaluateTargetScopedPolicyRules(
 			if err != nil {
 				return nil, err
 			}
-			ruleResults = append(ruleResults, result)
+			ruleResults = append(ruleResults, result.WithRuleId(rule.Id))
 		}
 		return ruleResults, nil
 	})
@@ -134,7 +134,7 @@ func (f *EvaluatorFactory) EvaluateReleaseScopedPolicyRules(
 			if err != nil {
 				return nil, err
 			}
-			ruleResults = append(ruleResults, result)
+			ruleResults = append(ruleResults, result.WithRuleId(rule.Id))
 		}
 		return ruleResults, nil
 	})
@@ -157,7 +157,7 @@ func (f *EvaluatorFactory) EvaluateWorkspaceScopedPolicyRules(
 			if err != nil {
 				return nil, err
 			}
-			ruleResults = append(ruleResults, result)
+			ruleResults = append(ruleResults, result.WithRuleId(rule.Id))
 		}
 		return ruleResults, nil
 	})


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added a new API endpoint to retrieve a specific policy rule by workspace, policy, and rule ID
  * Rule evaluation results now include the associated rule identifier

<!-- end of auto-generated comment: release notes by coderabbit.ai -->