### PR TITLE
Standardize Go templating variable casing to lowercase

### DIFF
--- a/apps/web/app/routes/ws/deployments/settings/_components/ArgoCD.tsx
+++ b/apps/web/app/routes/ws/deployments/settings/_components/ArgoCD.tsx
@@ -15,13 +15,13 @@ const DEFAULT_CONFIG = {
   apiVersion: "argoproj.io/v1alpha1",
   kind: "Application",
   metadata: {
-    name: "{{.Resource.Name}}-application",
+    name: "{{.resource.name}}-application",
     namespace: "argocd",
     labels: {
-      "app.kubernetes.io/name": "{{.Resource.Name}}",
-      environment: "{{.Environment.Name}}",
-      deployment: "{{.Deployment.Name}}",
-      resource: "{{.Resource.Name}}",
+      "app.kubernetes.io/name": "{{.resource.name}}",
+      environment: "{{.environment.name}}",
+      deployment: "{{.deployment.name}}",
+      resource: "{{.resource.name}}",
     },
   },
   spec: {
@@ -31,11 +31,11 @@ const DEFAULT_CONFIG = {
       path: "YOUR_PATH_IN_REPO",
       targetRevision: "HEAD",
       helm: {
-        releaseName: "{{.Resource.Name}}",
+        releaseName: "{{.resource.name}}",
       },
     },
     destination: {
-      name: "{{.Resource.Identifier}}",
+      name: "{{.resource.identifier}}",
       namespace: "default",
     },
     syncPolicy: {

--- a/apps/workspace-engine/pkg/oapi/job.go
+++ b/apps/workspace-engine/pkg/oapi/job.go
@@ -48,3 +48,54 @@ func (j *JobWithRelease) ToTemplatable() (*TemplatableJob,
 		Release:        release,
 	}, nil
 }
+
+// Map converts the TemplatableJob to a map with lowercase keys for template use.
+// This provides a consistent template interface using lowercase field names
+// (e.g., {{.resource.name}} instead of {{.Resource.Name}}).
+func (t *TemplatableJob) Map() map[string]any {
+	result := make(map[string]any)
+
+	// Convert each field to a map using JSON marshal/unmarshal
+	// This ensures all keys are lowercase per JSON tags
+
+	// Resource
+	if t.Resource != nil {
+		result["resource"] = structToMap(t.Resource)
+	}
+
+	// Deployment
+	if t.Deployment != nil {
+		result["deployment"] = structToMap(t.Deployment)
+	}
+
+	// Environment
+	if t.Environment != nil {
+		result["environment"] = structToMap(t.Environment)
+	}
+
+	// Job
+	result["job"] = structToMap(t.Job)
+
+	// Release with variables
+	if t.Release != nil {
+		releaseMap := structToMap(t.Release.Release)
+		releaseMap["variables"] = t.Release.Variables
+		result["release"] = releaseMap
+	}
+
+	return result
+}
+
+// structToMap converts a struct to a map using JSON marshal/unmarshal.
+// This ensures all keys use the lowercase JSON tag names.
+func structToMap(v any) map[string]any {
+	data, err := json.Marshal(v)
+	if err != nil {
+		return nil
+	}
+	var result map[string]any
+	if err := json.Unmarshal(data, &result); err != nil {
+		return nil
+	}
+	return result
+}

--- a/apps/workspace-engine/pkg/oapi/job_test.go
+++ b/apps/workspace-engine/pkg/oapi/job_test.go
@@ -1,0 +1,169 @@
+package oapi
+
+import (
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestTemplatableJob_Map(t *testing.T) {
+	now := time.Now()
+	job := &TemplatableJob{
+		JobWithRelease: JobWithRelease{
+			Job: Job{
+				Id:        "job-123",
+				ReleaseId: "release-456",
+				Status:    JobStatusPending,
+				CreatedAt: now,
+				UpdatedAt: now,
+			},
+			Resource: &Resource{
+				Id:         "resource-def",
+				Name:       "my-app",
+				Identifier: "my-app-identifier",
+				Kind:       "Kubernetes",
+				Version:    "1.0.0",
+				Config: map[string]interface{}{
+					"namespace": "production",
+					"cluster":   "us-west-2",
+				},
+				Metadata: map[string]string{
+					"team": "platform",
+				},
+			},
+			Environment: &Environment{
+				Id:   "env-abc",
+				Name: "production",
+			},
+			Deployment: &Deployment{
+				Id:   "deployment-789",
+				Name: "my-deployment",
+			},
+		},
+		Release: &TemplatableRelease{
+			Release: Release{
+				CreatedAt: now.Format(time.RFC3339),
+				ReleaseTarget: ReleaseTarget{
+					DeploymentId:  "deployment-789",
+					EnvironmentId: "env-abc",
+					ResourceId:    "resource-def",
+				},
+				Version: DeploymentVersion{
+					Id:   "version-001",
+					Name: "v1.2.3",
+					Tag:  "v1.2.3",
+				},
+			},
+			Variables: map[string]string{
+				"IMAGE_TAG": "v1.2.3",
+				"REPLICAS":  "3",
+			},
+		},
+	}
+
+	m := job.Map()
+	require.NotNil(t, m)
+
+	// Test lowercase resource fields
+	resource, ok := m["resource"].(map[string]any)
+	require.True(t, ok, "resource should be a map")
+	assert.Equal(t, "my-app", resource["name"])
+	assert.Equal(t, "my-app-identifier", resource["identifier"])
+	assert.Equal(t, "Kubernetes", resource["kind"])
+
+	// Test resource config
+	config, ok := resource["config"].(map[string]any)
+	require.True(t, ok, "resource.config should be a map")
+	assert.Equal(t, "production", config["namespace"])
+	assert.Equal(t, "us-west-2", config["cluster"])
+
+	// Test lowercase environment fields
+	environment, ok := m["environment"].(map[string]any)
+	require.True(t, ok, "environment should be a map")
+	assert.Equal(t, "production", environment["name"])
+
+	// Test lowercase deployment fields
+	deployment, ok := m["deployment"].(map[string]any)
+	require.True(t, ok, "deployment should be a map")
+	assert.Equal(t, "my-deployment", deployment["name"])
+
+	// Test lowercase release fields
+	release, ok := m["release"].(map[string]any)
+	require.True(t, ok, "release should be a map")
+
+	// Test release.version
+	version, ok := release["version"].(map[string]any)
+	require.True(t, ok, "release.version should be a map")
+	assert.Equal(t, "v1.2.3", version["name"])
+	assert.Equal(t, "v1.2.3", version["tag"])
+
+	// Test release.variables
+	variables, ok := release["variables"].(map[string]string)
+	require.True(t, ok, "release.variables should be a map[string]string")
+	assert.Equal(t, "v1.2.3", variables["IMAGE_TAG"])
+	assert.Equal(t, "3", variables["REPLICAS"])
+
+	// Test lowercase job fields
+	jobMap, ok := m["job"].(map[string]any)
+	require.True(t, ok, "job should be a map")
+	assert.Equal(t, "job-123", jobMap["id"])
+}
+
+func TestTemplatableJob_Map_NilFields(t *testing.T) {
+	now := time.Now()
+	job := &TemplatableJob{
+		JobWithRelease: JobWithRelease{
+			Job: Job{
+				Id:        "job-123",
+				ReleaseId: "release-456",
+				Status:    JobStatusPending,
+				CreatedAt: now,
+				UpdatedAt: now,
+			},
+			// Resource, Environment, Deployment are nil
+		},
+		// Release is nil
+	}
+
+	m := job.Map()
+	require.NotNil(t, m)
+
+	// Nil fields should not be present in the map
+	_, ok := m["resource"]
+	assert.False(t, ok, "resource should not be present when nil")
+
+	_, ok = m["environment"]
+	assert.False(t, ok, "environment should not be present when nil")
+
+	_, ok = m["deployment"]
+	assert.False(t, ok, "deployment should not be present when nil")
+
+	_, ok = m["release"]
+	assert.False(t, ok, "release should not be present when nil")
+
+	// Job should always be present
+	_, ok = m["job"]
+	assert.True(t, ok, "job should always be present")
+}
+
+func TestStructToMap(t *testing.T) {
+	resource := &Resource{
+		Id:         "resource-123",
+		Name:       "test-resource",
+		Identifier: "test-identifier",
+		Kind:       "Kubernetes",
+		Version:    "1.0.0",
+	}
+
+	m := structToMap(resource)
+	require.NotNil(t, m)
+
+	// Verify lowercase keys from JSON tags
+	assert.Equal(t, "resource-123", m["id"])
+	assert.Equal(t, "test-resource", m["name"])
+	assert.Equal(t, "test-identifier", m["identifier"])
+	assert.Equal(t, "Kubernetes", m["kind"])
+	assert.Equal(t, "1.0.0", m["version"])
+}

--- a/apps/workspace-engine/pkg/workspace/jobdispatch/argocd.go
+++ b/apps/workspace-engine/pkg/workspace/jobdispatch/argocd.go
@@ -198,7 +198,7 @@ func (d *ArgoCDDispatcher) DispatchJob(ctx context.Context, job *oapi.Job) error
 	}
 
 	var buf bytes.Buffer
-	if err := t.Execute(&buf, templatableJobWithRelease); err != nil {
+	if err := t.Execute(&buf, templatableJobWithRelease.Map()); err != nil {
 		span.RecordError(err)
 		span.SetStatus(codes.Error, "failed to execute template")
 		message := fmt.Sprintf("Failed to execute ArgoCD Application template: %s", err.Error())

--- a/apps/workspace-engine/pkg/workspace/jobdispatch/argocd_test.go
+++ b/apps/workspace-engine/pkg/workspace/jobdispatch/argocd_test.go
@@ -303,7 +303,8 @@ func executeTemplate(templateStr string, data *oapi.TemplatableJob) (string, err
 		return "", err
 	}
 	var buf bytes.Buffer
-	if err := t.Execute(&buf, data); err != nil {
+	// Use Map() for lowercase template variables, matching the actual dispatcher behavior
+	if err := t.Execute(&buf, data.Map()); err != nil {
 		return "", err
 	}
 	return buf.String(), nil
@@ -391,32 +392,32 @@ func TestTemplateExecution_BasicFields(t *testing.T) {
 	}{
 		{
 			name:     "job id",
-			template: `{{ .Job.Id }}`,
+			template: `{{ .job.id }}`,
 			expected: "job-123",
 		},
 		{
 			name:     "resource name",
-			template: `{{ .Resource.Name }}`,
+			template: `{{ .resource.name }}`,
 			expected: "my-app",
 		},
 		{
 			name:     "resource identifier",
-			template: `{{ .Resource.Identifier }}`,
+			template: `{{ .resource.identifier }}`,
 			expected: "my-app-identifier",
 		},
 		{
 			name:     "environment name",
-			template: `{{ .Environment.Name }}`,
+			template: `{{ .environment.name }}`,
 			expected: "production",
 		},
 		{
 			name:     "deployment name",
-			template: `{{ .Deployment.Name }}`,
+			template: `{{ .deployment.name }}`,
 			expected: "my-deployment",
 		},
 		{
 			name:     "release version name",
-			template: `{{ .Release.Version.Name }}`,
+			template: `{{ .release.version.name }}`,
 			expected: "v1.2.3",
 		},
 	}
@@ -440,17 +441,17 @@ func TestTemplateExecution_ReleaseVariables(t *testing.T) {
 	}{
 		{
 			name:     "access variable by key",
-			template: `{{ index .Release.Variables "IMAGE_TAG" }}`,
+			template: `{{ index .release.variables "IMAGE_TAG" }}`,
 			expected: "v1.2.3",
 		},
 		{
 			name:     "access multiple variables",
-			template: `tag={{ index .Release.Variables "IMAGE_TAG" }}, replicas={{ index .Release.Variables "REPLICAS" }}`,
+			template: `tag={{ index .release.variables "IMAGE_TAG" }}, replicas={{ index .release.variables "REPLICAS" }}`,
 			expected: "tag=v1.2.3, replicas=3",
 		},
 		{
 			name:     "missing variable returns empty with missingkey=zero",
-			template: `{{ index .Release.Variables "NONEXISTENT" }}`,
+			template: `{{ index .release.variables "NONEXISTENT" }}`,
 			expected: "",
 		},
 	}
@@ -474,12 +475,12 @@ func TestTemplateExecution_ResourceConfig(t *testing.T) {
 	}{
 		{
 			name:     "access config value",
-			template: `{{ index .Resource.Config "namespace" }}`,
+			template: `{{ index .resource.config "namespace" }}`,
 			expected: "production",
 		},
 		{
 			name:     "access nested config",
-			template: `{{ index .Resource.Config "cluster" }}`,
+			template: `{{ index .resource.config "cluster" }}`,
 			expected: "us-west-2",
 		},
 	}
@@ -503,22 +504,22 @@ func TestTemplateExecution_SprigFunctions(t *testing.T) {
 	}{
 		{
 			name:     "lower function",
-			template: `{{ .Resource.Name | lower }}`,
+			template: `{{ .resource.name | lower }}`,
 			expected: "my-app",
 		},
 		{
 			name:     "upper function",
-			template: `{{ .Resource.Name | upper }}`,
+			template: `{{ .resource.name | upper }}`,
 			expected: "MY-APP",
 		},
 		{
 			name:     "replace function",
-			template: `{{ .Resource.Name | replace "-" "_" }}`,
+			template: `{{ .resource.name | replace "-" "_" }}`,
 			expected: "my_app",
 		},
 		{
 			name:     "default function for missing value",
-			template: `{{ index .Release.Variables "MISSING" | default "default-value" }}`,
+			template: `{{ index .release.variables "MISSING" | default "default-value" }}`,
 			expected: "default-value",
 		},
 	}
@@ -538,20 +539,20 @@ func TestTemplateExecution_FullArgoCDApplication(t *testing.T) {
 	templateStr := `apiVersion: argoproj.io/v1alpha1
 kind: Application
 metadata:
-  name: {{ .Resource.Name }}
+  name: {{ .resource.name }}
   namespace: argocd
   labels:
-    app: {{ .Resource.Name }}
-    env: {{ .Environment.Name }}
+    app: {{ .resource.name }}
+    env: {{ .environment.name }}
 spec:
   project: default
   source:
     repoURL: https://github.com/example/repo
-    path: manifests/{{ .Environment.Name }}
-    targetRevision: {{ index .Release.Variables "IMAGE_TAG" }}
+    path: manifests/{{ .environment.name }}
+    targetRevision: {{ index .release.variables "IMAGE_TAG" }}
   destination:
     server: https://kubernetes.default.svc
-    namespace: {{ index .Resource.Config "namespace" }}`
+    namespace: {{ index .resource.config "namespace" }}`
 
 	result, err := executeTemplate(templateStr, job)
 	require.NoError(t, err)
@@ -578,7 +579,7 @@ func TestTemplateExecution_NilResource(t *testing.T) {
 	job.Resource = nil
 
 	// With missingkey=zero, accessing nil resource should not panic
-	templateStr := `name: {{ if .Resource }}{{ .Resource.Name }}{{ else }}unknown{{ end }}`
+	templateStr := `name: {{ if .resource }}{{ .resource.name }}{{ else }}unknown{{ end }}`
 	result, err := executeTemplate(templateStr, job)
 	require.NoError(t, err)
 	require.Equal(t, "name: unknown", result)
@@ -593,11 +594,11 @@ func TestTemplateExecution_InvalidTemplate(t *testing.T) {
 	}{
 		{
 			name:     "unclosed action",
-			template: `{{ .Job.Id`,
+			template: `{{ .job.id`,
 		},
 		{
 			name:     "unknown function",
-			template: `{{ nonexistentFunc .Job.Id }}`,
+			template: `{{ nonexistentFunc .job.id }}`,
 		},
 	}
 
@@ -787,15 +788,15 @@ func TestArgoCDDispatcher_DispatchJob_Success(t *testing.T) {
 	templateStr := `apiVersion: argoproj.io/v1alpha1
 kind: Application
 metadata:
-  name: {{ .Resource.Name }}
+  name: {{ .resource.name }}
   namespace: argocd
   labels:
-    env: {{ .Environment.Name }}
+    env: {{ .environment.name }}
 spec:
   project: default
   source:
     repoURL: https://github.com/example/repo
-    targetRevision: {{ .Release.Version.Name }}
+    targetRevision: {{ .release.version.name }}
   destination:
     server: https://kubernetes.default.svc
     namespace: production`
@@ -862,10 +863,10 @@ func TestArgoCDDispatcher_DispatchJob_CleansApplicationName(t *testing.T) {
 	templateStr := `apiVersion: argoproj.io/v1alpha1
 kind: Application
 metadata:
-  name: {{ .Resource.Name }}
+  name: {{ .resource.name }}
   namespace: argocd
   labels:
-    original-name: {{ .Resource.Name }}`
+    original-name: {{ .resource.name }}`
 
 	config := createArgoCDJobConfig(t, templateStr)
 
@@ -984,7 +985,7 @@ func TestArgoCDDispatcher_DispatchJob_InvalidTemplate(t *testing.T) {
 	)
 
 	// Invalid template syntax
-	templateStr := `{{ .Resource.Name`
+	templateStr := `{{ .resource.name`
 
 	config := createArgoCDJobConfig(t, templateStr)
 
@@ -1202,7 +1203,7 @@ func TestArgoCDDispatcher_DispatchJob_InvalidTemplate_SendsMessage(t *testing.T)
 	)
 
 	// Invalid template syntax
-	templateStr := `{{ .Resource.Name`
+	templateStr := `{{ .resource.name`
 
 	config := createArgoCDJobConfig(t, templateStr)
 

--- a/apps/workspace-engine/pkg/workspace/jobdispatch/terraformcloud.go
+++ b/apps/workspace-engine/pkg/workspace/jobdispatch/terraformcloud.go
@@ -198,7 +198,7 @@ func (d *TerraformCloudDispatcher) generateWorkspace(job *oapi.TemplatableJob, t
 	}
 
 	var buf bytes.Buffer
-	if err := t.Execute(&buf, job); err != nil {
+	if err := t.Execute(&buf, job.Map()); err != nil {
 		return nil, fmt.Errorf("failed to execute template: %w", err)
 	}
 


### PR DESCRIPTION
Standardize Go templating variable casing to lowercase for consistency across all templating surfaces.

Previously, verification templating used lowercase variables (via JSON serialization), while job dispatching used PascalCase directly from Go structs, leading to inconsistent template variable access. This change aligns job dispatching with the lowercase convention.

---
<a href="https://cursor.com/background-agent?bcId=bc-a4126ab4-d0c6-4dbc-b1e7-0478f8a01ea2"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-a4126ab4-d0c6-4dbc-b1e7-0478f8a01ea2"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Unifies template variable casing to lowercase across job dispatchers and UI.
> 
> - Adds `TemplatableJob.Map()` (with `structToMap`) to expose lowercase, JSON-tagged fields for templating (e.g., `{{.resource.name}}`, `{{.release.variables}}`)
> - Updates ArgoCD and Terraform Cloud dispatchers to execute templates using `Map()` instead of struct fields
> - Adjusts ArgoCD default YAML in the web UI to use lowercase placeholders
> - Updates and expands tests: new `oapi` tests for `Map()` behavior; ArgoCD dispatcher tests and templates migrated to lowercase variable access
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit aee5bbce9365f01dec7323a26b26d007f8770ef6. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Standardized template variable naming conventions across ArgoCD and Terraform Cloud integrations to consistently use lowercase field names (resource, environment, deployment, job, release) for improved template execution consistency and compatibility across deployment configurations.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->