### PR TITLE
Skip policy retrigger test

### DIFF
--- a/packages/trpc/src/routes/workflows.ts
+++ b/packages/trpc/src/routes/workflows.ts
@@ -2,10 +2,10 @@ import { TRPCError } from "@trpc/server";
 import { v4 as uuidv4 } from "uuid";
 import { z } from "zod";
 
+import { Event, sendGoEvent } from "@ctrlplane/events";
 import { getClientFor } from "@ctrlplane/workspace-engine-sdk";
 
 import { protectedProcedure, router } from "../trpc.js";
-import { Event, sendGoEvent } from "@ctrlplane/events";
 
 export const workflowsRouter = router({
   create: protectedProcedure
@@ -14,11 +14,11 @@ export const workflowsRouter = router({
         workspaceId: z.uuid(),
         workflowTemplateId: z.string(),
         inputs: z.record(z.string(), z.any()),
-      })
+      }),
     )
     .mutation(async ({ input }) => {
       const { workspaceId, workflowTemplateId, inputs } = input;
-      
+
       await sendGoEvent({
         workspaceId,
         eventType: Event.WorkflowCreated,
@@ -28,7 +28,7 @@ export const workflowsRouter = router({
           inputs,
         },
         timestamp: Date.now(),
-      })
+      });
     }),
   templates: router({
     get: protectedProcedure
@@ -36,7 +36,7 @@ export const workflowsRouter = router({
         z.object({
           workspaceId: z.uuid(),
           workflowTemplateId: z.string(),
-        })
+        }),
       )
       .query(async ({ input }) => {
         const { workspaceId, workflowTemplateId } = input;
@@ -56,34 +56,34 @@ export const workflowsRouter = router({
           });
         return result.data;
       }),
-    
-    list: protectedProcedure
-    .input(
-      z.object({
-        workspaceId: z.uuid(),
-        limit: z.number().min(1).max(1000).default(100),
-        offset: z.number().min(0).default(0),
-      }),
-    )
-    .query(async ({ input }) => {
-      const { workspaceId } = input;
-      const result = await getClientFor(workspaceId).GET(
-        "/v1/workspaces/{workspaceId}/workflow-templates",
-        {
-          params: {
-            path: { workspaceId },
-            query: { limit: input.limit, offset: input.offset },
-          },
-        },
-      );
 
-      if (result.error != null)
-        throw new TRPCError({
-          code: "INTERNAL_SERVER_ERROR",
-          message: "Failed to list workflow templates",
-        });
-      return result.data;
-    }),
+    list: protectedProcedure
+      .input(
+        z.object({
+          workspaceId: z.uuid(),
+          limit: z.number().min(1).max(1000).default(100),
+          offset: z.number().min(0).default(0),
+        }),
+      )
+      .query(async ({ input }) => {
+        const { workspaceId } = input;
+        const result = await getClientFor(workspaceId).GET(
+          "/v1/workspaces/{workspaceId}/workflow-templates",
+          {
+            params: {
+              path: { workspaceId },
+              query: { limit: input.limit, offset: input.offset },
+            },
+          },
+        );
+
+        if (result.error != null)
+          throw new TRPCError({
+            code: "INTERNAL_SERVER_ERROR",
+            message: "Failed to list workflow templates",
+          });
+        return result.data;
+      }),
 
     workflows: protectedProcedure
       .input(
@@ -92,7 +92,7 @@ export const workflowsRouter = router({
           workflowTemplateId: z.string(),
           limit: z.number().min(1).max(1000).default(100),
           offset: z.number().min(0).default(0),
-        })
+        }),
       )
       .query(async ({ input }) => {
         const { workspaceId, workflowTemplateId, limit, offset } = input;


### PR DESCRIPTION
Implement automatic reconciliation of release targets upon PolicySkip creation to ensure immediate re-evaluation of affected targets.

Previously, creating a PolicySkip did not automatically trigger re-evaluation of affected release targets, requiring a separate reconciliation event. This change ensures that applying a skip policy immediately updates the state of relevant release targets, and the e2e tests were updated to reflect this new automatic behavior.

---
<p><a href="https://cursor.com/background-agent?bcId=bc-135044c4-417b-411c-afc9-95024688d4cc"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-135044c4-417b-411c-afc9-95024688d4cc"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a></p>

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes reconciliation triggering/caching behavior in the release manager flow; incorrect target filtering or version lookup could cause missed or excessive reconciliations and affect deployment job creation timing.
> 
> **Overview**
> Creating a `PolicySkip` now **immediately triggers release-target re-evaluation**: the handler resolves the skip’s deployment version, filters release targets by optional environment/resource scope, invalidates cached target state, and calls `ReleaseManager.ReconcileTargets` with a policy-updated trigger and `WithVersionAndNewer`.
> 
> E2E policy-skip tests were updated to reflect this behavior by removing the extra `DeploymentVersionUpdate` event previously used to force reconciliation before asserting job creation.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 10298a53c0f688474cf30230d31ef54f5a9fbdbb. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Improvements**
  * Policy skips now affect only the relevant deployment targets, reducing unnecessary processing and improving reconciliation performance.

* **Tests**
  * Updated test suite to reflect the refined policy-skip triggering behavior and ensure correct job creation without explicit version-update events.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->