### PR TITLE
revert: use amd64-only docker builds instead of multi-arch

### DIFF
--- a/.github/workflows/apps-api.yaml
+++ b/.github/workflows/apps-api.yaml
@@ -25,3 +25,4 @@ jobs:
     with:
       image-name: ctrlplane/api
       dockerfile: apps/api/Dockerfile
+      platform: "linux/amd64"

--- a/.github/workflows/apps-relay.yaml
+++ b/.github/workflows/apps-relay.yaml
@@ -54,3 +54,4 @@ jobs:
       image-name: ctrlplane/relay
       dockerfile: apps/relay/Dockerfile
       context: apps/relay
+      platform: "linux/amd64"

--- a/.github/workflows/apps-web.yaml
+++ b/.github/workflows/apps-web.yaml
@@ -21,3 +21,4 @@ jobs:
     with:
       image-name: ctrlplane/web
       dockerfile: apps/web/Dockerfile
+      platform: "linux/amd64"

--- a/.github/workflows/apps-workspace-engine-router.yaml
+++ b/.github/workflows/apps-workspace-engine-router.yaml
@@ -20,3 +20,4 @@ jobs:
       image-name: ctrlplane/workspace-engine-router
       dockerfile: apps/workspace-engine-router/Dockerfile
       context: apps/workspace-engine-router
+      platform: "linux/amd64"

--- a/.github/workflows/apps-workspace-engine.yaml
+++ b/.github/workflows/apps-workspace-engine.yaml
@@ -137,3 +137,4 @@ jobs:
       image-name: ctrlplane/workspace-engine
       dockerfile: apps/workspace-engine/Dockerfile
       context: apps/workspace-engine
+      platform: "linux/amd64"

--- a/.github/workflows/packages-migrations.yaml
+++ b/.github/workflows/packages-migrations.yaml
@@ -21,3 +21,4 @@ jobs:
     with:
       image-name: ctrlplane/migrations
       dockerfile: packages/db/Dockerfile
+      platform: "linux/amd64"


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated build configuration to specify explicit platform targets for containerized services, improving build consistency and reliability across deployment pipelines.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->