### PR TITLE
fix: insert job agents on deployment POST and PUT

### DIFF
--- a/apps/api/src/routes/v1/workspaces/deployments.ts
+++ b/apps/api/src/routes/v1/workspaces/deployments.ts
@@ -240,6 +240,15 @@ const postDeployment: AsyncTypedHandler<
     workspaceId,
   });
 
+  if (body.jobAgents != null && body.jobAgents.length > 0)
+    await db.insert(schema.deploymentJobAgent).values(
+      body.jobAgents.map((agent) => ({
+        deploymentId: id,
+        jobAgentId: agent.ref,
+        config: agent.config,
+      })),
+    );
+
   enqueueReleaseTargetsForDeployment(db, workspaceId, id);
 
   res.status(202).json({ id, message: "Deployment creation requested" });
@@ -273,6 +282,22 @@ const upsertDeployment: AsyncTypedHandler<
         resourceSelector: body.resourceSelector ?? "false",
         metadata: body.metadata ?? {},
       },
+    });
+
+  if (body.jobAgents != null)
+    await db.transaction(async (tx) => {
+      await tx
+        .delete(schema.deploymentJobAgent)
+        .where(eq(schema.deploymentJobAgent.deploymentId, deploymentId));
+
+      if (body.jobAgents!.length > 0)
+        await tx.insert(schema.deploymentJobAgent).values(
+          body.jobAgents!.map((agent) => ({
+            deploymentId,
+            jobAgentId: agent.ref,
+            config: agent.config,
+          })),
+        );
     });
 
   enqueueReleaseTargetsForDeployment(db, workspaceId, deploymentId);

--- a/e2e/tests/api/deployments.spec.ts
+++ b/e2e/tests/api/deployments.spec.ts
@@ -82,6 +82,11 @@ test.describe("Deployment API", () => {
     expect(getRes.response.status).toBe(200);
     expect(getRes.data!.deployment.id).toBe(deploymentId);
     expect(getRes.data!.deployment.name).toBe(name);
+
+    await api.DELETE(
+      "/v1/workspaces/{workspaceId}/deployments/{deploymentId}",
+      { params: { path: { workspaceId: workspace.id, deploymentId } } },
+    );
   });
 
   test("should create a deployment with a job agent", async ({
@@ -96,8 +101,9 @@ test.describe("Deployment API", () => {
         body: {
           name,
           slug: name,
-          jobAgentId,
-          jobAgentConfig: { repo: "my-repo" },
+          jobAgents: [
+            { ref: jobAgentId, config: { repo: "my-repo" }, selector: "true" },
+          ],
         },
       },
     );
@@ -119,6 +125,11 @@ test.describe("Deployment API", () => {
     expect(deployment.jobAgents).toHaveLength(1);
     expect(deployment.jobAgents![0]!.ref).toBe(jobAgentId);
     expect(deployment.jobAgents![0]!.config).toEqual({ repo: "my-repo" });
+
+    await api.DELETE(
+      "/v1/workspaces/{workspaceId}/deployments/{deploymentId}",
+      { params: { path: { workspaceId: workspace.id, deploymentId } } },
+    );
   });
 
   test("should upsert a deployment with a job agent", async ({
@@ -138,8 +149,13 @@ test.describe("Deployment API", () => {
           name,
           slug: name,
           resourceSelector: "false",
-          jobAgentId,
-          jobAgentConfig: { workflow: "deploy.yaml" },
+          jobAgents: [
+            {
+              ref: jobAgentId,
+              config: { workflow: "deploy.yaml" },
+              selector: "true",
+            },
+          ],
         },
       },
     );
@@ -163,6 +179,11 @@ test.describe("Deployment API", () => {
     expect(deployment.jobAgents![0]!.config).toEqual({
       workflow: "deploy.yaml",
     });
+
+    await api.DELETE(
+      "/v1/workspaces/{workspaceId}/deployments/{deploymentId}",
+      { params: { path: { workspaceId: workspace.id, deploymentId } } },
+    );
   });
 
   test("should delete a deployment", async ({ api, workspace }) => {
@@ -224,5 +245,10 @@ test.describe("Deployment API", () => {
     expect(listRes.response.status).toBe(200);
     const items = listRes.data!.items;
     expect(items.some((d) => d.deployment.id === deploymentId)).toBe(true);
+
+    await api.DELETE(
+      "/v1/workspaces/{workspaceId}/deployments/{deploymentId}",
+      { params: { path: { workspaceId: workspace.id, deploymentId } } },
+    );
   });
 });


### PR DESCRIPTION
Resolves #921 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Deployments now support persisting multiple job agent configurations during creation and updates.
  * Job agent data is automatically overwritten when deployment configurations are updated.

* **Tests**
  * Updated end-to-end test suite to validate job agent deployment functionality and ensure proper resource cleanup.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->