### PR TITLE
perf: use shared evaluators between release targets so that cache can be utilized

### DIFF
--- a/apps/workspace-engine/svc/controllers/policyeval/reconcile.go
+++ b/apps/workspace-engine/svc/controllers/policyeval/reconcile.go
@@ -271,7 +271,10 @@ func loadReleaseTargetInputs(
 	return reconcilers, nil
 }
 
-func buildSharedEvaluators(getter Getter, reconcilers []*reconciler) map[string]evaluator.Evaluator {
+func buildSharedEvaluators(
+	getter Getter,
+	reconcilers []*reconciler,
+) map[string]evaluator.Evaluator {
 	shared := make(map[string]evaluator.Evaluator)
 	for _, r := range reconcilers {
 		for _, eval := range collectEvaluators(getter, r.policies) {


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Performance**
  * Improved policy evaluation throughput by concurrently loading release-target inputs and evaluating targets in parallel.
  * Introduced shared evaluator pooling with per-target filtering so only relevant rules run for each target.

* **Bug Fixes**
  * Prevented unintended modifications to shared rule evaluation data by ensuring each evaluation is copied before per-rule updates.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->