### PR TITLE
fix: use raw request body for webhook signature verification

### DIFF
--- a/apps/api/src/routes/github/index.ts
+++ b/apps/api/src/routes/github/index.ts
@@ -1,16 +1,19 @@
 import type { WorkflowRunEvent } from "@octokit/webhooks-types";
 import type { Request, Response } from "express";
 import { env } from "@/config.js";
-import { asyncHandler } from "@/types/api.js";
 import { Webhooks } from "@octokit/webhooks";
-import { Router } from "express";
+import express, { Router } from "express";
 
 import { logger } from "@ctrlplane/logger";
 
 import { handleWorkflowRunEvent } from "./workflow_run.js";
 
 export const createGithubRouter = (): Router =>
-  Router().post("/webhook", asyncHandler(handleWebhookRequest));
+  Router().post(
+    "/webhook",
+    express.raw({ type: "application/json" }),
+    handleWebhookRequest,
+  );
 
 const getGithubWebhooksObject = (): Webhooks => {
   const secret = env.GITHUB_WEBHOOK_SECRET;
@@ -18,27 +21,29 @@ const getGithubWebhooksObject = (): Webhooks => {
   return new Webhooks({ secret });
 };
 
-const verifyRequest = async (req: Request): Promise<boolean> => {
+const verifyRequest = async (
+  body: Buffer,
+  signature: string,
+): Promise<boolean> => {
   const webhooks = getGithubWebhooksObject();
-  const signature = req.headers["x-hub-signature-256"]?.toString();
-  if (signature == null) return false;
-
-  const { body } = req;
-  const json = JSON.stringify(body);
-  return webhooks.verify(json, signature);
+  return webhooks.verify(body.toString("utf8"), signature);
 };
 
 const handleWebhookRequest = async (req: Request, res: Response) => {
   try {
-    const isVerified = await verifyRequest(req);
-    if (!isVerified) {
+    const signature = req.headers["x-hub-signature-256"]?.toString();
+    if (
+      signature == null ||
+      !(await verifyRequest(req.body as Buffer, signature))
+    ) {
       res.status(401).json({ message: "Unauthorized" });
       return;
     }
 
+    const payload = JSON.parse((req.body as Buffer).toString("utf8"));
     const eventType = req.headers["x-github-event"]?.toString();
     if (eventType === "workflow_run")
-      await handleWorkflowRunEvent(req.body as WorkflowRunEvent);
+      await handleWorkflowRunEvent(payload as WorkflowRunEvent);
 
     res.status(200).json({ message: "OK" });
   } catch (error: unknown) {

--- a/apps/api/src/server.ts
+++ b/apps/api/src/server.ts
@@ -62,7 +62,16 @@ const app = express()
   .use(cors({ credentials: true }))
   .use(helmet())
   .use(express.urlencoded({ extended: true, limit: "100mb" }))
-  .use(express.json({ limit: "100mb" }))
+  .use((req, res, next) => {
+    if (
+      req.path.startsWith("/api/github/webhook") ||
+      req.path.startsWith("/api/tfe/webhook")
+    ) {
+      next();
+      return;
+    }
+    express.json({ limit: "100mb" })(req, res, next);
+  })
   .use(cookieParser())
   .use(loggerMiddleware)
 


### PR DESCRIPTION
## Summary
- Webhook HMAC signatures were computed over `JSON.stringify(req.body)` (re-serialized) instead of the original bytes from the request
- If GitHub or TFC ever changes JSON serialization (whitespace, key order, number formatting), signature verification would silently break
- Switch webhook routes to `express.raw({ type: "application/json" })` so handlers receive the original `Buffer` and verify against actual bytes
- Skip global `express.json()` for webhook paths to prevent it from consuming the stream first

## Test plan
- [ ] Verify GitHub webhook signature verification still works (send a test event)
- [ ] Verify TFE webhook signature verification still works after `tfc-workspace-job-agent-v2` merges
- [ ] Confirm non-webhook API routes still parse JSON normally

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Improvements**
  * Webhook handling made more reliable: incoming deliveries are now verified and requests lacking a valid signature return 401 Unauthorized.
  * Webhook payload parsing is more robust to prevent malformed delivery handling.
  * Webhook endpoints now bypass generic JSON parsing to avoid interference with raw delivery payloads and improve consistency.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->