### PR TITLE
refactor: rename minimumSockTimeMinutes to minimumSoakTimeMinutes

### DIFF
--- a/apps/api/openapi/openapi.json
+++ b/apps/api/openapi/openapi.json
@@ -994,9 +994,16 @@
                   "minimum": 0,
                   "type": "integer"
                },
-               "minimumSockTimeMinutes": {
+               "minimumSoakTimeMinutes": {
                   "default": 0,
                   "description": "Minimum time to wait after the depends on environment is in a success state before the current environment can be deployed",
+                  "format": "int32",
+                  "minimum": 0,
+                  "type": "integer"
+               },
+               "minimumSockTimeMinutes": {
+                  "default": 0,
+                  "description": "Deprecated: Use minimumSoakTimeMinutes instead. Minimum time to wait after the depends on environment is in a success state before the current environment can be deployed",
                   "format": "int32",
                   "minimum": 0,
                   "type": "integer"

--- a/apps/api/openapi/openapi.json
+++ b/apps/api/openapi/openapi.json
@@ -995,15 +995,14 @@
                   "type": "integer"
                },
                "minimumSoakTimeMinutes": {
-                  "default": 0,
-                  "description": "Minimum time to wait after the depends on environment is in a success state before the current environment can be deployed",
+                  "description": "Minimum time to wait after the depends on environment is in a success state before the current environment can be deployed. Defaults to 0 if not provided.",
                   "format": "int32",
                   "minimum": 0,
                   "type": "integer"
                },
                "minimumSockTimeMinutes": {
-                  "default": 0,
-                  "description": "Deprecated: Use minimumSoakTimeMinutes instead. Minimum time to wait after the depends on environment is in a success state before the current environment can be deployed",
+                  "deprecated": true,
+                  "description": "Use minimumSoakTimeMinutes instead. Minimum time to wait after the depends on environment is in a success state before the current environment can be deployed",
                   "format": "int32",
                   "minimum": 0,
                   "type": "integer"

--- a/apps/api/openapi/schemas/policies.jsonnet
+++ b/apps/api/openapi/schemas/policies.jsonnet
@@ -173,6 +173,14 @@ local openapi = import '../lib/openapi.libsonnet';
         format: 'int32',
         minimum: 0,
         default: 0,
+        description: 'Deprecated: Use minimumSoakTimeMinutes instead. Minimum time to wait after the depends on environment is in a success state before the current environment can be deployed',
+      },
+
+      minimumSoakTimeMinutes: {
+        type: 'integer',
+        format: 'int32',
+        minimum: 0,
+        default: 0,
         description: 'Minimum time to wait after the depends on environment is in a success state before the current environment can be deployed',
       },
 

--- a/apps/api/openapi/schemas/policies.jsonnet
+++ b/apps/api/openapi/schemas/policies.jsonnet
@@ -172,16 +172,15 @@ local openapi = import '../lib/openapi.libsonnet';
         type: 'integer',
         format: 'int32',
         minimum: 0,
-        default: 0,
-        description: 'Deprecated: Use minimumSoakTimeMinutes instead. Minimum time to wait after the depends on environment is in a success state before the current environment can be deployed',
+        deprecated: true,
+        description: 'Use minimumSoakTimeMinutes instead. Minimum time to wait after the depends on environment is in a success state before the current environment can be deployed',
       },
 
       minimumSoakTimeMinutes: {
         type: 'integer',
         format: 'int32',
         minimum: 0,
-        default: 0,
-        description: 'Minimum time to wait after the depends on environment is in a success state before the current environment can be deployed',
+        description: 'Minimum time to wait after the depends on environment is in a success state before the current environment can be deployed. Defaults to 0 if not provided.',
       },
 
       maximumAgeHours: {

--- a/apps/api/src/routes/v1/workspaces/policies.ts
+++ b/apps/api/src/routes/v1/workspaces/policies.ts
@@ -80,6 +80,7 @@ const insertPolicyRules = async (tx: Tx, policyId: string, rules: any[]) => {
           rule.environmentProgression.dependsOnEnvironmentSelector,
         maximumAgeHours: rule.environmentProgression.maximumAgeHours,
         minimumSoakTimeMinutes:
+          rule.environmentProgression.minimumSoakTimeMinutes ??
           rule.environmentProgression.minimumSockTimeMinutes,
         minimumSuccessPercentage:
           rule.environmentProgression.minimumSuccessPercentage,
@@ -193,6 +194,7 @@ const formatPolicy = (p: PolicyRow) => {
             maximumAgeHours: r.maximumAgeHours,
           }),
           minimumSockTimeMinutes: r.minimumSoakTimeMinutes,
+          minimumSoakTimeMinutes: r.minimumSoakTimeMinutes,
           minimumSuccessPercentage: r.minimumSuccessPercentage,
           ...(r.successStatuses != null && {
             successStatuses: r.successStatuses,

--- a/apps/api/src/types/openapi.ts
+++ b/apps/api/src/types/openapi.ts
@@ -1402,16 +1402,15 @@ export interface components {
             maximumAgeHours?: number;
             /**
              * Format: int32
-             * @description Minimum time to wait after the depends on environment is in a success state before the current environment can be deployed
-             * @default 0
+             * @description Minimum time to wait after the depends on environment is in a success state before the current environment can be deployed. Defaults to 0 if not provided.
              */
-            minimumSoakTimeMinutes: number;
+            minimumSoakTimeMinutes?: number;
             /**
              * Format: int32
-             * @description Deprecated: Use minimumSoakTimeMinutes instead. Minimum time to wait after the depends on environment is in a success state before the current environment can be deployed
-             * @default 0
+             * @deprecated
+             * @description Use minimumSoakTimeMinutes instead. Minimum time to wait after the depends on environment is in a success state before the current environment can be deployed
              */
-            minimumSockTimeMinutes: number;
+            minimumSockTimeMinutes?: number;
             /**
              * Format: float
              * @default 100

--- a/apps/api/src/types/openapi.ts
+++ b/apps/api/src/types/openapi.ts
@@ -1405,6 +1405,12 @@ export interface components {
              * @description Minimum time to wait after the depends on environment is in a success state before the current environment can be deployed
              * @default 0
              */
+            minimumSoakTimeMinutes: number;
+            /**
+             * Format: int32
+             * @description Deprecated: Use minimumSoakTimeMinutes instead. Minimum time to wait after the depends on environment is in a success state before the current environment can be deployed
+             * @default 0
+             */
             minimumSockTimeMinutes: number;
             /**
              * Format: float

--- a/apps/workspace-engine/oapi/openapi.json
+++ b/apps/workspace-engine/oapi/openapi.json
@@ -607,7 +607,7 @@
                   "minimum": 0,
                   "type": "integer"
                },
-               "minimumSockTimeMinutes": {
+               "minimumSoakTimeMinutes": {
                   "default": 0,
                   "description": "Minimum time to wait after the depends on environment is in a success state before the current environment can be deployed",
                   "format": "int32",

--- a/apps/workspace-engine/oapi/spec/schemas/policy.jsonnet
+++ b/apps/workspace-engine/oapi/spec/schemas/policy.jsonnet
@@ -149,7 +149,7 @@ local openapi = import '../lib/openapi.libsonnet';
       minimumSuccessPercentage: { type: 'number', format: 'float', minimum: 0, maximum: 100, default: 100 },
       successStatuses: { type: 'array', items: openapi.schemaRef('JobStatus') },
 
-      minimumSockTimeMinutes: {
+      minimumSoakTimeMinutes: {
         type: 'integer',
         format: 'int32',
         minimum: 0,

--- a/apps/workspace-engine/pkg/db/convert.go
+++ b/apps/workspace-engine/pkg/db/convert.go
@@ -148,7 +148,7 @@ func ToOapiPolicyWithRules(row ListPoliciesWithRulesByWorkspaceIDRow) *oapi.Poli
 		rule := oapi.EnvironmentProgressionRule{
 			DependsOnEnvironmentSelector: pr.DependsOnEnvironmentSelector,
 			MaximumAgeHours:              pr.MaximumAgeHours,
-			MinimumSockTimeMinutes:       pr.MinimumSoakTimeMinutes,
+			MinimumSoakTimeMinutes:       pr.MinimumSoakTimeMinutes,
 			MinimumSuccessPercentage:     pr.MinimumSuccessPercentage,
 		}
 		if pr.SuccessStatuses != nil {

--- a/apps/workspace-engine/pkg/oapi/oapi.gen.go
+++ b/apps/workspace-engine/pkg/oapi/oapi.gen.go
@@ -445,8 +445,8 @@ type EnvironmentProgressionRule struct {
 	// MaximumAgeHours Maximum age of dependency deployment before blocking progression (prevents stale promotions)
 	MaximumAgeHours *int32 `json:"maximumAgeHours,omitempty"`
 
-	// MinimumSockTimeMinutes Minimum time to wait after the depends on environment is in a success state before the current environment can be deployed
-	MinimumSockTimeMinutes   *int32       `json:"minimumSockTimeMinutes,omitempty"`
+	// MinimumSoakTimeMinutes Minimum time to wait after the depends on environment is in a success state before the current environment can be deployed
+	MinimumSoakTimeMinutes   *int32       `json:"minimumSoakTimeMinutes,omitempty"`
 	MinimumSuccessPercentage *float32     `json:"minimumSuccessPercentage,omitempty"`
 	SuccessStatuses          *[]JobStatus `json:"successStatuses,omitempty"`
 }

--- a/apps/workspace-engine/pkg/workspace/releasemanager/policy/evaluator/environmentprogression/environmentprogression.go
+++ b/apps/workspace-engine/pkg/workspace/releasemanager/policy/evaluator/environmentprogression/environmentprogression.go
@@ -224,10 +224,10 @@ func (e *EnvironmentProgressionEvaluator) checkDependencyEnvironments(
 	}
 
 	var soakTimeEvaluator *SoakTimeEvaluator
-	if e.rule.MinimumSockTimeMinutes != nil && *e.rule.MinimumSockTimeMinutes > 0 {
+	if e.rule.MinimumSoakTimeMinutes != nil && *e.rule.MinimumSoakTimeMinutes > 0 {
 		soakTimeEvaluator = &SoakTimeEvaluator{
 			getters:         e.getters,
-			soakMinutes:     *e.rule.MinimumSockTimeMinutes,
+			soakMinutes:     *e.rule.MinimumSoakTimeMinutes,
 			successStatuses: successStatuses,
 			timeGetter:      time.Now,
 		}

--- a/apps/workspace-engine/pkg/workspace/releasemanager/policy/evaluator/environmentprogression/environmentprogression_test.go
+++ b/apps/workspace-engine/pkg/workspace/releasemanager/policy/evaluator/environmentprogression/environmentprogression_test.go
@@ -184,7 +184,7 @@ func TestEnvironmentProgressionEvaluator_SoakTimeNotMet(t *testing.T) {
 		Id: "rule-1",
 		EnvironmentProgression: &oapi.EnvironmentProgressionRule{
 			DependsOnEnvironmentSelector: selector,
-			MinimumSockTimeMinutes:       &soakTime,
+			MinimumSoakTimeMinutes:       &soakTime,
 		},
 	}
 
@@ -462,7 +462,7 @@ func TestEnvironmentProgressionEvaluator_SatisfiedAt_SoakTimeOnly(t *testing.T) 
 		Id: "rule-1",
 		EnvironmentProgression: &oapi.EnvironmentProgressionRule{
 			DependsOnEnvironmentSelector: selector,
-			MinimumSockTimeMinutes:       &soakMinutes,
+			MinimumSoakTimeMinutes:       &soakMinutes,
 		},
 	}
 
@@ -586,7 +586,7 @@ func TestEnvironmentProgressionEvaluator_SatisfiedAt_BothPassRateAndSoakTime(t *
 		EnvironmentProgression: &oapi.EnvironmentProgressionRule{
 			DependsOnEnvironmentSelector: selector,
 			MinimumSuccessPercentage:     &minSuccessPercentage,
-			MinimumSockTimeMinutes:       &soakMinutes,
+			MinimumSoakTimeMinutes:       &soakMinutes,
 		},
 	}
 
@@ -743,7 +743,7 @@ func TestEnvironmentProgressionEvaluator_SatisfiedAt_PassRateBeforeSoakTime(t *t
 		EnvironmentProgression: &oapi.EnvironmentProgressionRule{
 			DependsOnEnvironmentSelector: selector,
 			MinimumSuccessPercentage:     &minSuccessPercentage,
-			MinimumSockTimeMinutes:       &soakMinutes,
+			MinimumSoakTimeMinutes:       &soakMinutes,
 		},
 	}
 
@@ -823,7 +823,7 @@ func TestEnvironmentProgressionEvaluator_SatisfiedAt_NotSatisfied(t *testing.T) 
 		Id: "rule-1",
 		EnvironmentProgression: &oapi.EnvironmentProgressionRule{
 			DependsOnEnvironmentSelector: selector,
-			MinimumSockTimeMinutes:       &soakMinutes,
+			MinimumSoakTimeMinutes:       &soakMinutes,
 		},
 	}
 
@@ -878,7 +878,7 @@ func TestEnvironmentProgressionEvaluator_NoReleaseTargets_Allowed(t *testing.T) 
 		Id: "rule-1",
 		EnvironmentProgression: &oapi.EnvironmentProgressionRule{
 			DependsOnEnvironmentSelector: selector,
-			MinimumSockTimeMinutes:       &soakMinutes,
+			MinimumSoakTimeMinutes:       &soakMinutes,
 		},
 	}
 

--- a/apps/workspace-engine/test/controllers/harness/pipeline_opts.go
+++ b/apps/workspace-engine/test/controllers/harness/pipeline_opts.go
@@ -446,7 +446,7 @@ func EnvProgressionMinSuccessPercentage(pct float32) EnvironmentProgressionOptio
 // wait after the dependency environment reaches a success state.
 func EnvProgressionMinSoakTimeMinutes(minutes int32) EnvironmentProgressionOption {
 	return func(r *oapi.EnvironmentProgressionRule) {
-		r.MinimumSockTimeMinutes = &minutes
+		r.MinimumSoakTimeMinutes = &minutes
 	}
 }
 

--- a/docs/policies/environment-progression.mdx
+++ b/docs/policies/environment-progression.mdx
@@ -201,7 +201,7 @@ resource "ctrlplane_policy" "production_soak_requirement" {
     {
       "environmentProgression": {
         "dependsOnEnvironmentSelector": "environment.name == 'staging'",
-        "minimumSockTimeMinutes": 60
+        "minimumSoakTimeMinutes": 60
       }
     }
   ]
@@ -302,7 +302,7 @@ resource "ctrlplane_policy" "production_full_gate" {
       "environmentProgression": {
         "dependsOnEnvironmentSelector": "environment.name == 'staging'",
         "minimumSuccessPercentage": 100,
-        "minimumSockTimeMinutes": 30,
+        "minimumSoakTimeMinutes": 30,
         "maximumAgeHours": 48
       }
     },

--- a/docs/policies/overview.mdx
+++ b/docs/policies/overview.mdx
@@ -160,7 +160,7 @@ Require successful deployment to a prerequisite environment:
 | ----------------------------------------------------- | ------------------------------------ | ----------------------------------- |
 | `environmentProgression.dependsOnEnvironmentSelector` | `depends_on_environment_selector`    | CEL matching prerequisite env       |
 | `environmentProgression.minimumSuccessPercentage`     | `minimum_success_percentage`         | Required success % (0-100)          |
-| `environmentProgression.minimumSockTimeMinutes`       | `minimum_sock_time_minutes`          | Soak time after success             |
+| `environmentProgression.minimumSoakTimeMinutes`       | `minimum_soak_time_minutes`          | Soak time after success             |
 | `environmentProgression.maximumAgeHours`              | `maximum_age_hours`                  | Max age of dependency deployment    |
 
 See [Environment Progression](./environment-progression) for details.
@@ -364,7 +364,7 @@ resource "ctrlplane_policy" "production_policy" {
       {
         "environmentProgression": {
           "dependsOnEnvironmentSelector": "environment.name == 'staging'",
-          "minimumSockTimeMinutes": 30
+          "minimumSoakTimeMinutes": 30
         }
       },
       {

--- a/packages/trpc/src/routes/policies.ts
+++ b/packages/trpc/src/routes/policies.ts
@@ -196,6 +196,7 @@ export const policiesRouter = router({
               dependsOnEnvironmentSelector: string;
               maximumAgeHours?: number;
               minimumSockTimeMinutes?: number;
+              minimumSoakTimeMinutes?: number;
               minimumSuccessPercentage?: number;
               successStatuses?: string[];
             };
@@ -204,7 +205,8 @@ export const policiesRouter = router({
               policyId,
               dependsOnEnvironmentSelector: ep.dependsOnEnvironmentSelector,
               maximumAgeHours: ep.maximumAgeHours,
-              minimumSoakTimeMinutes: ep.minimumSockTimeMinutes,
+              minimumSoakTimeMinutes:
+                ep.minimumSoakTimeMinutes ?? ep.minimumSockTimeMinutes,
               minimumSuccessPercentage: ep.minimumSuccessPercentage,
               successStatuses: ep.successStatuses,
             });

--- a/packages/workspace-engine-sdk/src/schema.ts
+++ b/packages/workspace-engine-sdk/src/schema.ts
@@ -394,7 +394,7 @@ export interface components {
        * @description Minimum time to wait after the depends on environment is in a success state before the current environment can be deployed
        * @default 0
        */
-      minimumSockTimeMinutes: number;
+      minimumSoakTimeMinutes: number;
       /**
        * Format: float
        * @default 100


### PR DESCRIPTION
Resolves #970 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Corrected soak-time field name: added minimumSoakTimeMinutes and deprecated the legacy minimumSockTimeMinutes. The old name remains supported via fallback handling to preserve backwards compatibility.

* **Documentation**
  * Updated policy docs and API examples to use minimumSoakTimeMinutes in environment progression configurations.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->