### PR TITLE
chore: init matrix oapi types

### DIFF
--- a/apps/workspace-engine/oapi/openapi.json
+++ b/apps/workspace-engine/oapi/openapi.json
@@ -2287,7 +2287,7 @@
                      }
                   },
                   "required": [
-                     "type"
+                     "entityType"
                   ],
                   "type": "object"
                },

--- a/apps/workspace-engine/oapi/spec/schemas/workflows.jsonnet
+++ b/apps/workspace-engine/oapi/spec/schemas/workflows.jsonnet
@@ -69,7 +69,7 @@ local openapi = import '../lib/openapi.libsonnet';
       type: { type: 'string', enum: ['array'] },
       selector: {
         type: 'object',
-        required: ['type'],
+        required: ['entityType'],
         properties: {
           entityType: { type: 'string', enum: ['resource', 'environment', 'deployment'] },
           default: openapi.schemaRef('Selector'),

--- a/apps/workspace-engine/pkg/oapi/oapi.gen.go
+++ b/apps/workspace-engine/pkg/oapi/oapi.gen.go
@@ -1147,8 +1147,8 @@ type WorkflowNumberInputType string
 type WorkflowSelectorArrayInput struct {
 	Name     string `json:"name"`
 	Selector struct {
-		Default    *Selector                                     `json:"default,omitempty"`
-		EntityType *WorkflowSelectorArrayInputSelectorEntityType `json:"entityType,omitempty"`
+		Default    *Selector                                    `json:"default,omitempty"`
+		EntityType WorkflowSelectorArrayInputSelectorEntityType `json:"entityType"`
 	} `json:"selector"`
 	Type WorkflowSelectorArrayInputType `json:"type"`
 }


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Workflows now support array-type inputs, including manual arrays and selector-based array inputs for more flexible input definitions.
  * Jobs can include a matrix field to define dynamic, multi-value job configurations for more powerful job permutations.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->