### PR TITLE
chore: Deny window end time

### DIFF
--- a/apps/web/app/routes/ws/deployments/_components/environmentversiondecisions/RuleResult.tsx
+++ b/apps/web/app/routes/ws/deployments/_components/environmentversiondecisions/RuleResult.tsx
@@ -1,5 +1,6 @@
 import type { WorkspaceEngine } from "@ctrlplane/workspace-engine-sdk";
 import type React from "react";
+import { format, isValid, parseISO } from "date-fns";
 import { AlertCircleIcon, Check, X } from "lucide-react";
 import { rrulestr } from "rrule";
 
@@ -34,20 +35,13 @@ type WindowInfo = {
 
 function parseTimestamp(value: string | undefined): Date | null {
   if (value == null) return null;
-  const parsed = new Date(value);
-  if (Number.isNaN(parsed.getTime())) return null;
+  const parsed = parseISO(value);
+  if (!isValid(parsed)) return null;
   return parsed;
 }
 
 function formatDateTime(date: Date): string {
-  return date.toLocaleString(undefined, {
-    year: "numeric",
-    month: "short",
-    day: "numeric",
-    hour: "2-digit",
-    minute: "2-digit",
-    hour12: false,
-  });
+  return format(date, "MMM d, yyyy HH:mm");
 }
 
 function Message({ ruleResult }: { ruleResult: RuleEvaluation }) {


### PR DESCRIPTION
Show deny window end time in policy version popups when currently in a deny window.

Previously, the UI only displayed the start of the next window, even when a policy was actively in a deny window, which did not provide sufficient information about the current state. This update prioritizes showing when the current deny window will end for better clarity.

---
<p><a href="https://cursor.com/background-agent?bcId=bc-c983776b-811e-4ed5-8546-8e6b4e4f019b"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-c983776b-811e-4ed5-8546-8e6b4e4f019b"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a></p>

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk UI-only change that adjusts how schedule window timestamps are parsed/formatted and displayed; main risk is incorrect/undefined date rendering for unexpected `details` payloads.
> 
> **Overview**
> Policy schedule rule popovers now display the most relevant window timestamp, **prioritizing the current window end time** when present (e.g., during an active deny window) instead of always showing the next window start.
> 
> This updates `RuleResult`’s `Rrule` rendering to accept additional optional window fields (`window_end`, `window_type`, `next_deny_window_start`), parse ISO timestamps safely, and format date/time consistently via `date-fns`.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit e95504e3d7f8fcccdf70cdbab1db750fbbc68c88. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->