### PR TITLE
feat: redact secrets in job agent UI

### DIFF
--- a/apps/web/app/components/config-entry.tsx
+++ b/apps/web/app/components/config-entry.tsx
@@ -1,0 +1,27 @@
+const sensitiveKeys = new Set(["token", "apiKey", "secret"]);
+
+export function ConfigEntry({
+  entryKey,
+  value,
+  className,
+}: {
+  entryKey: string;
+  value: unknown;
+  className?: string;
+}) {
+  const isSensitive = sensitiveKeys.has(entryKey);
+  return (
+    <div
+      className={`flex items-start gap-2 font-mono font-semibold ${className ?? ""}`}
+    >
+      <span className="shrink-0 text-red-600">{entryKey}:</span>
+      <pre className="text-green-700">
+        {isSensitive
+          ? "[REDACTED]"
+          : typeof value === "string"
+            ? value
+            : JSON.stringify(value, null, 2)}
+      </pre>
+    </div>
+  );
+}

--- a/apps/web/app/routes/ws/deployments/settings/_components/DeploymentAgentCard.tsx
+++ b/apps/web/app/routes/ws/deployments/settings/_components/DeploymentAgentCard.tsx
@@ -22,6 +22,7 @@ import {
   DialogTitle,
   DialogTrigger,
 } from "~/components/ui/dialog";
+import { ConfigEntry } from "~/components/config-entry";
 import { Skeleton } from "~/components/ui/skeleton";
 import { useJobAgent } from "../_hooks/job-agents";
 
@@ -86,17 +87,7 @@ function ConfigExpanded({
 
         <div className="max-h-[80vh] overflow-auto rounded-md border border-muted-foreground/20 p-2">
           {entries.map(([key, value]) => (
-            <div
-              key={key}
-              className="flex items-start gap-2 font-mono font-semibold"
-            >
-              <span className="shrink-0 text-red-600">{key}:</span>
-              <pre className="text-green-700">
-                {typeof value === "string"
-                  ? value
-                  : JSON.stringify(value, null, 2)}
-              </pre>
-            </div>
+            <ConfigEntry key={key} entryKey={key} value={value} />
           ))}
         </div>
       </DialogContent>
@@ -122,17 +113,7 @@ function Config({
       </div>
       <div className="max-h-60 overflow-auto rounded-md border border-muted-foreground/20 p-2">
         {entries.map(([key, value]) => (
-          <div
-            key={key}
-            className="flex items-start gap-2 font-mono font-semibold"
-          >
-            <span className="shrink-0 text-red-600">{key}:</span>
-            <pre className="text-green-700">
-              {typeof value === "string"
-                ? value
-                : JSON.stringify(value, null, 2)}
-            </pre>
-          </div>
+          <ConfigEntry key={key} entryKey={key} value={value} />
         ))}
       </div>
     </div>

--- a/apps/web/app/routes/ws/runners/JobAgentCard.tsx
+++ b/apps/web/app/routes/ws/runners/JobAgentCard.tsx
@@ -3,6 +3,7 @@ import { SiArgo, SiGithub, SiTerraform } from "@icons-pack/react-simple-icons";
 import { PlayIcon } from "lucide-react";
 
 import { trpc } from "~/api/trpc";
+import { ConfigEntry } from "~/components/config-entry";
 import { Card, CardContent, CardHeader, CardTitle } from "~/components/ui/card";
 import { useWorkspace } from "~/components/WorkspaceProvider";
 import { Badge } from "../../../components/ui/badge";
@@ -58,17 +59,12 @@ function ConfigSection({ config, id }: { config: JobAgentConfig; id: string }) {
         {entries
           .sort((a, b) => a[0].localeCompare(b[0]))
           .map(([key, value]) => (
-            <div
+            <ConfigEntry
               key={key}
-              className="flex items-start gap-2 font-mono text-xs font-semibold"
-            >
-              <span className="shrink-0 text-red-600">{key}:</span>
-              <pre className="text-green-700">
-                {typeof value === "string"
-                  ? value
-                  : JSON.stringify(value, null, 2)}
-              </pre>
-            </div>
+              entryKey={key}
+              value={value}
+              className="text-xs"
+            />
           ))}
       </CardContent>
     </Card>

--- a/apps/web/app/routes/ws/runners/card-contents/TfeConfig.tsx
+++ b/apps/web/app/routes/ws/runners/card-contents/TfeConfig.tsx
@@ -35,6 +35,10 @@ export function TfeConfig({ config }: { config: TfeConfig }) {
           {config.organization}
         </a>
       </div>
+      <div className="flex items-center justify-between">
+        <span className="text-muted-foreground">Token</span>
+        <span className="text-muted-foreground">[REDACTED]</span>
+      </div>
     </div>
   );
 }

--- a/apps/workspace-engine/svc/controllers/jobdispatch/jobagents/terraformcloud/tfe.go
+++ b/apps/workspace-engine/svc/controllers/jobdispatch/jobagents/terraformcloud/tfe.go
@@ -41,11 +41,15 @@ func (t *TFE) Dispatch(ctx context.Context, job *oapi.Job) error {
 	dispatchCtx := job.DispatchContext
 	cfg, err := parseJobAgentConfig(dispatchCtx.JobAgentConfig)
 	if err != nil {
+		t.updateJobStatus(ctx, job.Id, oapi.JobStatusFailure,
+			fmt.Sprintf("failed to parse job agent config: %s", err.Error()), nil)
 		return fmt.Errorf("failed to parse job agent config: %w", err)
 	}
 
 	workspace, err := templateWorkspace(job.DispatchContext, cfg.template)
 	if err != nil {
+		t.updateJobStatus(ctx, job.Id, oapi.JobStatusFailure,
+			fmt.Sprintf("failed to generate workspace from template: %s", err.Error()), nil)
 		return fmt.Errorf("failed to generate workspace from template: %w", err)
 	}
 


### PR DESCRIPTION
## Summary
- Show `[REDACTED]` for TFE token and ArgoCD API key in job agent config cards
- Redact sensitive keys (`token`, `apiKey`, `secret`) in the generic fallback config renderer
- Persist failure status when TFE config parsing or workspace templating fails early (bug fix)

Replaces #858 — keeps token in the per-agent config rather than moving to env var.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Job dispatch now properly reports failures when configuration parsing or workspace templating fails.

* **New Features**
  * Sensitive configuration fields (tokens, API keys, secrets) are now automatically redacted in configuration displays for improved security.
  * Configuration displays are now unified across different agent and deployment components for consistency.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->