### PR TITLE
Window policies initial deployment

### DIFF
--- a/apps/workspace-engine/pkg/workspace/releasemanager/policy/evaluator/gradualrollout/gradualrollout.go
+++ b/apps/workspace-engine/pkg/workspace/releasemanager/policy/evaluator/gradualrollout/gradualrollout.go
@@ -258,6 +258,9 @@ func (e *GradualRolloutEvaluator) getRolloutStartTime(ctx context.Context, envir
 	// - Allow windows: if outside, push to when window opens
 	// - Deny windows: if inside, push to when window ends
 	finalStartTime := baseStartTime
+	if _, _, err := e.store.ReleaseTargets.GetCurrentRelease(ctx, releaseTarget); err != nil {
+		return finalStartTime, nil
+	}
 	for _, windowRule := range deploymentWindowRules {
 		isAllowWindow := windowRule.AllowWindow == nil || *windowRule.AllowWindow
 


### PR DESCRIPTION
Bypass deployment window and gradual rollout policies for initial deployments to allow first versions regardless of time constraints.

When a resource has no prior deployed version, it must be deployed. Applying deployment window or gradual rollout policies in this scenario would unnecessarily block or delay the initial deployment. This change ensures that the first deployment can proceed immediately, while subsequent deployments respect the defined policies.

---
<p><a href="https://cursor.com/background-agent?bcId=bc-2afa7713-359b-4fcf-9a1d-fbd621134682"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-2afa7713-359b-4fcf-9a1d-fbd621134682"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a></p>

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes affect policy enforcement for deployments by adding a new “no previous successful release” bypass path; risk is mainly behavioral (first deployments may proceed when previously blocked) and depends on `GetCurrentRelease` accuracy.
> 
> **Overview**
> Deployment window evaluation now short-circuits to **allowed** when the `ReleaseTarget` has no current successful release, effectively ignoring window constraints for first deployments.
> 
> Gradual rollout’s rollout-start-time calculation similarly skips deployment-window adjustments until a target has a previously deployed version. Tests were updated to seed prior successful releases where required, add coverage for the first-deployment bypass, and evaluator scope/complexity were adjusted accordingly (deployment window now requires `ScopeReleaseTarget`, complexity `1→2`).
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit a37c5b1baf173258b70b394449db840fde28adc9. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * First-time deployments now bypass deployment window restrictions and proceed as allowed.
  * Enhanced error handling for release lookups in rollout scenarios.

* **Tests**
  * Expanded test coverage for deployment window and rollout edge cases.
  * Added test helpers for improved setup and repeatability.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->