### PR TITLE
fix: prevent panic on null job_agent_id in job dispatch

### DIFF
--- a/apps/workspace-engine/pkg/jobagents/registry.go
+++ b/apps/workspace-engine/pkg/jobagents/registry.go
@@ -57,7 +57,12 @@ func (r *Registry) Register(agent interface{ Type() string }) {
 }
 
 func (r *Registry) Dispatch(ctx context.Context, job *oapi.Job) error {
-	jobAgent, err := r.getter.GetJobAgent(ctx, uuid.MustParse(job.JobAgentId))
+	jobAgentID, err := uuid.Parse(job.JobAgentId)
+	if err != nil {
+		return fmt.Errorf("invalid job agent id %q: %w", job.JobAgentId, err)
+	}
+
+	jobAgent, err := r.getter.GetJobAgent(ctx, jobAgentID)
 	if err != nil {
 		return fmt.Errorf("job agent %s not found", job.JobAgentId)
 	}


### PR DESCRIPTION
## Summary

- Replace `uuid.MustParse(job.JobAgentId)` with `uuid.Parse` in `Registry.Dispatch` to return a handled error instead of panicking when `job_agent_id` is NULL in the database
- The `job.job_agent_id` column is nullable (`onDelete: "set null"` on the FK to `job_agent`), so deleted agents null out the field on existing jobs. When the dispatch controller picks up these jobs, `MustParse("")` panics, killing the goroutine. The lease expires, claim-cleanup re-releases it, and another worker picks it up — creating an infinite crash loop
- With this fix, the error is handled gracefully: the job is marked as failed and the worker moves on

## Test plan

- [x] Existing `jobdispatch` and `jobagents` tests pass
- [ ] Verify in staging that jobs with NULL `job_agent_id` no longer crash the workspace-engine
- [ ] Clean up stale pending jobs that reference nonexistent releases (separate from this fix — those produce `"no rows in result set"` errors, not panics)

🤖 Generated with [Claude Code](https://claude.com/claude-code)