### PR TITLE
fix: stop double-serializing CEL selectors on policy write

### DIFF
--- a/apps/api/src/routes/v1/workspaces/policies.ts
+++ b/apps/api/src/routes/v1/workspaces/policies.ts
@@ -76,9 +76,8 @@ const insertPolicyRules = async (tx: Tx, policyId: string, rules: any[]) => {
       await tx.insert(schema.policyRuleEnvironmentProgression).values({
         id: ruleId,
         policyId,
-        dependsOnEnvironmentSelector: JSON.stringify(
+        dependsOnEnvironmentSelector:
           rule.environmentProgression.dependsOnEnvironmentSelector,
-        ),
         maximumAgeHours: rule.environmentProgression.maximumAgeHours,
         minimumSoakTimeMinutes:
           rule.environmentProgression.minimumSockTimeMinutes,
@@ -126,7 +125,7 @@ const insertPolicyRules = async (tx: Tx, policyId: string, rules: any[]) => {
         id: ruleId,
         policyId,
         description: rule.versionSelector.description,
-        selector: JSON.stringify(rule.versionSelector.selector),
+        selector: rule.versionSelector.selector,
       });
   }
 };

--- a/apps/workspace-engine/pkg/workspace/releasemanager/policy/evaluator/versionselector/versionselector_test.go
+++ b/apps/workspace-engine/pkg/workspace/releasemanager/policy/evaluator/versionselector/versionselector_test.go
@@ -345,6 +345,62 @@ func TestEvaluate_InvalidCEL(t *testing.T) {
 	assert.Contains(t, result.Message, "failed to compile")
 }
 
+func TestEvaluate_DoubleQuotedCELExpression(t *testing.T) {
+	ctx := context.Background()
+
+	deployment, _ := createTestDeployment()
+	environment := createTestEnvironment()
+	resource := createTestResource(nil)
+	version := createTestVersion(deployment.Id, "v2.1.0", nil)
+
+	// Regression test for #886: JSON.stringify wraps a CEL string in extra
+	// quotes, producing "\"version.tag.startsWith('v2.')\"" in the DB.
+	// CEL sees a string literal instead of a boolean expression.
+	t.Run("double-quoted CEL expression fails to evaluate as boolean", func(t *testing.T) {
+		rule := &oapi.PolicyRule{
+			Id: "versionSelector",
+			VersionSelector: &oapi.VersionSelectorRule{
+				Selector: `"version.tag.startsWith('v2.')"`,
+			},
+		}
+
+		eval := NewEvaluator(rule)
+
+		scope := evaluator.EvaluatorScope{
+			Version:     version,
+			Environment: environment,
+			Resource:    resource,
+			Deployment:  deployment,
+		}
+
+		result := eval.Evaluate(ctx, scope)
+
+		assert.False(t, result.Allowed)
+	})
+
+	t.Run("plain CEL expression evaluates correctly", func(t *testing.T) {
+		rule := &oapi.PolicyRule{
+			Id: "versionSelector",
+			VersionSelector: &oapi.VersionSelectorRule{
+				Selector: "version.tag.startsWith('v2.')",
+			},
+		}
+
+		eval := NewEvaluator(rule)
+
+		scope := evaluator.EvaluatorScope{
+			Version:     version,
+			Environment: environment,
+			Resource:    resource,
+			Deployment:  deployment,
+		}
+
+		result := eval.Evaluate(ctx, scope)
+
+		assert.True(t, result.Allowed)
+	})
+}
+
 func TestEvaluate_WithDescription(t *testing.T) {
 	ctx := context.Background()
 

--- a/packages/trpc/src/routes/policies.ts
+++ b/packages/trpc/src/routes/policies.ts
@@ -193,7 +193,7 @@ export const policiesRouter = router({
 
           if (rule.environmentProgression != null) {
             const ep = rule.environmentProgression as {
-              dependsOnEnvironmentSelector: unknown;
+              dependsOnEnvironmentSelector: string;
               maximumAgeHours?: number;
               minimumSockTimeMinutes?: number;
               minimumSuccessPercentage?: number;
@@ -202,9 +202,8 @@ export const policiesRouter = router({
             await tx.insert(schema.policyRuleEnvironmentProgression).values({
               id: ruleId,
               policyId,
-              dependsOnEnvironmentSelector: JSON.stringify(
+              dependsOnEnvironmentSelector:
                 ep.dependsOnEnvironmentSelector,
-              ),
               maximumAgeHours: ep.maximumAgeHours,
               minimumSoakTimeMinutes: ep.minimumSockTimeMinutes,
               minimumSuccessPercentage: ep.minimumSuccessPercentage,
@@ -268,14 +267,14 @@ export const policiesRouter = router({
 
           if (rule.versionSelector != null) {
             const vs = rule.versionSelector as {
-              selector: unknown;
+              selector: string;
               description?: string;
             };
             await tx.insert(schema.policyRuleVersionSelector).values({
               id: ruleId,
               policyId,
               description: vs.description,
-              selector: JSON.stringify(vs.selector),
+              selector: vs.selector,
             });
           }
         }


### PR DESCRIPTION
## Summary

Fixes #886.

Policy version selectors and environment progression selectors are CEL expression strings. Both write paths (`trpc` and REST API) were wrapping them in `JSON.stringify()` before storing to a `text` column, which added literal double-quote characters around the value. The workspace engine then tried to compile `"version.tag == 'abc'"` (with quotes) as CEL, which is a string literal — not a boolean expression — so evaluation always failed.

Removed the `JSON.stringify` calls and corrected the type declarations to `string` to match the current API contract.

Also added a Go regression test that demonstrates the failure mode: a double-quoted CEL expression is rejected while the equivalent unquoted expression evaluates correctly.

## Test plan

- [x] Go unit tests pass (`go test ./pkg/workspace/releasemanager/policy/evaluator/versionselector/...`)
- [ ] Create a policy with a CEL version selector via the API and verify it evaluates correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved storage of policy rule selectors to ensure proper handling and evaluation of version and environment progression conditions.

* **Tests**
  * Added test coverage for CEL expression parsing behavior to prevent regressions in selector evaluation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->