### PR TITLE
fix: workspaceID check doesn't return

### DIFF
--- a/apps/workspace-engine-router/pkg/router/router.go
+++ b/apps/workspace-engine-router/pkg/router/router.go
@@ -235,6 +235,7 @@ func (r *Router) RouteToWorkerAllPaths(c *gin.Context) {
 			"error":   "Workspace ID required",
 			"message": "Please provide workspace ID via X-Workspace-ID header or in path (/v1/workspaces/{workspaceId}/...)",
 		})
+		return
 	}
 
 	// Get partition count


### PR DESCRIPTION
**Summary**
 Discovered during docker-compose troubleshooting that this check returned an error despite succeeding. This change resolves the issue. An image of the previous response is attached 

<img width="1463" height="824" alt="Screenshot 2026-01-17 at 5 12 20 PM" src="https://github.com/user-attachments/assets/ee53c075-e666-490e-bdbe-d790931c4842" />


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed improper error handling when required workspace identification is missing, ensuring the system correctly terminates request processing upon encountering the error.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->