### PR TITLE
perf: use date comparison to see if version should allowed if created before approval rule

### DIFF
--- a/apps/workspace-engine/pkg/workspace/store/policy.go
+++ b/apps/workspace-engine/pkg/workspace/store/policy.go
@@ -2,6 +2,7 @@ package store
 
 import (
 	"context"
+	"time"
 	"workspace-engine/pkg/oapi"
 	"workspace-engine/pkg/workspace/store/repository"
 )
@@ -29,6 +30,20 @@ func (p *Policies) Get(id string) (*oapi.Policy, bool) {
 func (p *Policies) Upsert(ctx context.Context, policy *oapi.Policy) {
 	if policy.Metadata == nil {
 		policy.Metadata = make(map[string]string)
+	}
+
+	if policy.CreatedAt == "" {
+		policy.CreatedAt = time.Now().Format(time.RFC3339)
+	}
+
+	for _, rule := range policy.Rules {
+		if rule.PolicyId == "" {
+			rule.PolicyId = policy.Id
+		}
+
+		if rule.CreatedAt == "" {
+			rule.CreatedAt = policy.CreatedAt
+		}
 	}
 
 	p.repo.Policies.Set(policy.Id, policy)


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed approval policy evaluation to automatically approve versions created prior to when the approval policy was established, eliminating unnecessary approval requirements for legacy versions.

* **Refactor**
  * Enhanced policy initialization to properly record and persist policy creation timestamps, enabling the approval evaluation system to accurately determine version eligibility based on policy timing.

* **Tests**
  * Updated test coverage to reflect the new automatic approval behavior for pre-policy versions.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->