### PR TITLE
perf: do nothing on upsert

### DIFF
--- a/apps/workspace-engine/pkg/db/computed_relationships.sql.go
+++ b/apps/workspace-engine/pkg/db/computed_relationships.sql.go
@@ -17,8 +17,7 @@ INSERT INTO computed_entity_relationship (
     rule_id, from_entity_type, from_entity_id, to_entity_type, to_entity_id, last_evaluated_at
 )
 VALUES ($1, $2, $3, $4, $5, NOW())
-ON CONFLICT (rule_id, from_entity_type, from_entity_id, to_entity_type, to_entity_id) DO UPDATE
-SET last_evaluated_at = NOW()
+ON CONFLICT (rule_id, from_entity_type, from_entity_id, to_entity_type, to_entity_id) DO NOTHING
 RETURNING rule_id, from_entity_type, from_entity_id, to_entity_type, to_entity_id
 `
 

--- a/apps/workspace-engine/pkg/db/computed_resources.sql.go
+++ b/apps/workspace-engine/pkg/db/computed_resources.sql.go
@@ -286,8 +286,7 @@ deleted AS (
 INSERT INTO computed_deployment_resource (deployment_id, resource_id, last_evaluated_at)
 SELECT $1, resource_id, NOW()
 FROM valid
-ON CONFLICT (deployment_id, resource_id) DO UPDATE
-SET last_evaluated_at = NOW()
+ON CONFLICT (deployment_id, resource_id) DO NOTHING
 `
 
 type SetComputedDeploymentResourcesParams struct {
@@ -321,8 +320,7 @@ deleted AS (
 INSERT INTO computed_environment_resource (environment_id, resource_id, last_evaluated_at)
 SELECT $1, resource_id, NOW()
 FROM valid
-ON CONFLICT (environment_id, resource_id) DO UPDATE
-SET last_evaluated_at = NOW()
+ON CONFLICT (environment_id, resource_id) DO NOTHING
 `
 
 type SetComputedEnvironmentResourcesParams struct {

--- a/apps/workspace-engine/pkg/db/queries/computed_relationships.sql
+++ b/apps/workspace-engine/pkg/db/queries/computed_relationships.sql
@@ -49,8 +49,7 @@ INSERT INTO computed_entity_relationship (
     rule_id, from_entity_type, from_entity_id, to_entity_type, to_entity_id, last_evaluated_at
 )
 VALUES ($1, $2, $3, $4, $5, NOW())
-ON CONFLICT (rule_id, from_entity_type, from_entity_id, to_entity_type, to_entity_id) DO UPDATE
-SET last_evaluated_at = NOW()
+ON CONFLICT (rule_id, from_entity_type, from_entity_id, to_entity_type, to_entity_id) DO NOTHING
 RETURNING rule_id, from_entity_type, from_entity_id, to_entity_type, to_entity_id;
 
 -- name: GetExistingRelationshipsForEntity :many

--- a/apps/workspace-engine/pkg/db/queries/computed_resources.sql
+++ b/apps/workspace-engine/pkg/db/queries/computed_resources.sql
@@ -19,8 +19,7 @@ deleted AS (
 INSERT INTO computed_deployment_resource (deployment_id, resource_id, last_evaluated_at)
 SELECT @deployment_id, resource_id, NOW()
 FROM valid
-ON CONFLICT (deployment_id, resource_id) DO UPDATE
-SET last_evaluated_at = NOW();
+ON CONFLICT (deployment_id, resource_id) DO NOTHING;
 
 -- name: GetReleaseTargetsForDeployment :many
 -- Returns all valid release targets for a deployment by joining computed
@@ -147,5 +146,4 @@ deleted AS (
 INSERT INTO computed_environment_resource (environment_id, resource_id, last_evaluated_at)
 SELECT @environment_id, resource_id, NOW()
 FROM valid
-ON CONFLICT (environment_id, resource_id) DO UPDATE
-SET last_evaluated_at = NOW();
+ON CONFLICT (environment_id, resource_id) DO NOTHING;


### PR DESCRIPTION
* update queries to not update last_evaluated_at

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Modified duplicate entry handling for computed relationships and resources to preserve existing evaluation timestamps instead of updating them on conflicts, ensuring data consistency during batch operations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->