### PR TITLE
Workspace relationships performance

### DIFF
--- a/apps/workspace-engine/pkg/workspace/relationships/compute/incremental.go
+++ b/apps/workspace-engine/pkg/workspace/relationships/compute/incremental.go
@@ -12,19 +12,26 @@ func FindRemovedRelations(
 	oldRelations []*relationships.EntityRelation,
 	newRelations []*relationships.EntityRelation,
 ) []*relationships.EntityRelation {
-	removedRelations := make([]*relationships.EntityRelation, 0)
+	removedRelations := make([]*relationships.EntityRelation, 0, len(oldRelations))
+	if len(oldRelations) == 0 {
+		return removedRelations
+	}
+
+	if len(newRelations) == 0 {
+		return append(removedRelations, oldRelations...)
+	}
+
+	newRelationKeys := make(map[string]struct{}, len(newRelations))
+	for _, newRelation := range newRelations {
+		newRelationKeys[newRelation.Key()] = struct{}{}
+	}
+
 	for _, oldRelation := range oldRelations {
-		found := false
-		for _, newRelation := range newRelations {
-			if oldRelation.Key() == newRelation.Key() {
-				found = true
-				break
-			}
-		}
-		if !found {
+		if _, found := newRelationKeys[oldRelation.Key()]; !found {
 			removedRelations = append(removedRelations, oldRelation)
 		}
 	}
+
 	return removedRelations
 }
 

--- a/apps/workspace-engine/pkg/workspace/relationships/compute/incremental_bench_test.go
+++ b/apps/workspace-engine/pkg/workspace/relationships/compute/incremental_bench_test.go
@@ -1,0 +1,40 @@
+package compute
+
+import (
+	"context"
+	"fmt"
+	"testing"
+	"workspace-engine/pkg/oapi"
+	"workspace-engine/pkg/workspace/relationships"
+)
+
+func BenchmarkFindRemovedRelations(b *testing.B) {
+	ctx := context.Background()
+
+	rule := &oapi.RelationshipRule{Id: "rule-1"}
+	from := relationships.NewResourceEntity(&oapi.Resource{Id: "resource-1"})
+
+	oldRelations := make([]*relationships.EntityRelation, 0, 20000)
+	newRelations := make([]*relationships.EntityRelation, 0, 15000)
+
+	for i := 0; i < 20000; i++ {
+		to := relationships.NewDeploymentEntity(&oapi.Deployment{Id: fmt.Sprintf("deployment-%d", i)})
+		relation := &relationships.EntityRelation{
+			Rule: rule,
+			From: from,
+			To:   to,
+		}
+		oldRelations = append(oldRelations, relation)
+		if i%4 != 0 {
+			newRelations = append(newRelations, relation)
+		}
+	}
+
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		removed := FindRemovedRelations(ctx, oldRelations, newRelations)
+		if len(removed) == 0 {
+			b.Fatal("unexpected empty result")
+		}
+	}
+}

--- a/apps/workspace-engine/pkg/workspace/relationships/compute/incremental_test.go
+++ b/apps/workspace-engine/pkg/workspace/relationships/compute/incremental_test.go
@@ -586,7 +586,6 @@ func TestFindRemovedRelations_NoneRemoved(t *testing.T) {
 
 	assert.Empty(t, removedRelations)
 }
-
 func TestFilterEntitiesByTypeAndSelector(t *testing.T) {
 	ctx := context.Background()
 

--- a/apps/workspace-engine/pkg/workspace/relationships/matcher.go
+++ b/apps/workspace-engine/pkg/workspace/relationships/matcher.go
@@ -120,13 +120,17 @@ func MatchesWithCache(ctx context.Context, matcher *oapi.RelationshipRule_Matche
 	return true
 }
 
-// BuildEntityMapCache pre-computes map representations for all entities
-// This is expensive but only needs to be done once per rule evaluation
+// BuildEntityMapCache pre-computes map representations for provided entities.
+// This is expensive but only needs to be done once per rule evaluation.
 func BuildEntityMapCache(entities []*oapi.RelatableEntity) EntityMapCache {
 	cache := make(EntityMapCache, len(entities))
 	for _, entity := range entities {
+		entityID := entity.GetID()
+		if _, exists := cache[entityID]; exists {
+			continue
+		}
 		if entityMap, err := entityToMap(entity.Item()); err == nil {
-			cache[entity.GetID()] = entityMap
+			cache[entityID] = entityMap
 		}
 	}
 	return cache

--- a/apps/workspace-engine/pkg/workspace/relationships/matcher_test.go
+++ b/apps/workspace-engine/pkg/workspace/relationships/matcher_test.go
@@ -58,6 +58,32 @@ func TestNewPropertyMatcher(t *testing.T) {
 	}
 }
 
+func TestBuildEntityMapCache_DedupesIDs(t *testing.T) {
+	resource1 := &oapi.Resource{
+		Id:          "resource-1",
+		Name:        "Resource One",
+		WorkspaceId: "workspace-1",
+	}
+	resource2 := &oapi.Resource{
+		Id:          "resource-1",
+		Name:        "Resource Two",
+		WorkspaceId: "workspace-1",
+	}
+
+	entities := []*oapi.RelatableEntity{
+		NewResourceEntity(resource1),
+		NewResourceEntity(resource2),
+	}
+
+	cache := BuildEntityMapCache(entities)
+	if len(cache) != 1 {
+		t.Fatalf("expected cache to dedupe IDs, got %d entries", len(cache))
+	}
+	if _, ok := cache["resource-1"]; !ok {
+		t.Fatal("expected cache to contain resource-1")
+	}
+}
+
 // TestPropertyMatcher_Evaluate_Equals tests the equals operator
 func TestPropertyMatcher_Evaluate_Equals(t *testing.T) {
 	tests := []struct {


### PR DESCRIPTION
Optimizes relationship computation by improving cache efficiency and speeding up `FindRemovedRelations`.

Relationship computation was slow due to inefficient cache building and an O(n²) algorithm for finding removed relations. This PR addresses these by:
*   Avoiding CEL entity-map cache construction for non-CEL rules.
*   Scoping entity-map cache building to only the `from` and `to` entity sets, with ID deduplication, to reduce JSON conversion overhead.
*   Refactoring `FindRemovedRelations` to use a key set, changing its complexity from O(n²) to O(n).
A benchmark for `FindRemovedRelations` and a test for cache deduplication have been added to validate these improvements.

---
<p><a href="https://cursor.com/background-agent?bcId=bc-39b6a05c-5578-435b-9fac-3ae1b9eb3cd1"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-39b6a05c-5578-435b-9fac-3ae1b9eb3cd1"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a></p>

