### PR TITLE
perf: only process newer candidate versions

### DIFF
--- a/apps/workspace-engine/pkg/events/handler/deploymentversion/deploymentversion.go
+++ b/apps/workspace-engine/pkg/events/handler/deploymentversion/deploymentversion.go
@@ -40,7 +40,8 @@ func HandleDeploymentVersionCreated(
 	}
 
 	ws.ReleaseManager().ReconcileTargets(ctx, releaseTargets,
-		releasemanager.WithTrigger(trace.TriggerVersionCreated))
+		releasemanager.WithTrigger(trace.TriggerVersionCreated),
+		releasemanager.WithEarliestVersionForEvaluation(deploymentVersion))
 
 	return nil
 }
@@ -68,7 +69,8 @@ func HandleDeploymentVersionUpdated(
 		return err
 	}
 	ws.ReleaseManager().ReconcileTargets(ctx, releaseTargets,
-		releasemanager.WithTrigger(trace.TriggerVersionCreated))
+		releasemanager.WithTrigger(trace.TriggerVersionCreated),
+		releasemanager.WithEarliestVersionForEvaluation(deploymentVersion))
 
 	return nil
 }

--- a/apps/workspace-engine/pkg/workspace/releasemanager/deployment_orchestrator.go
+++ b/apps/workspace-engine/pkg/workspace/releasemanager/deployment_orchestrator.go
@@ -93,6 +93,7 @@ func (o *DeploymentOrchestrator) Reconcile(
 		releaseTarget,
 		deployment.WithResourceRelatedEntities(options.resourceRelationships),
 		deployment.WithTraceRecorder(recorder),
+		deployment.WithEarliestVersionForEvaluation(options.earliestVersionForEvaluation),
 	)
 	if err != nil {
 		span.RecordError(err)

--- a/apps/workspace-engine/pkg/workspace/releasemanager/opts.go
+++ b/apps/workspace-engine/pkg/workspace/releasemanager/opts.go
@@ -8,9 +8,10 @@ import (
 // options is a unified options struct for all releasemanager methods
 type options struct {
 	// ReleaseManager options
-	skipEligibilityCheck  bool
-	trigger               trace.TriggerReason
-	resourceRelationships map[string][]*oapi.EntityRelation
+	skipEligibilityCheck         bool
+	trigger                      trace.TriggerReason
+	resourceRelationships        map[string][]*oapi.EntityRelation
+	earliestVersionForEvaluation *oapi.DeploymentVersion
 
 	// StateCache options
 	bypassCache    bool
@@ -32,6 +33,12 @@ func WithSkipEligibilityCheck(skip bool) Option {
 func WithTrigger(trigger trace.TriggerReason) Option {
 	return func(opts *options) {
 		opts.trigger = trigger
+	}
+}
+
+func WithEarliestVersionForEvaluation(version *oapi.DeploymentVersion) Option {
+	return func(opts *options) {
+		opts.earliestVersionForEvaluation = version
 	}
 }
 

--- a/apps/workspace-engine/test/e2e/engine_environment_progression_soak_test.go
+++ b/apps/workspace-engine/test/e2e/engine_environment_progression_soak_test.go
@@ -663,8 +663,10 @@ func TestEngine_EnvironmentProgression_MultipleVersions(t *testing.T) {
 	engine.PushEvent(ctx, handler.JobUpdate, v2StagingJob)
 
 	// Trigger policy re-evaluation
-	engine.PushEvent(ctx, handler.DeploymentVersionUpdate, version2)
 	time.Sleep(100 * time.Millisecond)
+
+	// send a workspace tick to trigger reconciliation
+	engine.PushEvent(ctx, handler.WorkspaceTick, nil)
 
 	// v2.0.0 production job should NOT be created
 	// (even though v1.0.0 has past soak time, v2.0.0's own soak time hasn't elapsed)


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Deployment version selection now supports filtering based on earliest evaluation timestamp, enabling more granular control over which versions are considered during release planning and reconciliation workflows.
  * Enhanced deployment orchestration to leverage earliest-version constraints during the reconciliation process, improving version candidate selection logic.

* **Tests**
  * Updated test scenarios to reflect new version evaluation behavior in multi-version deployment workflows.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->