### PR TITLE
perf: dispatch desired releases only for progression-dependent environments

### DIFF
--- a/apps/workspace-engine/pkg/db/computed_resources.sql.go
+++ b/apps/workspace-engine/pkg/db/computed_resources.sql.go
@@ -148,6 +148,49 @@ func (q *Queries) GetReleaseTargetsForEnvironment(ctx context.Context, environme
 	return items, nil
 }
 
+const getReleaseTargetsForEnvironments = `-- name: GetReleaseTargetsForEnvironments :many
+SELECT DISTINCT
+    cdr.deployment_id,
+    cer.environment_id,
+    cdr.resource_id
+FROM computed_deployment_resource cdr
+JOIN computed_environment_resource cer
+    ON cer.resource_id = cdr.resource_id
+JOIN system_deployment sd
+    ON sd.deployment_id = cdr.deployment_id
+JOIN system_environment se
+    ON se.environment_id = cer.environment_id
+    AND se.system_id = sd.system_id
+WHERE cer.environment_id = ANY($1::uuid[])
+`
+
+type GetReleaseTargetsForEnvironmentsRow struct {
+	DeploymentID  uuid.UUID
+	EnvironmentID uuid.UUID
+	ResourceID    uuid.UUID
+}
+
+// Returns all valid release targets for a set of environments.
+func (q *Queries) GetReleaseTargetsForEnvironments(ctx context.Context, environmentIds []uuid.UUID) ([]GetReleaseTargetsForEnvironmentsRow, error) {
+	rows, err := q.db.Query(ctx, getReleaseTargetsForEnvironments, environmentIds)
+	if err != nil {
+		return nil, err
+	}
+	defer rows.Close()
+	var items []GetReleaseTargetsForEnvironmentsRow
+	for rows.Next() {
+		var i GetReleaseTargetsForEnvironmentsRow
+		if err := rows.Scan(&i.DeploymentID, &i.EnvironmentID, &i.ResourceID); err != nil {
+			return nil, err
+		}
+		items = append(items, i)
+	}
+	if err := rows.Err(); err != nil {
+		return nil, err
+	}
+	return items, nil
+}
+
 const getReleaseTargetsForResource = `-- name: GetReleaseTargetsForResource :many
 SELECT DISTINCT
     cdr.deployment_id,

--- a/apps/workspace-engine/pkg/db/queries/computed_resources.sql
+++ b/apps/workspace-engine/pkg/db/queries/computed_resources.sql
@@ -89,6 +89,22 @@ JOIN system_environment se
     AND se.system_id = sd.system_id
 WHERE cer.environment_id = @environment_id;
 
+-- name: GetReleaseTargetsForEnvironments :many
+-- Returns all valid release targets for a set of environments.
+SELECT DISTINCT
+    cdr.deployment_id,
+    cer.environment_id,
+    cdr.resource_id
+FROM computed_deployment_resource cdr
+JOIN computed_environment_resource cer
+    ON cer.resource_id = cdr.resource_id
+JOIN system_deployment sd
+    ON sd.deployment_id = cdr.deployment_id
+JOIN system_environment se
+    ON se.environment_id = cer.environment_id
+    AND se.system_id = sd.system_id
+WHERE cer.environment_id = ANY(@environment_ids::uuid[]);
+
 -- name: GetReleaseTargetsForWorkspace :many
 -- Returns all valid release targets for a workspace.
 SELECT DISTINCT

--- a/apps/workspace-engine/svc/controllers/jobdispatch/dispatch_progression_targets.go
+++ b/apps/workspace-engine/svc/controllers/jobdispatch/dispatch_progression_targets.go
@@ -1,0 +1,231 @@
+package jobdispatch
+
+import (
+	"context"
+	"fmt"
+
+	"workspace-engine/pkg/db"
+	"workspace-engine/pkg/oapi"
+	"workspace-engine/pkg/reconcile"
+	"workspace-engine/pkg/reconcile/events"
+	"workspace-engine/pkg/selector"
+
+	"github.com/google/uuid"
+	"go.opentelemetry.io/otel/attribute"
+	"go.opentelemetry.io/otel/trace"
+)
+
+// DispatchProgressionTargets enqueues desired-release evaluations for
+// release targets that are gated by environment progression policies
+// whose dependsOnEnvironmentSelector matches the environment of the
+// given job.
+func dispatchProgressionTargets(
+	ctx context.Context,
+	queue reconcile.Queue,
+	jobID uuid.UUID,
+) error {
+	ctx, span := tracer.Start(ctx, "DispatchProgressionTargets",
+		trace.WithAttributes(attribute.String("job.id", jobID.String())),
+	)
+	defer span.End()
+
+	queries := db.GetQueries(ctx)
+
+	release, err := queries.GetReleaseByJobID(ctx, jobID)
+	if err != nil {
+		return fmt.Errorf("get release by job id: %w", err)
+	}
+
+	wsID, err := queries.GetWorkspaceIDByJobID(ctx, jobID)
+	if err != nil {
+		return fmt.Errorf("get workspace id: %w", err)
+	}
+
+	span.SetAttributes(
+		attribute.String("workspace.id", wsID.String()),
+		attribute.String("environment.id", release.EnvironmentID.String()),
+	)
+
+	jobEnv, err := queries.GetEnvironmentByID(ctx, release.EnvironmentID)
+	if err != nil {
+		return fmt.Errorf("get environment by id: %w", err)
+	}
+	jobOapiEnv := db.ToOapiEnvironment(jobEnv)
+
+	dependentEnvIDs, err := findDependentEnvironments(ctx, queries, wsID, jobOapiEnv)
+	if err != nil {
+		return fmt.Errorf("find dependent environments: %w", err)
+	}
+
+	span.SetAttributes(attribute.Int("dependent_environments.count", len(dependentEnvIDs)))
+
+	jobReleaseTarget := releaseTargetForJob(wsID, release)
+
+	if len(dependentEnvIDs) == 0 {
+		span.AddEvent("no dependent environments found, dispatching job release target only")
+		if err := events.EnqueueManyDesiredRelease(queue, ctx, []events.DesiredReleaseEvalParams{jobReleaseTarget}); err != nil {
+			return fmt.Errorf("enqueue desired releases: %w", err)
+		}
+		return nil
+	}
+
+	params, err := collectReleaseTargets(ctx, queries, wsID, dependentEnvIDs)
+	if err != nil {
+		return fmt.Errorf("collect release targets: %w", err)
+	}
+
+	params = append(params, jobReleaseTarget)
+
+	span.SetAttributes(attribute.Int("release_targets.count", len(params)))
+
+	if err := events.EnqueueManyDesiredRelease(queue, ctx, params); err != nil {
+		return fmt.Errorf("enqueue desired releases: %w", err)
+	}
+
+	span.AddEvent("desired releases enqueued", trace.WithAttributes(
+		attribute.Int("enqueued.count", len(params)),
+	))
+
+	return nil
+}
+
+// findDependentEnvironments returns the IDs of environments that have
+// policies with environment progression rules whose
+// dependsOnEnvironmentSelector matches jobEnv.
+func findDependentEnvironments(
+	ctx context.Context,
+	queries *db.Queries,
+	workspaceID uuid.UUID,
+	jobEnv *oapi.Environment,
+) ([]uuid.UUID, error) {
+	policyRows, err := queries.ListPoliciesWithRulesByWorkspaceID(ctx, workspaceID)
+	if err != nil {
+		return nil, fmt.Errorf("list policies: %w", err)
+	}
+
+	envRows, err := queries.ListEnvironmentsByWorkspaceID(ctx, db.ListEnvironmentsByWorkspaceIDParams{
+		WorkspaceID: workspaceID,
+	})
+	if err != nil {
+		return nil, fmt.Errorf("list environments: %w", err)
+	}
+
+	seen := make(map[uuid.UUID]struct{})
+	var envIDs []uuid.UUID
+
+	for _, row := range policyRows {
+		policy := db.ToOapiPolicyWithRules(row)
+		if !policy.Enabled {
+			continue
+		}
+
+		for _, rule := range policy.Rules {
+			if rule.EnvironmentProgression == nil {
+				continue
+			}
+
+			sel := rule.EnvironmentProgression.DependsOnEnvironmentSelector
+			if sel == "" {
+				continue
+			}
+
+			matched, err := selector.Match(ctx, sel, *jobEnv)
+			if err != nil {
+				continue
+			}
+			if !matched {
+				continue
+			}
+
+			policyEnvIDs, err := environmentsMatchingPolicy(ctx, envRows, policy)
+			if err != nil {
+				continue
+			}
+
+			for _, eid := range policyEnvIDs {
+				if eid == jobEnv.Id {
+					continue
+				}
+				uid, err := uuid.Parse(eid)
+				if err != nil {
+					continue
+				}
+				if _, ok := seen[uid]; !ok {
+					seen[uid] = struct{}{}
+					envIDs = append(envIDs, uid)
+				}
+			}
+		}
+	}
+
+	return envIDs, nil
+}
+
+// environmentsMatchingPolicy returns the environment IDs that the
+// policy's top-level selector applies to.
+func environmentsMatchingPolicy(
+	ctx context.Context,
+	envRows []db.Environment,
+	policy *oapi.Policy,
+) ([]string, error) {
+	if policy.Selector == "" {
+		return nil, nil
+	}
+
+	if policy.Selector == "true" {
+		ids := make([]string, len(envRows))
+		for i, e := range envRows {
+			ids[i] = e.ID.String()
+		}
+		return ids, nil
+	}
+
+	var ids []string
+	for _, e := range envRows {
+		env := db.ToOapiEnvironment(e)
+		matched, err := selector.Match(ctx, policy.Selector, *env)
+		if err != nil {
+			continue
+		}
+		if matched {
+			ids = append(ids, env.Id)
+		}
+	}
+	return ids, nil
+}
+
+// collectReleaseTargets gathers all release targets for the given
+// environment IDs and returns them as DesiredReleaseEvalParams.
+func collectReleaseTargets(
+	ctx context.Context,
+	queries *db.Queries,
+	workspaceID uuid.UUID,
+	envIDs []uuid.UUID,
+) ([]events.DesiredReleaseEvalParams, error) {
+	rts, err := queries.GetReleaseTargetsForEnvironments(ctx, envIDs)
+	if err != nil {
+		return nil, fmt.Errorf("get release targets for environments: %w", err)
+	}
+
+	wsIDStr := workspaceID.String()
+	params := make([]events.DesiredReleaseEvalParams, len(rts))
+	for i, rt := range rts {
+		params[i] = events.DesiredReleaseEvalParams{
+			WorkspaceID:   wsIDStr,
+			ResourceID:    rt.ResourceID.String(),
+			EnvironmentID: rt.EnvironmentID.String(),
+			DeploymentID:  rt.DeploymentID.String(),
+		}
+	}
+
+	return params, nil
+}
+
+func releaseTargetForJob(workspaceID uuid.UUID, release db.Release) events.DesiredReleaseEvalParams {
+	return events.DesiredReleaseEvalParams{
+		WorkspaceID:   workspaceID.String(),
+		ResourceID:    release.ResourceID.String(),
+		EnvironmentID: release.EnvironmentID.String(),
+		DeploymentID:  release.DeploymentID.String(),
+	}
+}

--- a/apps/workspace-engine/svc/controllers/jobdispatch/setters_postgres.go
+++ b/apps/workspace-engine/svc/controllers/jobdispatch/setters_postgres.go
@@ -86,51 +86,22 @@ func (s *PostgresSetter) UpdateJob(
 		}
 	}
 
-	// statusChanged := existingJob != nil && existingJob.Status != status
-	// span.SetAttributes(attribute.Bool("job.status_changed", statusChanged))
+	statusChanged := existingJob != nil && existingJob.Status != status
+	span.SetAttributes(attribute.Bool("job.status_changed", statusChanged))
 
-	// if existingJob != nil && existingJob.Status == status {
-	// 	span.AddEvent("skipping desired release enqueue - status unchanged")
-	// 	return nil
-	// }
+	if existingJob != nil && existingJob.Status == status {
+		span.AddEvent("skipping progression dispatch - status unchanged")
+		return nil
+	}
 
-	// if existingJob == nil {
-	// 	span.AddEvent("skipping desired release enqueue - no existing job found")
-	// 	return nil
-	// }
+	if existingJob == nil {
+		span.AddEvent("skipping progression dispatch - no existing job found")
+		return nil
+	}
 
-	// workspaceID, err := queries.GetWorkspaceIDByJobID(ctx, jobIDUUID)
-	// if err != nil {
-	// 	return fmt.Errorf("get workspace id by job id: %w", err)
-	// }
-
-	// allReleaseTargets, err := queries.GetReleaseTargetsForWorkspace(ctx, workspaceID)
-	// if err != nil {
-	// 	return fmt.Errorf("get release targets for workspace: %w", err)
-	// }
-
-	// span.SetAttributes(
-	// 	attribute.String("workspace.id", workspaceID.String()),
-	// 	attribute.Int("release_targets.count", len(allReleaseTargets)),
-	// )
-
-	// params := make([]events.DesiredReleaseEvalParams, len(allReleaseTargets))
-	// for i, releaseTarget := range allReleaseTargets {
-	// 	params[i] = events.DesiredReleaseEvalParams{
-	// 		WorkspaceID:   workspaceID.String(),
-	// 		ResourceID:    releaseTarget.ResourceID.String(),
-	// 		EnvironmentID: releaseTarget.EnvironmentID.String(),
-	// 		DeploymentID:  releaseTarget.DeploymentID.String(),
-	// 	}
-	// }
-
-	// if err := events.EnqueueManyDesiredRelease(s.Queue, ctx, params); err != nil {
-	// 	return fmt.Errorf("enqueue many desired release: %w", err)
-	// }
-
-	// span.AddEvent("desired release enqueued", trace.WithAttributes(
-	// 	attribute.Int("enqueued.count", len(params)),
-	// ))
+	if err := dispatchProgressionTargets(ctx, s.Queue, jobIDUUID); err != nil {
+		return fmt.Errorf("dispatch progression targets: %w", err)
+	}
 
 	return nil
 }


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Improved job dispatch to automatically evaluate environment progression policies and enqueue release targets across dependent environments based on configured policies.
  * Enhanced database layer to efficiently query and retrieve release targets by environment, enabling complex environment relationship handling in job processing workflows.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->