### PR TITLE
Evaluator deployment conditions

### DIFF
--- a/apps/workspace-engine/pkg/workspace/releasemanager/policy/evaluator/deploymentwindow/deploymentwindow_test.go
+++ b/apps/workspace-engine/pkg/workspace/releasemanager/policy/evaluator/deploymentwindow/deploymentwindow_test.go
@@ -71,7 +71,7 @@ func seedSuccessfulRelease(
 	ctx context.Context,
 	st *store.Store,
 	releaseTarget *oapi.ReleaseTarget,
-) {
+) *oapi.DeploymentVersion {
 	t.Helper()
 
 	versionCreatedAt := time.Now().Add(-2 * time.Hour)
@@ -99,6 +99,24 @@ func seedSuccessfulRelease(
 		CreatedAt:   completedAt,
 	}
 	st.Jobs.Upsert(ctx, job)
+
+	return version
+}
+
+func createCandidateVersion(
+	ctx context.Context,
+	st *store.Store,
+	deploymentId string,
+	tag string,
+) *oapi.DeploymentVersion {
+	version := &oapi.DeploymentVersion{
+		Id:           uuid.New().String(),
+		DeploymentId: deploymentId,
+		Tag:          tag,
+		CreatedAt:    time.Now(),
+	}
+	st.DeploymentVersions.Upsert(ctx, version.Id, version)
+	return version
 }
 
 func setupScopeWithDeployedTarget(t *testing.T, st *store.Store) (context.Context, evaluator.EvaluatorScope) {
@@ -106,9 +124,28 @@ func setupScopeWithDeployedTarget(t *testing.T, st *store.Store) (context.Contex
 
 	ctx, releaseTarget := setupReleaseTarget(t, st)
 	seedSuccessfulRelease(t, ctx, st, releaseTarget)
+	candidateVersion := createCandidateVersion(ctx, st, releaseTarget.DeploymentId, "v2.0.0")
 
 	return ctx, evaluator.EvaluatorScope{
 		Environment: &oapi.Environment{Id: releaseTarget.EnvironmentId},
+		Version:     candidateVersion,
+		Resource:    &oapi.Resource{Id: releaseTarget.ResourceId},
+		Deployment:  &oapi.Deployment{Id: releaseTarget.DeploymentId},
+	}
+}
+
+func setupScopeWithPreviouslyDeployedVersion(
+	t *testing.T,
+	st *store.Store,
+) (context.Context, evaluator.EvaluatorScope) {
+	t.Helper()
+
+	ctx, releaseTarget := setupReleaseTarget(t, st)
+	deployedVersion := seedSuccessfulRelease(t, ctx, st, releaseTarget)
+
+	return ctx, evaluator.EvaluatorScope{
+		Environment: &oapi.Environment{Id: releaseTarget.EnvironmentId},
+		Version:     deployedVersion,
 		Resource:    &oapi.Resource{Id: releaseTarget.ResourceId},
 		Deployment:  &oapi.Deployment{Id: releaseTarget.DeploymentId},
 	}
@@ -166,8 +203,9 @@ func TestDeploymentWindowEvaluator_ScopeFields(t *testing.T) {
 	eval := NewEvaluator(st, rule)
 	require.NotNil(t, eval, "expected non-nil evaluator")
 
-	// Deployment window needs release target to check for existing deployments
-	assert.Equal(t, evaluator.ScopeReleaseTarget, eval.ScopeFields())
+	// Deployment window needs release target + version to evaluate whether this
+	// candidate version has already been deployed for the target.
+	assert.Equal(t, evaluator.ScopeVersion|evaluator.ScopeReleaseTarget, eval.ScopeFields())
 }
 
 func TestDeploymentWindowEvaluator_RuleType(t *testing.T) {
@@ -323,8 +361,10 @@ func TestDeploymentWindowEvaluator_IgnoresWindowWithoutDeployedVersion(t *testin
 	require.NotNil(t, eval, "expected non-nil evaluator")
 
 	ctx, releaseTarget := setupReleaseTarget(t, st)
+	candidateVersion := createCandidateVersion(ctx, st, releaseTarget.DeploymentId, "v1.0.0")
 	scope := evaluator.EvaluatorScope{
 		Environment: &oapi.Environment{Id: releaseTarget.EnvironmentId},
+		Version:     candidateVersion,
 		Resource:    &oapi.Resource{Id: releaseTarget.ResourceId},
 		Deployment:  &oapi.Deployment{Id: releaseTarget.DeploymentId},
 	}
@@ -333,6 +373,31 @@ func TestDeploymentWindowEvaluator_IgnoresWindowWithoutDeployedVersion(t *testin
 	assert.True(t, result.Allowed, "expected allowed when no deployment exists")
 	assert.Contains(t, result.Message, "deployment window ignored")
 	assert.Equal(t, "first_deployment", result.Details["reason"])
+}
+
+func TestDeploymentWindowEvaluator_IgnoresWindowForPreviouslyDeployedVersion(t *testing.T) {
+	st := setupStore()
+
+	// Outside this allow window by default, so this would normally be blocked.
+	rule := &oapi.PolicyRule{
+		Id: "rule-1",
+		DeploymentWindow: &oapi.DeploymentWindowRule{
+			Rrule:           "FREQ=YEARLY;COUNT=1;DTSTART=20200101T000000Z",
+			DurationMinutes: 1,
+			AllowWindow:     boolPtr(true),
+		},
+	}
+
+	eval := NewEvaluator(st, rule)
+	require.NotNil(t, eval, "expected non-nil evaluator")
+
+	ctx, scope := setupScopeWithPreviouslyDeployedVersion(t, st)
+	result := eval.Evaluate(ctx, scope)
+
+	assert.True(t, result.Allowed, "expected allowed when candidate version was previously deployed")
+	assert.Contains(t, result.Message, "deployment window ignored")
+	assert.Equal(t, "version_previously_deployed", result.Details["reason"])
+	assert.Equal(t, scope.Version.Id, result.Details["version_id"])
 }
 
 func TestDeploymentWindowEvaluator_NextEvaluationTime(t *testing.T) {


### PR DESCRIPTION
Make the deployment window evaluator version-aware to allow redeployments and rollbacks of previously deployed versions.

Previously, the deployment window evaluator would block all deployments if a window was closed, even for versions that had been successfully deployed before. This change updates the evaluator to check if the candidate version has already been successfully deployed to the release target. If it has, the deployment window is bypassed, enabling redeployments and rollbacks without being constrained by active windows. New versions continue to be subject to deployment window policies.

---
<p><a href="https://cursor.com/background-agent?bcId=bc-9a711e5c-9ac8-4909-b820-1c99b788f65b"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-9a711e5c-9ac8-4909-b820-1c99b788f65b"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a></p>

