### PR TITLE
Ctrlplane init `ctrlplane.yaml` support

### DIFF
--- a/apps/workspace-engine/pkg/workspace/jobdispatch/argocd.go
+++ b/apps/workspace-engine/pkg/workspace/jobdispatch/argocd.go
@@ -197,8 +197,11 @@ func (d *ArgoCDDispatcher) DispatchJob(ctx context.Context, job *oapi.Job) error
 		return fmt.Errorf("failed to parse template: %w", err)
 	}
 
+	// Convert to map with lowercase keys for consistent template variable naming
+	templateData := templatableJobWithRelease.ToTemplateData()
+
 	var buf bytes.Buffer
-	if err := t.Execute(&buf, templatableJobWithRelease); err != nil {
+	if err := t.Execute(&buf, templateData); err != nil {
 		span.RecordError(err)
 		span.SetStatus(codes.Error, "failed to execute template")
 		message := fmt.Sprintf("Failed to execute ArgoCD Application template: %s", err.Error())

--- a/apps/workspace-engine/pkg/workspace/jobdispatch/terraformcloud.go
+++ b/apps/workspace-engine/pkg/workspace/jobdispatch/terraformcloud.go
@@ -197,8 +197,11 @@ func (d *TerraformCloudDispatcher) generateWorkspace(job *oapi.TemplatableJob, t
 		return nil, fmt.Errorf("failed to parse template: %w", err)
 	}
 
+	// Convert to map with lowercase keys for consistent template variable naming
+	templateData := job.ToTemplateData()
+
 	var buf bytes.Buffer
-	if err := t.Execute(&buf, job); err != nil {
+	if err := t.Execute(&buf, templateData); err != nil {
 		return nil, fmt.Errorf("failed to execute template: %w", err)
 	}
 


### PR DESCRIPTION
Standardize Go templating variable casing to lowercase to ensure consistency across all templating surfaces.

Previously, `ProviderContext` used JSON marshaling, resulting in lowercase template keys, while `TemplatableJob` was passed directly, exposing PascalCase Go struct field names. This PR introduces a `Map()` method for `TemplatableJob` to convert its fields to a map with lowercase keys (matching JSON tags), aligning all templating surfaces with a consistent lowercase naming convention as requested in #738.

---
<a href="https://cursor.com/background-agent?bcId=bc-536ae35f-af5b-4706-a855-eb4546e47ab2"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-536ae35f-af5b-4706-a855-eb4546e47ab2"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

