### PR TITLE
chore: make workflow jobs run concurrently

### DIFF
--- a/apps/workspace-engine/pkg/workspace/workflowmanager/action.go
+++ b/apps/workspace-engine/pkg/workspace/workflowmanager/action.go
@@ -2,7 +2,6 @@ package workflowmanager
 
 import (
 	"context"
-	"fmt"
 	"workspace-engine/pkg/oapi"
 	"workspace-engine/pkg/workspace/store"
 )
@@ -24,19 +23,5 @@ func (w *WorkflowManagerAction) Name() string {
 }
 
 func (w *WorkflowManagerAction) Execute(ctx context.Context, trigger ActionTrigger, job *oapi.Job) error {
-	if trigger != ActionTriggerJobSuccess {
-		return nil
-	}
-
-	workflowJob, ok := w.store.WorkflowJobs.Get(job.WorkflowJobId)
-	if !ok {
-		return nil
-	}
-
-	workflow, ok := w.store.Workflows.Get(workflowJob.WorkflowId)
-	if !ok {
-		return fmt.Errorf("workflow %s not found for job %s", workflowJob.WorkflowId, workflowJob.Id)
-	}
-
-	return w.manager.ReconcileWorkflow(ctx, workflow)
+	return nil
 }

--- a/apps/workspace-engine/pkg/workspace/workflowmanager/manager_test.go
+++ b/apps/workspace-engine/pkg/workspace/workflowmanager/manager_test.go
@@ -36,16 +36,6 @@ func TestWorkflowManager_CreatesNewWorkflow(t *testing.T) {
 	}
 	store.JobAgents.Upsert(ctx, jobAgent1)
 
-	jobAgent2 := &oapi.JobAgent{
-		Id:   "test-job-agent-2",
-		Name: "test-job-agent-2",
-		Type: "test-runner",
-		Config: map[string]any{
-			"test-config": "test-value-2",
-		},
-	}
-	store.JobAgents.Upsert(ctx, jobAgent2)
-
 	workflowTemplate := &oapi.WorkflowTemplate{
 		Id:     "test-workflow-template",
 		Name:   "test-workflow-template",
@@ -93,7 +83,7 @@ func TestWorkflowManager_CreatesNewWorkflow(t *testing.T) {
 	}, job.JobAgentConfig)
 }
 
-func TestWorkflowManager_ContinuesWorkflowAfterJobComplete(t *testing.T) {
+func TestWorkflowManager_DispatchesAllJobsConcurrently(t *testing.T) {
 	ctx := context.Background()
 	store := store.New("test-workspace", statechange.NewChangeSet[any]())
 	jobAgentRegistry := jobagents.NewRegistry(store, verification.NewManager(store))
@@ -157,141 +147,83 @@ func TestWorkflowManager_ContinuesWorkflowAfterJobComplete(t *testing.T) {
 	assert.NoError(t, err)
 	assert.NotNil(t, wf)
 	assert.Equal(t, "test-workflow-template", wf.WorkflowTemplateId)
-	assert.Equal(t, map[string]any{
-		"test-input": "test-value",
-	}, wf.Inputs)
 
 	wfJobs := store.WorkflowJobs.GetByWorkflowId(wf.Id)
 	assert.Len(t, wfJobs, 2)
 	assert.Equal(t, 0, wfJobs[0].Index)
 	assert.Equal(t, 1, wfJobs[1].Index)
 
+	jobs1 := store.Jobs.GetByWorkflowJobId(wfJobs[0].Id)
+	assert.Len(t, jobs1, 1)
+	assert.Equal(t, oapi.JobStatusPending, jobs1[0].Status)
+	assert.Equal(t, jobAgent1.Id, jobs1[0].JobAgentId)
+	assert.Equal(t, oapi.JobAgentConfig{
+		"test-config":  "test-value-1",
+		"delaySeconds": 10,
+	}, jobs1[0].JobAgentConfig)
+
+	jobs2 := store.Jobs.GetByWorkflowJobId(wfJobs[1].Id)
+	assert.Len(t, jobs2, 1)
+	assert.Equal(t, oapi.JobStatusPending, jobs2[0].Status)
+	assert.Equal(t, jobAgent2.Id, jobs2[0].JobAgentId)
+	assert.Equal(t, oapi.JobAgentConfig{
+		"test-config":  "test-value-2",
+		"delaySeconds": 20,
+	}, jobs2[0].JobAgentConfig)
+}
+
+func TestWorkflowView_IsComplete(t *testing.T) {
+	ctx := context.Background()
+	store := store.New("test-workspace", statechange.NewChangeSet[any]())
+	jobAgentRegistry := jobagents.NewRegistry(store, verification.NewManager(store))
+	manager := NewWorkflowManager(store, jobAgentRegistry)
+
+	jobAgent1 := &oapi.JobAgent{
+		Id:   "test-job-agent-1",
+		Name: "test-job-agent-1",
+		Type: "test-runner",
+	}
+	store.JobAgents.Upsert(ctx, jobAgent1)
+
+	jobAgent2 := &oapi.JobAgent{
+		Id:   "test-job-agent-2",
+		Name: "test-job-agent-2",
+		Type: "test-runner",
+	}
+	store.JobAgents.Upsert(ctx, jobAgent2)
+
+	workflowTemplate := &oapi.WorkflowTemplate{
+		Id:   "test-workflow-template",
+		Name: "test-workflow-template",
+		Jobs: []oapi.WorkflowJobTemplate{
+			{Id: "test-job-1", Name: "test-job-1", Ref: "test-job-agent-1"},
+			{Id: "test-job-2", Name: "test-job-2", Ref: "test-job-agent-2"},
+		},
+	}
+	store.WorkflowTemplates.Upsert(ctx, workflowTemplate)
+
+	wf, _ := manager.CreateWorkflow(ctx, "test-workflow-template", nil)
+
+	wfv, err := NewWorkflowView(store, wf.Id)
+	assert.NoError(t, err)
+	assert.False(t, wfv.IsComplete())
+
+	wfJobs := store.WorkflowJobs.GetByWorkflowId(wf.Id)
 	now := time.Now().UTC()
+
 	job1 := store.Jobs.GetByWorkflowJobId(wfJobs[0].Id)[0]
 	job1.CompletedAt = &now
 	job1.Status = oapi.JobStatusSuccessful
 	store.Jobs.Upsert(ctx, job1)
 
-	wfv, err := NewWorkflowView(store, wf.Id)
-	assert.NoError(t, err)
+	wfv, _ = NewWorkflowView(store, wf.Id)
 	assert.False(t, wfv.IsComplete())
-	assert.Equal(t, 1, wfv.GetNextJob().Index)
 
-	err = manager.ReconcileWorkflow(ctx, wf)
-	assert.NoError(t, err)
+	job2 := store.Jobs.GetByWorkflowJobId(wfJobs[1].Id)[0]
+	job2.CompletedAt = &now
+	job2.Status = oapi.JobStatusSuccessful
+	store.Jobs.Upsert(ctx, job2)
 
-	wfJobs = store.WorkflowJobs.GetByWorkflowId(wf.Id)
-	assert.Len(t, wfJobs, 2)
-	assert.Equal(t, 0, wfJobs[0].Index)
-	assert.Equal(t, 1, wfJobs[1].Index)
-
-	jobs := store.Jobs.GetByWorkflowJobId(wfJobs[1].Id)
-	assert.Len(t, jobs, 1)
-	assert.Equal(t, oapi.JobStatusPending, jobs[0].Status)
-	assert.Equal(t, wfJobs[1].Id, jobs[0].WorkflowJobId)
-	assert.Equal(t, jobAgent2.Id, jobs[0].JobAgentId)
-	assert.Equal(t, oapi.JobAgentConfig{
-		"test-config":  "test-value-2",
-		"delaySeconds": 20,
-	}, jobs[0].JobAgentConfig)
-}
-
-func TestWorkflowManager_DoesNotContinueIfJobIsInProgress(t *testing.T) {
-	ctx := context.Background()
-	store := store.New("test-workspace", statechange.NewChangeSet[any]())
-	jobAgentRegistry := jobagents.NewRegistry(store, verification.NewManager(store))
-	manager := NewWorkflowManager(store, jobAgentRegistry)
-
-	var stringInput oapi.WorkflowInput
-	_ = stringInput.FromWorkflowStringInput(oapi.WorkflowStringInput{
-		Name:    "test-input",
-		Type:    oapi.String,
-		Default: "test-default",
-	})
-
-	jobAgent1 := &oapi.JobAgent{
-		Id:   "test-job-agent-1",
-		Name: "test-job-agent-1",
-		Type: "test-runner",
-		Config: map[string]any{
-			"test-config": "test-value-1",
-		},
-	}
-	store.JobAgents.Upsert(ctx, jobAgent1)
-
-	jobAgent2 := &oapi.JobAgent{
-		Id:   "test-job-agent-2",
-		Name: "test-job-agent-2",
-		Type: "test-runner",
-		Config: map[string]any{
-			"test-config": "test-value-2",
-		},
-	}
-	store.JobAgents.Upsert(ctx, jobAgent2)
-
-	workflowTemplate := &oapi.WorkflowTemplate{
-		Id:     "test-workflow-template",
-		Name:   "test-workflow-template",
-		Inputs: []oapi.WorkflowInput{stringInput},
-		Jobs: []oapi.WorkflowJobTemplate{
-			{
-				Id:   "test-job-1",
-				Name: "test-job-1",
-				Ref:  "test-job-agent-1",
-				Config: map[string]any{
-					"delaySeconds": 10,
-				},
-			},
-			{
-				Id:   "test-job-2",
-				Name: "test-job-2",
-				Ref:  "test-job-agent-2",
-				Config: map[string]any{
-					"delaySeconds": 20,
-				},
-			},
-		},
-	}
-	store.WorkflowTemplates.Upsert(ctx, workflowTemplate)
-
-	wf, err := manager.CreateWorkflow(ctx, "test-workflow-template", map[string]any{
-		"test-input": "test-value",
-	})
-	assert.NoError(t, err)
-	assert.NotNil(t, wf)
-	assert.Equal(t, "test-workflow-template", wf.WorkflowTemplateId)
-	assert.Equal(t, map[string]any{
-		"test-input": "test-value",
-	}, wf.Inputs)
-
-	wfJobs := store.WorkflowJobs.GetByWorkflowId(wf.Id)
-	assert.Len(t, wfJobs, 2)
-	assert.Equal(t, 0, wfJobs[0].Index)
-	assert.Equal(t, 1, wfJobs[1].Index)
-
-	now := time.Now().UTC()
-	job1 := store.Jobs.GetByWorkflowJobId(wfJobs[0].Id)[0]
-	job1.CompletedAt = &now
-	job1.Status = oapi.JobStatusInProgress
-	store.Jobs.Upsert(ctx, job1)
-
-	wfv, err := NewWorkflowView(store, wf.Id)
-	assert.NoError(t, err)
-	assert.False(t, wfv.IsComplete())
-	assert.Nil(t, wfv.GetNextJob())
-	assert.True(t, wfv.HasActiveJobs())
-
-	wfJob0Jobs := store.Jobs.GetByWorkflowJobId(wfJobs[0].Id)
-	assert.Len(t, wfJob0Jobs, 1)
-
-	err = manager.ReconcileWorkflow(ctx, wf)
-	assert.NoError(t, err)
-
-	wfJobs = store.WorkflowJobs.GetByWorkflowId(wf.Id)
-	assert.Len(t, wfJobs, 2)
-	assert.Equal(t, 0, wfJobs[0].Index)
-	assert.Equal(t, 1, wfJobs[1].Index)
-
-	jobs := store.Jobs.GetByWorkflowJobId(wfJobs[1].Id)
-	assert.Len(t, jobs, 0)
+	wfv, _ = NewWorkflowView(store, wf.Id)
+	assert.True(t, wfv.IsComplete())
 }


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Workflow execution model updated: jobs are now dispatched concurrently during workflow creation instead of through sequential step-by-step reconciliation.
  * Eliminated the runtime reconciliation process for improved performance and streamlined execution flow.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->