### PR TITLE
fix(ci): remove id-token write perm (not needed)

### DIFF
--- a/.github/workflows/build-image.yaml
+++ b/.github/workflows/build-image.yaml
@@ -28,7 +28,6 @@ jobs:
 
     permissions:
       contents: read
-      id-token: write
 
     steps:
       - uses: actions/checkout@v4


### PR DESCRIPTION
# Background

CI pipeline is failing because `id-token: write` permission isn't granted to the calling workflow. This permission isn't needed at all, so removing it.

## What's Changed?

 - remove `id-token: write` workflow permission in ci

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Chores**
  * Updated build workflow permissions to improve security configuration.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->