### PR TITLE
chore: enqueue policy eval when desired release changes

### DIFF
--- a/apps/workspace-engine/svc/controllers/desiredrelease/setters_postgres.go
+++ b/apps/workspace-engine/svc/controllers/desiredrelease/setters_postgres.go
@@ -3,13 +3,16 @@ package desiredrelease
 import (
 	"context"
 	"encoding/json"
+	"errors"
 	"fmt"
 
-	"github.com/google/uuid"
 	"workspace-engine/pkg/db"
 	"workspace-engine/pkg/oapi"
 	"workspace-engine/pkg/reconcile"
 	"workspace-engine/pkg/reconcile/events"
+
+	"github.com/google/uuid"
+	"github.com/jackc/pgx/v5"
 )
 
 type PostgresSetter struct {
@@ -70,6 +73,15 @@ func (s *PostgresSetter) SetDesiredRelease(
 		return fmt.Errorf("upsert release: %w", err)
 	}
 
+	currentDesiredRelease, err := q.GetDesiredReleaseByReleaseTarget(ctx, db.GetDesiredReleaseByReleaseTargetParams{
+		ResourceID:    rt.ResourceID,
+		EnvironmentID: rt.EnvironmentID,
+		DeploymentID:  rt.DeploymentID,
+	})
+	if err != nil && !errors.Is(err, pgx.ErrNoRows) {
+		return fmt.Errorf("get current desired release: %w", err)
+	}
+
 	_, err = q.UpsertReleaseDesired(ctx, db.UpsertReleaseDesiredParams{
 		ResourceID:       rt.ResourceID,
 		EnvironmentID:    rt.EnvironmentID,
@@ -78,6 +90,15 @@ func (s *PostgresSetter) SetDesiredRelease(
 	})
 	if err != nil {
 		return fmt.Errorf("upsert release desired: %w", err)
+	}
+
+	if currentDesiredRelease.ID != releaseRow.ID {
+		if err := events.EnqueuePolicyEval(s.Queue, ctx, events.PolicyEvalParams{
+			WorkspaceID: rt.WorkspaceID.String(),
+			VersionID:   versionID.String(),
+		}); err != nil {
+			return fmt.Errorf("enqueue policy eval: %w", err)
+		}
 	}
 
 	return nil


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed policy evaluation triggering to ensure it occurs when desired releases change, allowing the system to respond correctly to release configuration updates.
  * Enhanced error handling for database operations to provide clearer diagnostics when issues occur with desired release queries.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->