### PR TITLE
fix: prevent phantom work items from zero-value params in policy event enqueue

### DIFF
--- a/apps/workspace-engine/pkg/events/handler/policies/policies.go
+++ b/apps/workspace-engine/pkg/events/handler/policies/policies.go
@@ -47,7 +47,7 @@ func getAffectedTargets(ctx context.Context, ws *workspace.Workspace, policyID s
 }
 
 func enqueueAffectedTargets(ctx context.Context, ws *workspace.Workspace, targets map[string]*oapi.ReleaseTarget) {
-	params := make([]events.DesiredReleaseEvalParams, len(targets))
+	params := make([]events.DesiredReleaseEvalParams, 0, len(targets))
 	for _, rt := range targets {
 		params = append(params, events.DesiredReleaseEvalParams{
 			WorkspaceID:   ws.ID,


### PR DESCRIPTION
## Summary

- Fix `enqueueAffectedTargets` in `apps/workspace-engine/pkg/events/handler/policies/policies.go` to stop producing phantom queue items

## Root cause

`make([]events.DesiredReleaseEvalParams, len(targets))` allocates a slice with `len(targets)` zero-value elements. The subsequent `append` calls add the real entries *after* these zero values, resulting in a slice of length `2 * len(targets)` -- the first half being zero-value structs with empty string IDs.

These zero-value entries get enqueued with `ScopeID = "::"`, creating phantom work items that produce unnecessary downstream processing.

This was introduced in d830127aa, which changed from slice-based to map-based iteration of targets but kept the `make` + `append` pattern without adjusting the `make` call.

## The fix

One-line change: `make([]T, len(targets))` -> `make([]T, 0, len(targets))`, setting capacity without length so `append` fills from index 0.

## Out of scope

There is a separate design question about whether the handlers should enqueue *all* release targets (as they currently do) vs only the *affected* targets. That is a behavioral change and is intentionally not addressed in this fix.

## Test plan

- [x] `go build ./...` passes in `apps/workspace-engine`
- [ ] Verify in staging that policy create/update/delete events no longer produce queue items with empty ScopeID `::`


🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Internal performance optimization for release evaluation processing.

---

**Note:** This release contains no user-visible changes or feature updates.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->