### PR TITLE
chore: init matrix support

### DIFF
--- a/apps/workspace-engine/oapi/openapi.json
+++ b/apps/workspace-engine/oapi/openapi.json
@@ -2112,6 +2112,9 @@
                },
                {
                   "$ref": "#/components/schemas/WorkflowBooleanInput"
+               },
+               {
+                  "$ref": "#/components/schemas/WorkflowMatrixInput"
                }
             ]
          },
@@ -2128,6 +2131,37 @@
             "required": [
                "id",
                "config"
+            ],
+            "type": "object"
+         },
+         "WorkflowMatrixInput": {
+            "properties": {
+               "entityType": {
+                  "enum": [
+                     "resource",
+                     "environment",
+                     "deployment"
+                  ],
+                  "type": "string"
+               },
+               "name": {
+                  "type": "string"
+               },
+               "selector": {
+                  "$ref": "#/components/schemas/Selector"
+               },
+               "type": {
+                  "enum": [
+                     "matrix"
+                  ],
+                  "type": "string"
+               }
+            },
+            "required": [
+               "name",
+               "type",
+               "entityType",
+               "selector"
             ],
             "type": "object"
          },

--- a/apps/workspace-engine/oapi/spec/schemas/workflows.jsonnet
+++ b/apps/workspace-engine/oapi/spec/schemas/workflows.jsonnet
@@ -50,11 +50,23 @@ local openapi = import '../lib/openapi.libsonnet';
     },
   },
 
+  WorkflowMatrixInput: {
+    type: 'object',
+    required: ['name', 'type', 'entityType', 'selector'],
+    properties: {
+      name: { type: 'string' },
+      type: { type: 'string', enum: ['matrix'] },
+      entityType: { type: 'string', enum: ['resource', 'environment', 'deployment'] },
+      selector: openapi.schemaRef('Selector'),
+    },
+  },
+
   WorkflowInput: {
     oneOf: [
       openapi.schemaRef('WorkflowStringInput'),
       openapi.schemaRef('WorkflowNumberInput'),
       openapi.schemaRef('WorkflowBooleanInput'),
+      openapi.schemaRef('WorkflowMatrixInput'),
     ],
   },
 

--- a/apps/workspace-engine/pkg/oapi/oapi.gen.go
+++ b/apps/workspace-engine/pkg/oapi/oapi.gen.go
@@ -181,6 +181,18 @@ const (
 	Boolean WorkflowBooleanInputType = "boolean"
 )
 
+// Defines values for WorkflowMatrixInputEntityType.
+const (
+	WorkflowMatrixInputEntityTypeDeployment  WorkflowMatrixInputEntityType = "deployment"
+	WorkflowMatrixInputEntityTypeEnvironment WorkflowMatrixInputEntityType = "environment"
+	WorkflowMatrixInputEntityTypeResource    WorkflowMatrixInputEntityType = "resource"
+)
+
+// Defines values for WorkflowMatrixInputType.
+const (
+	Matrix WorkflowMatrixInputType = "matrix"
+)
+
 // Defines values for WorkflowNumberInputType.
 const (
 	Number WorkflowNumberInputType = "number"
@@ -1062,6 +1074,20 @@ type WorkflowJobAgentConfig struct {
 	Config map[string]interface{} `json:"config"`
 	Id     string                 `json:"id"`
 }
+
+// WorkflowMatrixInput defines model for WorkflowMatrixInput.
+type WorkflowMatrixInput struct {
+	EntityType WorkflowMatrixInputEntityType `json:"entityType"`
+	Name       string                        `json:"name"`
+	Selector   Selector                      `json:"selector"`
+	Type       WorkflowMatrixInputType       `json:"type"`
+}
+
+// WorkflowMatrixInputEntityType defines model for WorkflowMatrixInput.EntityType.
+type WorkflowMatrixInputEntityType string
+
+// WorkflowMatrixInputType defines model for WorkflowMatrixInput.Type.
+type WorkflowMatrixInputType string
 
 // WorkflowNumberInput defines model for WorkflowNumberInput.
 type WorkflowNumberInput struct {
@@ -2148,6 +2174,32 @@ func (t *WorkflowInput) FromWorkflowBooleanInput(v WorkflowBooleanInput) error {
 
 // MergeWorkflowBooleanInput performs a merge with any union data inside the WorkflowInput, using the provided WorkflowBooleanInput
 func (t *WorkflowInput) MergeWorkflowBooleanInput(v WorkflowBooleanInput) error {
+	b, err := json.Marshal(v)
+	if err != nil {
+		return err
+	}
+
+	merged, err := runtime.JSONMerge(t.union, b)
+	t.union = merged
+	return err
+}
+
+// AsWorkflowMatrixInput returns the union data inside the WorkflowInput as a WorkflowMatrixInput
+func (t WorkflowInput) AsWorkflowMatrixInput() (WorkflowMatrixInput, error) {
+	var body WorkflowMatrixInput
+	err := json.Unmarshal(t.union, &body)
+	return body, err
+}
+
+// FromWorkflowMatrixInput overwrites any union data inside the WorkflowInput as the provided WorkflowMatrixInput
+func (t *WorkflowInput) FromWorkflowMatrixInput(v WorkflowMatrixInput) error {
+	b, err := json.Marshal(v)
+	t.union = b
+	return err
+}
+
+// MergeWorkflowMatrixInput performs a merge with any union data inside the WorkflowInput, using the provided WorkflowMatrixInput
+func (t *WorkflowInput) MergeWorkflowMatrixInput(v WorkflowMatrixInput) error {
 	b, err := json.Marshal(v)
 	if err != nil {
 		return err


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Workflows now support matrix-type inputs for configuring parameters across multiple resources, environments, and deployments. Matrix inputs use selector-based configuration to enable scalable workflow automation alongside existing string, number, and boolean input types.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->