### PR TITLE
refactor: job dispatcher only fetches single job agent

### DIFF
--- a/apps/workspace-engine/svc/controllers/jobdispatch/controller.go
+++ b/apps/workspace-engine/svc/controllers/jobdispatch/controller.go
@@ -5,12 +5,6 @@ import (
 	"fmt"
 	"time"
 
-	"github.com/charmbracelet/log"
-	"github.com/google/uuid"
-	"github.com/jackc/pgx/v5/pgxpool"
-	"go.opentelemetry.io/otel"
-	"go.opentelemetry.io/otel/attribute"
-	"go.opentelemetry.io/otel/codes"
 	"workspace-engine/pkg/config"
 	"workspace-engine/pkg/jobagents"
 	"workspace-engine/pkg/jobagents/argo"
@@ -21,6 +15,13 @@ import (
 	"workspace-engine/pkg/oapi"
 	"workspace-engine/pkg/reconcile"
 	"workspace-engine/pkg/reconcile/postgres"
+
+	"github.com/charmbracelet/log"
+	"github.com/google/uuid"
+	"github.com/jackc/pgx/v5/pgxpool"
+	"go.opentelemetry.io/otel"
+	"go.opentelemetry.io/otel/attribute"
+	"go.opentelemetry.io/otel/codes"
 )
 
 var (
@@ -52,11 +53,6 @@ func (c *Controller) Process(ctx context.Context, item reconcile.Item) (reconcil
 		return reconcile.Result{}, fmt.Errorf("parse job id: %w", err)
 	}
 
-	workspaceID, err := uuid.Parse(item.WorkspaceID)
-	if err != nil {
-		return reconcile.Result{}, fmt.Errorf("parse workspace id: %w", err)
-	}
-
 	job, err := c.getter.GetJob(ctx, jobID)
 	if err != nil {
 		span.RecordError(err)
@@ -66,7 +62,7 @@ func (c *Controller) Process(ctx context.Context, item reconcile.Item) (reconcil
 
 	span.SetAttributes(attribute.String("job", fmt.Sprintf("%+v", job)))
 
-	result, err := c.reconcileJob(ctx, workspaceID, jobID, job)
+	result, err := c.reconcileJob(ctx, jobID, job)
 	if err != nil {
 		span.RecordError(err)
 		span.SetStatus(codes.Error, err.Error())
@@ -95,7 +91,6 @@ func (c *Controller) Process(ctx context.Context, item reconcile.Item) (reconcil
 
 func (c *Controller) reconcileJob(
 	ctx context.Context,
-	workspaceID uuid.UUID,
 	jobID uuid.UUID,
 	job *oapi.Job,
 ) (*ReconcileResult, error) {
@@ -106,7 +101,7 @@ func (c *Controller) reconcileJob(
 	if isWorkflowJob {
 		return ReconcileWorkflowJob(ctx, c.dispatcher, job)
 	}
-	return Reconcile(ctx, c.getter, c.setter, c.verifier, c.dispatcher, workspaceID, job)
+	return Reconcile(ctx, c.getter, c.setter, c.verifier, c.dispatcher, job)
 }
 
 // NewController creates a Controller with the given dependencies.

--- a/apps/workspace-engine/svc/controllers/jobdispatch/controller.go
+++ b/apps/workspace-engine/svc/controllers/jobdispatch/controller.go
@@ -5,6 +5,12 @@ import (
 	"fmt"
 	"time"
 
+	"github.com/charmbracelet/log"
+	"github.com/google/uuid"
+	"github.com/jackc/pgx/v5/pgxpool"
+	"go.opentelemetry.io/otel"
+	"go.opentelemetry.io/otel/attribute"
+	"go.opentelemetry.io/otel/codes"
 	"workspace-engine/pkg/config"
 	"workspace-engine/pkg/jobagents"
 	"workspace-engine/pkg/jobagents/argo"
@@ -15,13 +21,6 @@ import (
 	"workspace-engine/pkg/oapi"
 	"workspace-engine/pkg/reconcile"
 	"workspace-engine/pkg/reconcile/postgres"
-
-	"github.com/charmbracelet/log"
-	"github.com/google/uuid"
-	"github.com/jackc/pgx/v5/pgxpool"
-	"go.opentelemetry.io/otel"
-	"go.opentelemetry.io/otel/attribute"
-	"go.opentelemetry.io/otel/codes"
 )
 
 var (

--- a/apps/workspace-engine/svc/controllers/jobdispatch/getters.go
+++ b/apps/workspace-engine/svc/controllers/jobdispatch/getters.go
@@ -10,10 +10,7 @@ import (
 type Getter interface {
 	GetJob(ctx context.Context, jobID uuid.UUID) (*oapi.Job, error)
 	GetRelease(ctx context.Context, releaseID uuid.UUID) (*oapi.Release, error)
-	GetDeployment(ctx context.Context, deploymentID uuid.UUID) (*oapi.Deployment, error)
-	GetResource(ctx context.Context, resourceID uuid.UUID) (*oapi.Resource, error)
 	GetJobAgent(ctx context.Context, jobAgentID uuid.UUID) (*oapi.JobAgent, error)
-	ListJobAgentsByWorkspaceID(ctx context.Context, workspaceID uuid.UUID) ([]oapi.JobAgent, error)
 	GetVerificationPolicies(
 		ctx context.Context,
 		rt *ReleaseTarget,

--- a/apps/workspace-engine/svc/controllers/jobdispatch/getters_postgres.go
+++ b/apps/workspace-engine/svc/controllers/jobdispatch/getters_postgres.go
@@ -48,43 +48,6 @@ func (p *PostgresGetter) GetRelease(
 	return release, nil
 }
 
-func (p *PostgresGetter) GetDeployment(
-	ctx context.Context,
-	deploymentID uuid.UUID,
-) (*oapi.Deployment, error) {
-	row, err := db.GetQueries(ctx).GetDeploymentByID(ctx, deploymentID)
-	if err != nil {
-		return nil, err
-	}
-	return db.ToOapiDeployment(row), nil
-}
-
-func (p *PostgresGetter) GetResource(
-	ctx context.Context,
-	resourceID uuid.UUID,
-) (*oapi.Resource, error) {
-	row, err := db.GetQueries(ctx).GetResourceByID(ctx, resourceID)
-	if err != nil {
-		return nil, err
-	}
-	return db.ToOapiResource(row), nil
-}
-
-func (p *PostgresGetter) ListJobAgentsByWorkspaceID(
-	ctx context.Context,
-	workspaceID uuid.UUID,
-) ([]oapi.JobAgent, error) {
-	rows, err := db.GetQueries(ctx).ListJobAgentsByWorkspaceID(ctx, workspaceID)
-	if err != nil {
-		return nil, err
-	}
-	agents := make([]oapi.JobAgent, len(rows))
-	for i, row := range rows {
-		agents[i] = *db.ToOapiJobAgent(row)
-	}
-	return agents, nil
-}
-
 func (p *PostgresGetter) GetJobAgent(
 	ctx context.Context,
 	jobAgentID uuid.UUID,

--- a/apps/workspace-engine/svc/controllers/jobdispatch/reconcile.go
+++ b/apps/workspace-engine/svc/controllers/jobdispatch/reconcile.go
@@ -5,13 +5,12 @@ import (
 	"fmt"
 	"time"
 
-	"workspace-engine/pkg/oapi"
-	"workspace-engine/svc/controllers/jobdispatch/verification"
-
 	"github.com/google/uuid"
 	"go.opentelemetry.io/otel/attribute"
 	"go.opentelemetry.io/otel/codes"
 	"go.opentelemetry.io/otel/trace"
+	"workspace-engine/pkg/oapi"
+	"workspace-engine/svc/controllers/jobdispatch/verification"
 )
 
 type ReconcileResult struct {
@@ -60,17 +59,17 @@ func Reconcile(
 
 	agentUUID, err := uuid.Parse(job.JobAgentId)
 	if err != nil {
-		return nil, err
+		return nil, recordErr(span, "parse job agent id", err)
 	}
 
 	agent, err := getter.GetJobAgent(ctx, agentUUID)
 	if err != nil {
-		return nil, err
+		return nil, recordErr(span, "get job agent", err)
 	}
 
 	var agentSpecs []oapi.VerificationMetricSpec
 	if verifier != nil {
-		agentSpecs, err = verifier.AgentVerifications(agent.Type, agent.Config)
+		agentSpecs, err = verifier.AgentVerifications(agent.Type, job.JobAgentConfig)
 		if err != nil {
 			return nil, err
 		}

--- a/apps/workspace-engine/svc/controllers/jobdispatch/reconcile.go
+++ b/apps/workspace-engine/svc/controllers/jobdispatch/reconcile.go
@@ -5,13 +5,13 @@ import (
 	"fmt"
 	"time"
 
+	"workspace-engine/pkg/oapi"
+	"workspace-engine/svc/controllers/jobdispatch/verification"
+
 	"github.com/google/uuid"
 	"go.opentelemetry.io/otel/attribute"
 	"go.opentelemetry.io/otel/codes"
 	"go.opentelemetry.io/otel/trace"
-	"workspace-engine/pkg/oapi"
-	"workspace-engine/pkg/selector"
-	"workspace-engine/svc/controllers/jobdispatch/verification"
 )
 
 type ReconcileResult struct {
@@ -35,102 +35,6 @@ func getRelease(ctx context.Context, getter Getter, job *oapi.Job) (*oapi.Releas
 	return release, nil
 }
 
-func getDeployment(
-	ctx context.Context,
-	getter Getter,
-	release *oapi.Release,
-) (*oapi.Deployment, error) {
-	ctx, span := tracer.Start(ctx, "jobdispatch.getDeployment")
-	defer span.End()
-
-	deploymentID := uuid.MustParse(release.Version.DeploymentId)
-	deployment, err := getter.GetDeployment(ctx, deploymentID)
-	if err != nil {
-		return nil, recordErr(span, "get deployment", err)
-	}
-	return deployment, nil
-}
-
-func getJobAgents(
-	ctx context.Context,
-	getter Getter,
-	workspaceID uuid.UUID,
-	release *oapi.Release,
-) ([]oapi.JobAgent, error) {
-	ctx, span := tracer.Start(ctx, "jobdispatch.getJobAgents")
-	defer span.End()
-
-	deployment, err := getDeployment(ctx, getter, release)
-	if err != nil {
-		return nil, err
-	}
-
-	if deployment.JobAgentSelector == "" {
-		return nil, fmt.Errorf("deployment job agent selector is empty")
-	}
-
-	resourceID, err := uuid.Parse(release.ReleaseTarget.ResourceId)
-	if err != nil {
-		return nil, fmt.Errorf("parse resource id: %w", err)
-	}
-
-	resource, err := getter.GetResource(ctx, resourceID)
-	if err != nil {
-		return nil, fmt.Errorf("get resource: %w", err)
-	}
-
-	allAgents, err := getter.ListJobAgentsByWorkspaceID(ctx, workspaceID)
-	if err != nil {
-		return nil, fmt.Errorf("list job agents: %w", err)
-	}
-
-	matched, err := selector.MatchJobAgentsWithResource(
-		ctx,
-		deployment.JobAgentSelector,
-		allAgents,
-		resource,
-	)
-	if err != nil {
-		return nil, fmt.Errorf("match job agents: %w", err)
-	}
-
-	return matched, nil
-}
-
-func getAgentSpecs(
-	ctx context.Context,
-	verifier AgentVerifier,
-	getter Getter,
-	workspaceID uuid.UUID,
-	release *oapi.Release,
-) ([]oapi.VerificationMetricSpec, error) {
-	ctx, span := tracer.Start(ctx, "jobdispatch.getAgentSpecs")
-	defer span.End()
-
-	if verifier == nil {
-		return nil, nil
-	}
-
-	agents, err := getJobAgents(ctx, getter, workspaceID, release)
-	if err != nil {
-		return nil, err
-	}
-
-	specs := make([]oapi.VerificationMetricSpec, 0)
-	for _, agent := range agents {
-		agentSpecs, err := verifier.AgentVerifications(agent.Type, agent.Config)
-		if err != nil {
-			return nil, recordErr(
-				span,
-				fmt.Sprintf("get agent verifications for agent %s", agent.Id),
-				err,
-			)
-		}
-		specs = append(specs, agentSpecs...)
-	}
-	return specs, nil
-}
-
 // Reconcile dispatches a job and enqueues verifications for the job.
 func Reconcile(
 	ctx context.Context,
@@ -138,7 +42,6 @@ func Reconcile(
 	setter Setter,
 	verifier AgentVerifier,
 	dispatcher Dispatcher,
-	workspaceID uuid.UUID,
 	job *oapi.Job,
 ) (*ReconcileResult, error) {
 	ctx, span := tracer.Start(ctx, "jobdispatch.Reconcile")
@@ -149,29 +52,31 @@ func Reconcile(
 		return nil, err
 	}
 
-	agents, err := getJobAgents(ctx, getter, workspaceID, release)
-	if err != nil {
-		span.RecordError(err)
-		span.SetStatus(codes.Error, err.Error())
-		return nil, err
-	}
-	if len(agents) == 0 {
-		span.AddEvent("no job agents matched selector for deployment")
-		return &ReconcileResult{}, nil
-	}
-
 	releaseTarget := &ReleaseTarget{
 		DeploymentID:  uuid.MustParse(release.ReleaseTarget.DeploymentId),
 		EnvironmentID: uuid.MustParse(release.ReleaseTarget.EnvironmentId),
 		ResourceID:    uuid.MustParse(release.ReleaseTarget.ResourceId),
 	}
 
-	policySpecs, err := getter.GetVerificationPolicies(ctx, releaseTarget)
+	agentUUID, err := uuid.Parse(job.JobAgentId)
 	if err != nil {
 		return nil, err
 	}
 
-	agentSpecs, err := getAgentSpecs(ctx, verifier, getter, workspaceID, release)
+	agent, err := getter.GetJobAgent(ctx, agentUUID)
+	if err != nil {
+		return nil, err
+	}
+
+	var agentSpecs []oapi.VerificationMetricSpec
+	if verifier != nil {
+		agentSpecs, err = verifier.AgentVerifications(agent.Type, agent.Config)
+		if err != nil {
+			return nil, err
+		}
+	}
+
+	policySpecs, err := getter.GetVerificationPolicies(ctx, releaseTarget)
 	if err != nil {
 		return nil, err
 	}

--- a/apps/workspace-engine/svc/controllers/jobdispatch/reconcile_test.go
+++ b/apps/workspace-engine/svc/controllers/jobdispatch/reconcile_test.go
@@ -6,10 +6,11 @@ import (
 	"testing"
 	"time"
 
+	"workspace-engine/pkg/oapi"
+
 	"github.com/google/uuid"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
-	"workspace-engine/pkg/oapi"
 )
 
 // ---------------------------------------------------------------------------
@@ -19,13 +20,8 @@ import (
 type mockGetter struct {
 	release                 *oapi.Release
 	releaseErr              error
-	deployment              *oapi.Deployment
-	deploymentErr           error
-	resource                *oapi.Resource
-	resourceErr             error
 	jobAgents               map[string]*oapi.JobAgent
 	jobAgentErr             error
-	workspaceAgents         []oapi.JobAgent
 	verificationPolicies    []oapi.VerificationMetricSpec
 	verificationPoliciesErr error
 }
@@ -38,20 +34,6 @@ func (m *mockGetter) GetRelease(_ context.Context, _ uuid.UUID) (*oapi.Release, 
 	return m.release, m.releaseErr
 }
 
-func (m *mockGetter) GetDeployment(_ context.Context, _ uuid.UUID) (*oapi.Deployment, error) {
-	return m.deployment, m.deploymentErr
-}
-
-func (m *mockGetter) GetResource(_ context.Context, _ uuid.UUID) (*oapi.Resource, error) {
-	if m.resource != nil || m.resourceErr != nil {
-		return m.resource, m.resourceErr
-	}
-	return &oapi.Resource{
-		Config:   map[string]any{},
-		Metadata: map[string]string{},
-	}, nil
-}
-
 func (m *mockGetter) GetJobAgent(_ context.Context, id uuid.UUID) (*oapi.JobAgent, error) {
 	if m.jobAgentErr != nil {
 		return nil, m.jobAgentErr
@@ -61,13 +43,6 @@ func (m *mockGetter) GetJobAgent(_ context.Context, id uuid.UUID) (*oapi.JobAgen
 		return nil, fmt.Errorf("agent %s not found", id)
 	}
 	return agent, nil
-}
-
-func (m *mockGetter) ListJobAgentsByWorkspaceID(
-	_ context.Context,
-	_ uuid.UUID,
-) ([]oapi.JobAgent, error) {
-	return m.workspaceAgents, nil
 }
 
 func (m *mockGetter) GetVerificationPolicies(
@@ -198,20 +173,6 @@ func testRelease(deploymentID string) *oapi.Release {
 	}
 }
 
-var testWorkspaceID = uuid.New()
-
-func testDeployment() *oapi.Deployment {
-	sel := "true"
-	return &oapi.Deployment{
-		Id:               uuid.New().String(),
-		Name:             "test-deployment",
-		Slug:             "test-deployment",
-		Metadata:         map[string]string{},
-		JobAgentConfig:   oapi.JobAgentConfig{},
-		JobAgentSelector: sel,
-	}
-}
-
 func setupGetterWithAgents(agents []oapi.JobAgent) (*oapi.Job, *mockGetter) {
 	agentMap := make(map[string]*oapi.JobAgent, len(agents))
 	for i := range agents {
@@ -220,14 +181,15 @@ func setupGetterWithAgents(agents []oapi.JobAgent) (*oapi.Job, *mockGetter) {
 
 	deploymentID := uuid.New().String()
 	release := testRelease(deploymentID)
-	deployment := testDeployment()
 	job := testJob(release.Id.String())
 
+	if len(agents) > 0 {
+		job.JobAgentId = agents[0].Id
+	}
+
 	getter := &mockGetter{
-		release:         release,
-		deployment:      deployment,
-		jobAgents:       agentMap,
-		workspaceAgents: agents,
+		release:   release,
+		jobAgents: agentMap,
 	}
 	return job, getter
 }
@@ -249,32 +211,28 @@ func TestReconcile_GetReleaseFails(t *testing.T) {
 		setter,
 		verifier,
 		dispatcher,
-		testWorkspaceID,
 		job,
 	)
 	require.Error(t, err)
 	assert.Empty(t, dispatcher.dispatchCalls)
 }
 
-func TestReconcile_NoAgentsOnDeployment(t *testing.T) {
+func TestReconcile_AgentNotFound(t *testing.T) {
 	job, getter := setupGetterWithAgents(nil)
 	setter := &mockSetter{}
 	dispatcher := &mockDispatcher{}
 	verifier := &mockVerifier{specs: map[string][]oapi.VerificationMetricSpec{}}
 
-	result, err := Reconcile(
+	_, err := Reconcile(
 		context.Background(),
 		getter,
 		setter,
 		verifier,
 		dispatcher,
-		testWorkspaceID,
 		job,
 	)
-	require.NoError(t, err)
-	assert.NotNil(t, result)
+	require.Error(t, err)
 	assert.Empty(t, dispatcher.dispatchCalls)
-	assert.Empty(t, setter.createCalls)
 }
 
 func TestReconcile_DispatchesWithoutVerifications(t *testing.T) {
@@ -292,7 +250,6 @@ func TestReconcile_DispatchesWithoutVerifications(t *testing.T) {
 		setter,
 		verifier,
 		dispatcher,
-		testWorkspaceID,
 		job,
 	)
 	require.NoError(t, err)
@@ -325,7 +282,6 @@ func TestReconcile_DispatchesWithPolicyVerifications(t *testing.T) {
 		setter,
 		verifier,
 		dispatcher,
-		testWorkspaceID,
 		job,
 	)
 	require.NoError(t, err)
@@ -359,7 +315,6 @@ func TestReconcile_DispatchesWithAgentVerifications(t *testing.T) {
 		setter,
 		verifier,
 		dispatcher,
-		testWorkspaceID,
 		job,
 	)
 	require.NoError(t, err)
@@ -402,7 +357,6 @@ func TestReconcile_MergesAndDeduplicatesPolicyAndAgentSpecs(t *testing.T) {
 		setter,
 		verifier,
 		dispatcher,
-		testWorkspaceID,
 		job,
 	)
 	require.NoError(t, err)
@@ -450,7 +404,6 @@ func TestReconcile_TemplatesConditionsFromDispatchContext(t *testing.T) {
 		setter,
 		verifier,
 		dispatcher,
-		testWorkspaceID,
 		job,
 	)
 	require.NoError(t, err)
@@ -464,22 +417,19 @@ func TestReconcile_TemplatesConditionsFromDispatchContext(t *testing.T) {
 	)
 }
 
-func TestReconcile_MultipleAgentsContributeSpecs(t *testing.T) {
-	agent1ID := uuid.New().String()
-	agent2ID := uuid.New().String()
+func TestReconcile_AgentContributesMultipleSpecs(t *testing.T) {
+	agentID := uuid.New().String()
 	prov := sleepProvider(t)
 
 	job, getter := setupGetterWithAgents([]oapi.JobAgent{
-		{Id: agent1ID, Type: "argo-cd", Config: oapi.JobAgentConfig{}},
-		{Id: agent2ID, Type: "github", Config: oapi.JobAgentConfig{}},
+		{Id: agentID, Type: "argo-cd", Config: oapi.JobAgentConfig{}},
 	})
 
 	setter := &mockSetter{}
 	dispatcher := &mockDispatcher{}
 	verifier := &mockVerifier{
 		specs: map[string][]oapi.VerificationMetricSpec{
-			"argo-cd": {makeSpec("argo-check", prov)},
-			"github":  {makeSpec("gh-check", prov)},
+			"argo-cd": {makeSpec("argo-check", prov), makeSpec("argo-health", prov)},
 		},
 	}
 
@@ -489,7 +439,6 @@ func TestReconcile_MultipleAgentsContributeSpecs(t *testing.T) {
 		setter,
 		verifier,
 		dispatcher,
-		testWorkspaceID,
 		job,
 	)
 	require.NoError(t, err)

--- a/apps/workspace-engine/svc/controllers/jobdispatch/reconcile_test.go
+++ b/apps/workspace-engine/svc/controllers/jobdispatch/reconcile_test.go
@@ -235,6 +235,42 @@ func TestReconcile_AgentNotFound(t *testing.T) {
 	assert.Empty(t, dispatcher.dispatchCalls)
 }
 
+func TestReconcile_EmptyJobAgentId(t *testing.T) {
+	agentID := uuid.New().String()
+	job, getter := setupGetterWithAgents([]oapi.JobAgent{
+		{Id: agentID, Config: oapi.JobAgentConfig{}},
+	})
+	job.JobAgentId = ""
+
+	_, err := Reconcile(
+		context.Background(),
+		getter,
+		&mockSetter{},
+		&mockVerifier{specs: map[string][]oapi.VerificationMetricSpec{}},
+		&mockDispatcher{},
+		job,
+	)
+	require.Error(t, err)
+}
+
+func TestReconcile_InvalidJobAgentId(t *testing.T) {
+	agentID := uuid.New().String()
+	job, getter := setupGetterWithAgents([]oapi.JobAgent{
+		{Id: agentID, Config: oapi.JobAgentConfig{}},
+	})
+	job.JobAgentId = "not-a-uuid"
+
+	_, err := Reconcile(
+		context.Background(),
+		getter,
+		&mockSetter{},
+		&mockVerifier{specs: map[string][]oapi.VerificationMetricSpec{}},
+		&mockDispatcher{},
+		job,
+	)
+	require.Error(t, err)
+}
+
 func TestReconcile_DispatchesWithoutVerifications(t *testing.T) {
 	agentID := uuid.New().String()
 	job, getter := setupGetterWithAgents([]oapi.JobAgent{

--- a/apps/workspace-engine/svc/controllers/jobdispatch/reconcile_test.go
+++ b/apps/workspace-engine/svc/controllers/jobdispatch/reconcile_test.go
@@ -6,11 +6,10 @@ import (
 	"testing"
 	"time"
 
-	"workspace-engine/pkg/oapi"
-
 	"github.com/google/uuid"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
+	"workspace-engine/pkg/oapi"
 )
 
 // ---------------------------------------------------------------------------


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Simplified job agent selection and retrieval logic in the workspace job dispatch system.
  * Streamlined internal method signatures by removing unnecessary parameters.
  * Removed redundant getter interface methods and consolidated agent specification handling.

* **Tests**
  * Updated tests to reflect the simplified job dispatch workflow.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->