### PR TITLE
fix: get job inputs action uses dispatch ctx

### DIFF
--- a/github/get-job-inputs/index.js
+++ b/github/get-job-inputs/index.js
@@ -28163,15 +28163,16 @@ async function run() {
         core.setFailed(`Job not found: ${jobId}`);
         return;
     }
+    const { dispatchContext, ...restJob } = job.job;
     const ghActionsJobObject = {
-        ...job.job,
+        ...restJob,
         base: { url: baseUrl },
-        variable: job.release.variables,
-        resource: job.resource,
-        version: job.release.version,
+        variable: dispatchContext?.variables,
+        resource: dispatchContext?.resource,
+        version: dispatchContext?.version,
         workspace: { id: job.workspaceId },
-        environment: job.environment,
-        deployment: job.deployment,
+        environment: dispatchContext?.environment,
+        deployment: dispatchContext?.deployment,
     };
     setOutputsRecursively(null, ghActionsJobObject);
     const missingOutputs = requiredOutputs.filter((output) => !outputTracker.has(output));

--- a/integrations/github-get-job-inputs/src/index.ts
+++ b/integrations/github-get-job-inputs/src/index.ts
@@ -72,15 +72,17 @@ async function run() {
     return;
   }
 
+  const { dispatchContext, ...restJob } = job.job;
+
   const ghActionsJobObject = {
-    ...job.job,
+    ...restJob,
     base: { url: baseUrl },
-    variable: job.release.variables,
-    resource: job.resource,
-    version: job.release.version,
+    variable: dispatchContext?.variables,
+    resource: dispatchContext?.resource,
+    version: dispatchContext?.version,
     workspace: { id: job.workspaceId },
-    environment: job.environment,
-    deployment: job.deployment,
+    environment: dispatchContext?.environment,
+    deployment: dispatchContext?.deployment,
   };
 
   setOutputsRecursively(null, ghActionsJobObject);


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Refactor**
  * Updated GitHub Actions job input processing to restructure how job-related fields are sourced. Certain job details may now be unavailable when dispatch context is absent.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->