### PR TITLE
fix: crud operations on var sets trigger reconciliations

### DIFF
--- a/apps/api/src/routes/v1/workspaces/variable-sets.ts
+++ b/apps/api/src/routes/v1/workspaces/variable-sets.ts
@@ -166,12 +166,11 @@ const updateVariableSet: AsyncTypedHandler<
       }
     }
 
-    enqueueAllReleaseTargetsDesiredVersion(tx, workspaceId);
-
     return vs;
   });
 
   if (updated == null) throw new NotFoundError("Variable set not found");
+  enqueueAllReleaseTargetsDesiredVersion(db, workspaceId);
   res.status(202).json(updated);
 };
 


### PR DESCRIPTION
Resolves #911 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Variable set create/update/delete now reliably trigger synchronization of related release targets.
  * Synchronization is initiated after changes are fully persisted and before the API responds, ensuring external systems see up-to-date versions.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->