### PR TITLE
fix: upsert deletes resources not in payload

### DIFF
--- a/apps/api/src/routes/v1/workspaces/resource-providers.ts
+++ b/apps/api/src/routes/v1/workspaces/resource-providers.ts
@@ -123,6 +123,9 @@ const setResourceProviderResources: AsyncTypedHandler<
   const { resources: incoming } = req.body;
 
   const incomingIdentifiers = incoming.map((r: any) => r.identifier as string);
+  const incomingKinds = [
+    ...new Set(incoming.map((r: any) => r.kind as string)),
+  ];
 
   await db.transaction(async (tx) => {
     if (incomingIdentifiers.length > 0) {
@@ -178,17 +181,21 @@ const setResourceProviderResources: AsyncTypedHandler<
           });
     }
 
-    await tx
-      .delete(resource)
-      .where(
-        and(
-          eq(resource.workspaceId, workspaceId),
-          eq(resource.providerId, providerId),
-          incomingIdentifiers.length > 0
-            ? notInArray(resource.identifier, incomingIdentifiers)
-            : undefined,
-        ),
-      );
+    // Delete resources of the same kind(s) that aren't in the incoming list
+    if (incomingKinds.length > 0) {
+      await tx
+        .delete(resource)
+        .where(
+          and(
+            eq(resource.workspaceId, workspaceId),
+            eq(resource.providerId, providerId),
+            inArray(resource.kind, incomingKinds),
+            incomingIdentifiers.length > 0
+              ? notInArray(resource.identifier, incomingIdentifiers)
+              : undefined,
+          ),
+        );
+    }
   });
 
   const deployments = await db


### PR DESCRIPTION
* while working on a feature to selectively sync k8s resources I noticed that things not in the payload were being deleted in the db. This fixes that so that if the same type of resource is being sent we delete items that of the same type aren't in the payload

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved resource deletion logic when updating resource providers. The system now more precisely identifies and removes only the specific resources intended for deletion, preventing unintended removal of other resource types during updates.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->