### PR TITLE
refactor: pull verification manager out to workspace level

### DIFF
--- a/apps/workspace-engine/pkg/workspace/releasemanager/manager.go
+++ b/apps/workspace-engine/pkg/workspace/releasemanager/manager.go
@@ -39,12 +39,11 @@ type PersistenceStore = trace.PersistenceStore
 
 // New creates a new release manager for a workspace.
 // traceStore must not be nil - panics if not provided.
-func New(store *store.Store, traceStore PersistenceStore) *Manager {
+func New(store *store.Store, traceStore PersistenceStore, verificationManager *verification.Manager) *Manager {
 	if traceStore == nil {
 		panic("traceStore cannot be nil - deployment tracing is mandatory")
 	}
 
-	verificationManager := verification.NewManager(store)
 	deploymentOrch := NewDeploymentOrchestrator(store, verificationManager)
 	stateCache := NewStateCache(store, deploymentOrch.Planner())
 

--- a/apps/workspace-engine/pkg/workspace/releasemanager/manager_test.go
+++ b/apps/workspace-engine/pkg/workspace/releasemanager/manager_test.go
@@ -7,6 +7,7 @@ import (
 	"workspace-engine/pkg/oapi"
 	"workspace-engine/pkg/statechange"
 	"workspace-engine/pkg/workspace/releasemanager/trace/spanstore"
+	"workspace-engine/pkg/workspace/releasemanager/verification"
 	"workspace-engine/pkg/workspace/store"
 
 	"github.com/google/uuid"
@@ -20,7 +21,8 @@ func setupTestManager(t *testing.T) (*Manager, *store.Store) {
 	cs := statechange.NewChangeSet[any]()
 	testStore := store.New("test-workspace", cs)
 	traceStore := spanstore.NewInMemoryStore()
-	manager := New(testStore, traceStore)
+	verificationManager := verification.NewManager(testStore)
+	manager := New(testStore, traceStore, verificationManager)
 	return manager, testStore
 }
 


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Verification manager initialization is now injected into the release manager rather than created internally.
  * Verification manager is now directly accessible as a top-level component within the workspace.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->