### PR TITLE
chore: retrieve metrics from verification metric trpc endpoint

### DIFF
--- a/apps/web/app/routes/ws/deployments/_components/release-targets/VerificationMetricStatus.tsx
+++ b/apps/web/app/routes/ws/deployments/_components/release-targets/VerificationMetricStatus.tsx
@@ -1,6 +1,9 @@
 import { formatDistanceToNowStrict } from "date-fns";
 
+import { Skeleton } from "~/components/ui/skeleton";
 import { cn } from "~/lib/utils";
+
+import { useMetricMeasurements } from "./useMetricMeasurements";
 
 type MetricMeasurement = {
   status: "failed" | "inconclusive" | "passed";
@@ -10,6 +13,7 @@ type MetricMeasurement = {
 };
 
 type VerificationMetricStatusType = {
+  id: string;
   name: string;
   count: number;
   successCondition: string;
@@ -50,11 +54,13 @@ export function calculateMeasurementCounts(
   return { failedCount, consecutiveSuccessCount };
 }
 
-export function getVerificationStatus(metric: VerificationMetricStatusType): {
+export function getVerificationStatus(
+  metric: VerificationMetricStatusType,
+  measurements: MetricMeasurement[],
+): {
   status: VerificationStatus;
   message: string;
 } {
-  const measurements: MetricMeasurement[] = [];
   if (measurements.length === 0)
     return {
       status: "in_progress",
@@ -109,14 +115,29 @@ export function VerificationMetricStatus({
 }: {
   metric: VerificationMetricStatusType;
 }) {
-  const { status, message } = getVerificationStatus(metric);
+  const { measurements, isLoading } = useMetricMeasurements(metric.id);
+
+  if (isLoading)
+    return <Skeleton className="h-4 w-20" />;
+
+  const { status, message } = getVerificationStatus(metric, measurements);
+  const latestMeasurement = [...measurements].sort(
+    (a, b) =>
+      new Date(b.measuredAt).getTime() - new Date(a.measuredAt).getTime(),
+  )[0];
+
+  const timeAgo = latestMeasurement
+    ? formatDistanceToNowStrict(new Date(latestMeasurement.measuredAt), {
+        addSuffix: true,
+      })
+    : null;
 
   return (
     <div className="flex flex-col items-end text-right">
       <span
         className={cn("text-xs font-medium", VerificationStatusColors[status])}
       >
-        {VerificationStatusLabels[status]}
+        {VerificationStatusLabels[status]} {timeAgo}
       </span>
       {status === "in_progress" && (
         <span className="text-xs text-muted-foreground">{message}</span>

--- a/apps/web/app/routes/ws/deployments/_components/release-targets/Verifications.tsx
+++ b/apps/web/app/routes/ws/deployments/_components/release-targets/Verifications.tsx
@@ -14,6 +14,7 @@ import {
   DialogTitle,
   DialogTrigger,
 } from "~/components/ui/dialog";
+import { Spinner } from "~/components/ui/spinner";
 import { cn } from "~/lib/utils";
 import { ArgoCDVerificationDisplay } from "./argocd/ArgoCD";
 import { isArgoCDMeasurement } from "./argocd/argocd-metric";
@@ -22,6 +23,7 @@ import { isDatadogProvider } from "./datadog/datadog-metric";
 import { PrometheusVerificationDisplay } from "./prometheus/Prometheus";
 import { isPrometheusProvider } from "./prometheus/prometheus-metric";
 import { PrometheusIcon } from "./prometheus/PrometheusIcon";
+import { useMetricMeasurements } from "./useMetricMeasurements";
 import { VerificationMetricStatus } from "./VerificationMetricStatus";
 
 type MetricMeasurement = {
@@ -114,7 +116,15 @@ function getStatusMessage(
 }
 
 function MetricSummaryDisplay({ metric }: { metric: VerificationMetric }) {
-  const measurements: MetricMeasurement[] = [];
+  const { measurements, isLoading } = useMetricMeasurements(metric.id);
+
+  if (isLoading)
+    return (
+      <div className="flex items-center justify-center py-4">
+        <Spinner />
+      </div>
+    );
+
   const passedCount = measurements.filter(
     (m) => m.status === "passed",
   ).length;
@@ -167,7 +177,7 @@ const nullToUndefined = <T,>(v: T | null | undefined): T | undefined =>
 
 function MetricDisplay({ metric }: { metric: VerificationMetric }) {
   const [open, setOpen] = useState(false);
-  const measurements: MetricMeasurement[] = [];
+  const { measurements, isLoading } = useMetricMeasurements(metric.id);
   const sortedMeasurements = [...measurements].sort(
     (a, b) =>
       new Date(b.measuredAt).getTime() - new Date(a.measuredAt).getTime(),
@@ -182,7 +192,9 @@ function MetricDisplay({ metric }: { metric: VerificationMetric }) {
   };
 
   const isArgoCD =
-    latestMeasurement != null && isArgoCDMeasurement(latestMeasurement.data);
+    !isLoading &&
+    latestMeasurement != null &&
+    isArgoCDMeasurement(latestMeasurement.data);
   const isPrometheus = isPrometheusProvider(metric.provider);
   const isDatadog = isDatadogProvider(metric.provider);
 
@@ -209,12 +221,21 @@ function MetricDisplay({ metric }: { metric: VerificationMetric }) {
       </CollapsibleTrigger>
 
       <CollapsibleContent className="space-y-2 pl-6 text-xs">
-        {isArgoCD && <ArgoCDVerificationDisplay metric={displayMetric} />}
-        {isPrometheus && (
+        {isLoading && (
+          <div className="flex items-center justify-center py-4">
+            <Spinner />
+          </div>
+        )}
+        {!isLoading && isArgoCD && (
+          <ArgoCDVerificationDisplay metric={displayMetric} />
+        )}
+        {!isLoading && isPrometheus && (
           <PrometheusVerificationDisplay metric={displayMetric} />
         )}
-        {isDatadog && <DatadogVerificationDisplay metric={displayMetric} />}
-        {!isArgoCD && !isPrometheus && !isDatadog && (
+        {!isLoading && isDatadog && (
+          <DatadogVerificationDisplay metric={displayMetric} />
+        )}
+        {!isLoading && !isArgoCD && !isPrometheus && !isDatadog && (
           <>
             <MetricSummaryDisplay metric={metric} />
             {sortedMeasurements.map((measurement, idx) => (

--- a/apps/web/app/routes/ws/deployments/_components/release-targets/argocd/ArgoCD.tsx
+++ b/apps/web/app/routes/ws/deployments/_components/release-targets/argocd/ArgoCD.tsx
@@ -1,7 +1,9 @@
 import { formatDistanceToNowStrict } from "date-fns";
 import { Check, Loader2, X } from "lucide-react";
 
+import { Spinner } from "~/components/ui/spinner";
 import { cn } from "~/lib/utils";
+import { useMetricMeasurements } from "../useMetricMeasurements";
 import {
   getArgoCDAppUrl,
   getArgoCDStatus,
@@ -17,6 +19,7 @@ type MetricMeasurement = {
 };
 
 type VerificationMetricStatus = {
+  id: string;
   name: string;
   provider: unknown;
   count: number;
@@ -67,7 +70,13 @@ export function ArgoCDVerificationDisplay({
 }: {
   metric: VerificationMetricStatus;
 }) {
-  const measurements: MetricMeasurement[] = [];
+  const { measurements, isLoading } = useMetricMeasurements(metric.id);
+  if (isLoading)
+    return (
+      <div className="flex items-center justify-center py-4">
+        <Spinner />
+      </div>
+    );
   const sortedMeasurements = [...measurements].sort(
     (a, b) =>
       new Date(b.measuredAt).getTime() - new Date(a.measuredAt).getTime(),

--- a/apps/web/app/routes/ws/deployments/_components/release-targets/datadog/Datadog.tsx
+++ b/apps/web/app/routes/ws/deployments/_components/release-targets/datadog/Datadog.tsx
@@ -5,7 +5,9 @@ import {
   TooltipContent,
   TooltipTrigger,
 } from "~/components/ui/tooltip";
+import { Spinner } from "~/components/ui/spinner";
 import { cn } from "~/lib/utils";
+import { useMetricMeasurements } from "../useMetricMeasurements";
 import {
   parseDatadogMeasurement,
   parseDatadogProvider,
@@ -19,6 +21,7 @@ type MetricMeasurement = {
 };
 
 type VerificationMetricStatus = {
+  id: string;
   name: string;
   provider: unknown;
   count: number;
@@ -34,7 +37,13 @@ export function DatadogVerificationDisplay({
   metric: VerificationMetricStatus;
 }) {
   const provider = parseDatadogProvider(metric.provider);
-  const measurements: MetricMeasurement[] = [];
+  const { measurements, isLoading } = useMetricMeasurements(metric.id);
+  if (isLoading)
+    return (
+      <div className="flex items-center justify-center py-4">
+        <Spinner />
+      </div>
+    );
   const sortedMeasurements = [...measurements].sort(
     (a, b) =>
       new Date(b.measuredAt).getTime() - new Date(a.measuredAt).getTime(),

--- a/apps/web/app/routes/ws/deployments/_components/release-targets/prometheus/Prometheus.tsx
+++ b/apps/web/app/routes/ws/deployments/_components/release-targets/prometheus/Prometheus.tsx
@@ -1,6 +1,8 @@
 import { formatDistanceToNowStrict } from "date-fns";
 
+import { Spinner } from "~/components/ui/spinner";
 import { cn } from "~/lib/utils";
+import { useMetricMeasurements } from "../useMetricMeasurements";
 import {
   parsePrometheusMeasurement,
   parsePrometheusProvider,
@@ -14,6 +16,7 @@ type MetricMeasurement = {
 };
 
 type VerificationMetricStatus = {
+  id: string;
   name: string;
   provider: unknown;
   count: number;
@@ -29,7 +32,13 @@ export function PrometheusVerificationDisplay({
   metric: VerificationMetricStatus;
 }) {
   const provider = parsePrometheusProvider(metric.provider);
-  const measurements: MetricMeasurement[] = [];
+  const { measurements, isLoading } = useMetricMeasurements(metric.id);
+  if (isLoading)
+    return (
+      <div className="flex items-center justify-center py-4">
+        <Spinner />
+      </div>
+    );
   const sortedMeasurements = [...measurements].sort(
     (a, b) =>
       new Date(b.measuredAt).getTime() - new Date(a.measuredAt).getTime(),

--- a/apps/web/app/routes/ws/deployments/_components/release-targets/useMetricMeasurements.ts
+++ b/apps/web/app/routes/ws/deployments/_components/release-targets/useMetricMeasurements.ts
@@ -1,0 +1,8 @@
+import { trpc } from "~/api/trpc";
+
+export function useMetricMeasurements(metricId: string) {
+  const { data, isLoading } = trpc.verifications.measurements.useQuery(
+    metricId,
+  );
+  return { measurements: data ?? [], isLoading };
+}

--- a/packages/trpc/src/root.ts
+++ b/packages/trpc/src/root.ts
@@ -18,6 +18,7 @@ import { resourcesRouter } from "./routes/resources.js";
 import { systemsRouter } from "./routes/systems.js";
 import { userRouter } from "./routes/user.js";
 import { validateRouter } from "./routes/validate.js";
+import { verificationsRouter } from "./routes/verifications.js";
 import { workflowsRouter } from "./routes/workflows.js";
 import { workspaceRouter } from "./routes/workspace.js";
 import { router } from "./trpc.js";
@@ -44,5 +45,6 @@ export const appRouter = router({
   resourceProviders: resourceProvidersRouter,
   jobAgents: jobAgentsRouter,
   releaseTargets: releaseTargetsRouter,
+  verifications: verificationsRouter,
   workflows: workflowsRouter,
 });

--- a/packages/trpc/src/routes/verifications.ts
+++ b/packages/trpc/src/routes/verifications.ts
@@ -1,0 +1,29 @@
+import { z } from "zod";
+
+import { desc, eq } from "@ctrlplane/db";
+import * as schema from "@ctrlplane/db/schema";
+
+import { protectedProcedure, router } from "../trpc.js";
+
+export const verificationsRouter = router({
+  measurements: protectedProcedure
+    .input(z.uuid())
+    .query(async ({ input, ctx }) => {
+      return ctx.db
+        .select({
+          id: schema.jobVerificationMetricMeasurement.id,
+          status: schema.jobVerificationMetricMeasurement.status,
+          data: schema.jobVerificationMetricMeasurement.data,
+          measuredAt: schema.jobVerificationMetricMeasurement.measuredAt,
+        })
+        .from(schema.jobVerificationMetricMeasurement)
+        .where(
+          eq(
+            schema.jobVerificationMetricMeasurement
+              .jobVerificationMetricStatusId,
+            input,
+          ),
+        )
+        .orderBy(desc(schema.jobVerificationMetricMeasurement.measuredAt));
+    }),
+});


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added loading indicators while metric measurements are being retrieved.
  * Metrics now display relative time information (e.g., "5 minutes ago") indicating when they were last measured.
  * Enhanced measurement data fetching from backend to provide real-time metric status updates across verification displays.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->