### PR TITLE
feat: add cel filtering to v1 deployment list endpoint

### DIFF
--- a/.github/workflows/apps-api.yaml
+++ b/.github/workflows/apps-api.yaml
@@ -77,6 +77,22 @@ jobs:
       - name: Seed test data
         run: pnpm -F @ctrlplane/e2e seed
 
+      - name: Setup Go
+        uses: actions/setup-go@v5
+        with:
+          go-version-file: apps/workspace-engine/go.mod
+
+      - name: Build workspace-engine
+        run: go build -o ./bin/workspace-engine .
+        working-directory: apps/workspace-engine
+
+      - name: Start workspace-engine
+        run: ./bin/workspace-engine &
+        env:
+          POSTGRES_URL: "postgresql://ctrlplane_test:test_password@localhost:5432/ctrlplane_test?sslmode=disable"
+          PORT: "8081"
+        working-directory: apps/workspace-engine
+
       - name: Start API server
         run: pnpm -F @ctrlplane/web-api dev &
         env:

--- a/.github/workflows/apps-api.yaml
+++ b/.github/workflows/apps-api.yaml
@@ -93,6 +93,10 @@ jobs:
           PORT: "8081"
         working-directory: apps/workspace-engine
 
+      - name: Wait for workspace-engine
+        run: |
+          timeout 60s bash -c 'until curl -sf http://localhost:8081/healthz; do sleep 2; done'
+
       - name: Start API server
         run: pnpm -F @ctrlplane/web-api dev &
         env:

--- a/apps/api/openapi/lib/openapi.libsonnet
+++ b/apps/api/openapi/lib/openapi.libsonnet
@@ -67,6 +67,7 @@
     name: 'cel',
     'in': 'query',
     required: false,
+    allowReserved: true,
     description: 'CEL expression to filter the results',
     schema: {
       type: 'string',

--- a/apps/api/openapi/openapi.json
+++ b/apps/api/openapi/openapi.json
@@ -4458,6 +4458,16 @@
                      "minimum": 0,
                      "type": "integer"
                   }
+               },
+               {
+                  "allowReserved": true,
+                  "description": "CEL expression to filter the results",
+                  "in": "query",
+                  "name": "cel",
+                  "required": false,
+                  "schema": {
+                     "type": "string"
+                  }
                }
             ],
             "responses": {
@@ -6939,6 +6949,7 @@
                   }
                },
                {
+                  "allowReserved": true,
                   "description": "CEL expression to filter the results",
                   "in": "query",
                   "name": "cel",
@@ -7480,6 +7491,7 @@
                   }
                },
                {
+                  "allowReserved": true,
                   "description": "CEL expression to filter the results",
                   "in": "query",
                   "name": "cel",

--- a/apps/api/openapi/paths/deployments.jsonnet
+++ b/apps/api/openapi/paths/deployments.jsonnet
@@ -9,6 +9,7 @@ local openapi = import '../lib/openapi.libsonnet';
         openapi.workspaceIdParam(),
         openapi.limitParam(),
         openapi.offsetParam(),
+        openapi.celParam(),
       ],
       responses: openapi.paginatedResponse(openapi.schemaRef('DeploymentAndSystems')),
     },

--- a/apps/api/src/routes/v1/workspaces/deployments.ts
+++ b/apps/api/src/routes/v1/workspaces/deployments.ts
@@ -69,7 +69,7 @@ const listDeployments: AsyncTypedHandler<
   const offset = req.query.offset ?? 0;
   const cel = req.query.cel;
 
-  const result = await getClientFor().GET(
+  const { data, error, response } = await getClientFor().GET(
     "/v1/workspaces/{workspaceId}/deployments",
     {
       params: {
@@ -79,10 +79,13 @@ const listDeployments: AsyncTypedHandler<
     },
   );
 
-  if (result.error != null)
-    throw new ApiError(JSON.stringify(result.error), result.response.status);
+  if (error != null)
+    throw new ApiError(
+      error.error ?? "Failed to list deployments",
+      response.status >= 400 && response.status < 500 ? response.status : 502,
+    );
 
-  res.status(200).json(result.data);
+  res.status(200).json(data);
 };
 
 const getDeployment: AsyncTypedHandler<

--- a/apps/api/src/routes/v1/workspaces/deployments.ts
+++ b/apps/api/src/routes/v1/workspaces/deployments.ts
@@ -11,6 +11,7 @@ import {
   enqueueReleaseTargetsForDeployment,
 } from "@ctrlplane/db/reconcilers";
 import * as schema from "@ctrlplane/db/schema";
+import { getClientFor } from "@ctrlplane/workspace-engine-sdk";
 
 // 1 hour
 
@@ -66,54 +67,22 @@ const listDeployments: AsyncTypedHandler<
   const { workspaceId } = req.params;
   const limit = req.query.limit ?? 50;
   const offset = req.query.offset ?? 0;
+  const cel = req.query.cel;
 
-  const [countResult] = await db
-    .select({ total: count() })
-    .from(schema.deployment)
-    .where(eq(schema.deployment.workspaceId, workspaceId));
+  const result = await getClientFor().GET(
+    "/v1/workspaces/{workspaceId}/deployments",
+    {
+      params: {
+        path: { workspaceId },
+        query: { limit, offset, cel },
+      },
+    },
+  );
 
-  const total = countResult?.total ?? 0;
+  if (result.error != null)
+    throw new ApiError(JSON.stringify(result.error), result.response.status);
 
-  const deployments = await db
-    .select()
-    .from(schema.deployment)
-    .where(eq(schema.deployment.workspaceId, workspaceId))
-    .limit(limit)
-    .offset(offset);
-
-  const deploymentIds = deployments.map((d) => d.id);
-
-  const systemLinks =
-    deploymentIds.length > 0
-      ? await db
-          .select({
-            deploymentId: schema.systemDeployment.deploymentId,
-            system: schema.system,
-          })
-          .from(schema.systemDeployment)
-          .innerJoin(
-            schema.system,
-            eq(schema.systemDeployment.systemId, schema.system.id),
-          )
-          .where(inArray(schema.systemDeployment.deploymentId, deploymentIds))
-      : [];
-
-  const systemsByDeploymentId = new Map<
-    string,
-    (typeof schema.system.$inferSelect)[]
-  >();
-  for (const link of systemLinks) {
-    const arr = systemsByDeploymentId.get(link.deploymentId) ?? [];
-    arr.push(link.system);
-    systemsByDeploymentId.set(link.deploymentId, arr);
-  }
-
-  const items = deployments.map((dep) => ({
-    deployment: formatDeployment(dep),
-    systems: (systemsByDeploymentId.get(dep.id) ?? []).map(formatSystem),
-  }));
-
-  res.status(200).json({ items, total, limit, offset });
+  res.status(200).json(result.data);
 };
 
 const getDeployment: AsyncTypedHandler<

--- a/apps/api/src/types/openapi.ts
+++ b/apps/api/src/types/openapi.ts
@@ -2959,6 +2959,8 @@ export interface operations {
                 limit?: number;
                 /** @description Number of items to skip */
                 offset?: number;
+                /** @description CEL expression to filter the results */
+                cel?: string;
             };
             header?: never;
             path: {

--- a/apps/workspace-engine/oapi/openapi.json
+++ b/apps/workspace-engine/oapi/openapi.json
@@ -3395,6 +3395,104 @@
             "summary": "Validate a resource selector"
          }
       },
+      "/v1/workspaces/{workspaceId}/deployments": {
+         "get": {
+            "description": "Returns a paginated list of deployments for a workspace. Optionally filter with a CEL expression using the \"deployment\" variable.",
+            "operationId": "listDeployments",
+            "parameters": [
+               {
+                  "description": "ID of the workspace",
+                  "in": "path",
+                  "name": "workspaceId",
+                  "required": true,
+                  "schema": {
+                     "type": "string"
+                  }
+               },
+               {
+                  "description": "Maximum number of items to return",
+                  "in": "query",
+                  "name": "limit",
+                  "required": false,
+                  "schema": {
+                     "default": 50,
+                     "maximum": 1000,
+                     "minimum": 1,
+                     "type": "integer"
+                  }
+               },
+               {
+                  "description": "Number of items to skip",
+                  "in": "query",
+                  "name": "offset",
+                  "required": false,
+                  "schema": {
+                     "default": 0,
+                     "minimum": 0,
+                     "type": "integer"
+                  }
+               },
+               {
+                  "description": "CEL expression to filter the results",
+                  "in": "query",
+                  "name": "cel",
+                  "required": false,
+                  "schema": {
+                     "type": "string"
+                  }
+               }
+            ],
+            "responses": {
+               "200": {
+                  "content": {
+                     "application/json": {
+                        "schema": {
+                           "properties": {
+                              "items": {
+                                 "items": {
+                                    "$ref": "#/components/schemas/DeploymentAndSystems"
+                                 },
+                                 "type": "array"
+                              },
+                              "limit": {
+                                 "description": "Maximum number of items returned",
+                                 "type": "integer"
+                              },
+                              "offset": {
+                                 "description": "Number of items skipped",
+                                 "type": "integer"
+                              },
+                              "total": {
+                                 "description": "Total number of items available",
+                                 "type": "integer"
+                              }
+                           },
+                           "required": [
+                              "items",
+                              "total",
+                              "limit",
+                              "offset"
+                           ],
+                           "type": "object"
+                        }
+                     }
+                  },
+                  "description": "Paginated list of items"
+               },
+               "400": {
+                  "content": {
+                     "application/json": {
+                        "schema": {
+                           "$ref": "#/components/schemas/ErrorResponse"
+                        }
+                     }
+                  },
+                  "description": "Invalid request"
+               }
+            },
+            "summary": "List deployments"
+         }
+      },
       "/v1/workspaces/{workspaceId}/release-targets/{releaseTargetKey}/state": {
          "get": {
             "operationId": "getReleaseTargetState",

--- a/apps/workspace-engine/oapi/spec/paths/deployment.jsonnet
+++ b/apps/workspace-engine/oapi/spec/paths/deployment.jsonnet
@@ -1,6 +1,21 @@
 local openapi = import '../lib/openapi.libsonnet';
 
 {
+  '/v1/workspaces/{workspaceId}/deployments': {
+    get: {
+      summary: 'List deployments',
+      operationId: 'listDeployments',
+      description: 'Returns a paginated list of deployments for a workspace. Optionally filter with a CEL expression using the "deployment" variable.',
+      parameters: [
+        openapi.workspaceIdParam(),
+        openapi.limitParam(),
+        openapi.offsetParam(),
+        openapi.celParam(),
+      ],
+      responses: openapi.paginatedResponse(openapi.schemaRef('DeploymentAndSystems'))
+                 + openapi.badRequestResponse(),
+    },
+  },
   '/v1/deployments/{deploymentId}/job-agents': {
     get: {
       summary: 'Get job agents matching a deployment selector',

--- a/apps/workspace-engine/pkg/db/convert.go
+++ b/apps/workspace-engine/pkg/db/convert.go
@@ -12,12 +12,16 @@ func ToOapiDeployment(row Deployment) *oapi.Deployment {
 	d := &oapi.Deployment{
 		Id:               row.ID.String(),
 		Name:             row.Name,
+		Slug:             row.Name,
 		Metadata:         row.Metadata,
 		JobAgentConfig:   oapi.JobAgentConfig(row.JobAgentConfig),
 		JobAgentSelector: row.JobAgentSelector,
 	}
 	if row.Description != "" {
 		d.Description = &row.Description
+	}
+	if row.ResourceSelector.Valid && row.ResourceSelector.String != "" {
+		d.ResourceSelector = &row.ResourceSelector.String
 	}
 	return d
 }

--- a/apps/workspace-engine/pkg/db/convert_test.go
+++ b/apps/workspace-engine/pkg/db/convert_test.go
@@ -65,37 +65,45 @@ func TestToOapiEnvironment_NilOptionalFields(t *testing.T) {
 
 func TestToOapiDeployment(t *testing.T) {
 	depID := uuid.New()
+	celExpr := `resource.kind == "Service"`
 
 	row := Deployment{
-		ID:          depID,
-		Name:        "api-server",
-		Description: "Main API deployment",
-		Metadata:    map[string]string{"team": "platform"},
+		ID:               depID,
+		Name:             "api-server",
+		Description:      "Main API deployment",
+		ResourceSelector: pgtype.Text{String: celExpr, Valid: true},
+		Metadata:         map[string]string{"team": "platform"},
 	}
 
 	dep := ToOapiDeployment(row)
 
 	assert.Equal(t, depID.String(), dep.Id)
 	assert.Equal(t, "api-server", dep.Name)
+	assert.Equal(t, "api-server", dep.Slug)
 	assert.NotNil(t, dep.Description)
 	assert.Equal(t, "Main API deployment", *dep.Description)
 	assert.Equal(t, map[string]string{"team": "platform"}, dep.Metadata)
 	assert.Empty(t, dep.JobAgentSelector, "empty selector when not set")
+	require.NotNil(t, dep.ResourceSelector)
+	assert.Equal(t, celExpr, *dep.ResourceSelector)
 }
 
 func TestToOapiDeployment_NilOptionalFields(t *testing.T) {
 	depID := uuid.New()
 
 	row := Deployment{
-		ID:       depID,
-		Name:     "worker",
-		Metadata: map[string]string{},
+		ID:               depID,
+		Name:             "worker",
+		ResourceSelector: pgtype.Text{Valid: false},
+		Metadata:         map[string]string{},
 	}
 
 	dep := ToOapiDeployment(row)
 
 	assert.Equal(t, depID.String(), dep.Id)
+	assert.Equal(t, "worker", dep.Slug)
 	assert.Nil(t, dep.Description, "empty description should not be set")
+	assert.Nil(t, dep.ResourceSelector, "invalid selector should not be set")
 }
 
 // ---------------------------------------------------------------------------

--- a/apps/workspace-engine/pkg/db/deployments.sql.go
+++ b/apps/workspace-engine/pkg/db/deployments.sql.go
@@ -114,6 +114,49 @@ func (q *Queries) GetSystemIDsForDeployment(ctx context.Context, deploymentID uu
 	return items, nil
 }
 
+const getSystemsByDeploymentIDs = `-- name: GetSystemsByDeploymentIDs :many
+SELECT sd.deployment_id, s.id, s.name, s.description, s.workspace_id, s.metadata
+FROM system_deployment sd
+INNER JOIN system s ON s.id = sd.system_id
+WHERE sd.deployment_id = ANY($1::uuid[])
+`
+
+type GetSystemsByDeploymentIDsRow struct {
+	DeploymentID uuid.UUID
+	ID           uuid.UUID
+	Name         string
+	Description  string
+	WorkspaceID  uuid.UUID
+	Metadata     []byte
+}
+
+func (q *Queries) GetSystemsByDeploymentIDs(ctx context.Context, deploymentIds []uuid.UUID) ([]GetSystemsByDeploymentIDsRow, error) {
+	rows, err := q.db.Query(ctx, getSystemsByDeploymentIDs, deploymentIds)
+	if err != nil {
+		return nil, err
+	}
+	defer rows.Close()
+	var items []GetSystemsByDeploymentIDsRow
+	for rows.Next() {
+		var i GetSystemsByDeploymentIDsRow
+		if err := rows.Scan(
+			&i.DeploymentID,
+			&i.ID,
+			&i.Name,
+			&i.Description,
+			&i.WorkspaceID,
+			&i.Metadata,
+		); err != nil {
+			return nil, err
+		}
+		items = append(items, i)
+	}
+	if err := rows.Err(); err != nil {
+		return nil, err
+	}
+	return items, nil
+}
+
 const listDeploymentsBySystemID = `-- name: ListDeploymentsBySystemID :many
 SELECT d.id, d.name, d.description, d.resource_selector, d.metadata, d.workspace_id
 FROM deployment d

--- a/apps/workspace-engine/pkg/db/queries/deployments.sql
+++ b/apps/workspace-engine/pkg/db/queries/deployments.sql
@@ -28,6 +28,12 @@ RETURNING *;
 -- name: GetSystemIDsForDeployment :many
 SELECT system_id FROM system_deployment WHERE deployment_id = $1;
 
+-- name: GetSystemsByDeploymentIDs :many
+SELECT sd.deployment_id, s.*
+FROM system_deployment sd
+INNER JOIN system s ON s.id = sd.system_id
+WHERE sd.deployment_id = ANY(@deployment_ids::uuid[]);
+
 -- name: UpsertSystemDeployment :exec
 INSERT INTO system_deployment (system_id, deployment_id)
 VALUES ($1, $2)

--- a/apps/workspace-engine/pkg/oapi/oapi.gen.go
+++ b/apps/workspace-engine/pkg/oapi/oapi.gen.go
@@ -1494,6 +1494,18 @@ type ValidateResourceSelectorJSONBody struct {
 	ResourceSelector string `json:"resourceSelector"`
 }
 
+// ListDeploymentsParams defines parameters for ListDeployments.
+type ListDeploymentsParams struct {
+	// Limit Maximum number of items to return
+	Limit *int `form:"limit,omitempty" json:"limit,omitempty"`
+
+	// Offset Number of items to skip
+	Offset *int `form:"offset,omitempty" json:"offset,omitempty"`
+
+	// Cel CEL expression to filter the results
+	Cel *string `form:"cel,omitempty" json:"cel,omitempty"`
+}
+
 // ComputeAggergateJSONBody defines parameters for ComputeAggergate.
 type ComputeAggergateJSONBody struct {
 	// Filter CEL expression to filter resources. Defaults to "true" (all resources).
@@ -2464,6 +2476,9 @@ type ServerInterface interface {
 	// Validate a resource selector
 	// (POST /v1/validate/resource-selector)
 	ValidateResourceSelector(c *gin.Context)
+	// List deployments
+	// (GET /v1/workspaces/{workspaceId}/deployments)
+	ListDeployments(c *gin.Context, workspaceId string, params ListDeploymentsParams)
 	// Get the state of a release target
 	// (GET /v1/workspaces/{workspaceId}/release-targets/{releaseTargetKey}/state)
 	GetReleaseTargetState(c *gin.Context, workspaceId string, releaseTargetKey string)
@@ -2570,6 +2585,57 @@ func (siw *ServerInterfaceWrapper) ValidateResourceSelector(c *gin.Context) {
 	}
 
 	siw.Handler.ValidateResourceSelector(c)
+}
+
+// ListDeployments operation middleware
+func (siw *ServerInterfaceWrapper) ListDeployments(c *gin.Context) {
+
+	var err error
+
+	// ------------- Path parameter "workspaceId" -------------
+	var workspaceId string
+
+	err = runtime.BindStyledParameterWithOptions("simple", "workspaceId", c.Param("workspaceId"), &workspaceId, runtime.BindStyledParameterOptions{Explode: false, Required: true})
+	if err != nil {
+		siw.ErrorHandler(c, fmt.Errorf("Invalid format for parameter workspaceId: %w", err), http.StatusBadRequest)
+		return
+	}
+
+	// Parameter object where we will unmarshal all parameters from the context
+	var params ListDeploymentsParams
+
+	// ------------- Optional query parameter "limit" -------------
+
+	err = runtime.BindQueryParameter("form", true, false, "limit", c.Request.URL.Query(), &params.Limit)
+	if err != nil {
+		siw.ErrorHandler(c, fmt.Errorf("Invalid format for parameter limit: %w", err), http.StatusBadRequest)
+		return
+	}
+
+	// ------------- Optional query parameter "offset" -------------
+
+	err = runtime.BindQueryParameter("form", true, false, "offset", c.Request.URL.Query(), &params.Offset)
+	if err != nil {
+		siw.ErrorHandler(c, fmt.Errorf("Invalid format for parameter offset: %w", err), http.StatusBadRequest)
+		return
+	}
+
+	// ------------- Optional query parameter "cel" -------------
+
+	err = runtime.BindQueryParameter("form", true, false, "cel", c.Request.URL.Query(), &params.Cel)
+	if err != nil {
+		siw.ErrorHandler(c, fmt.Errorf("Invalid format for parameter cel: %w", err), http.StatusBadRequest)
+		return
+	}
+
+	for _, middleware := range siw.HandlerMiddlewares {
+		middleware(c)
+		if c.IsAborted() {
+			return
+		}
+	}
+
+	siw.Handler.ListDeployments(c, workspaceId, params)
 }
 
 // GetReleaseTargetState operation middleware
@@ -2736,6 +2802,7 @@ func RegisterHandlersWithOptions(router gin.IRouter, si ServerInterface, options
 	router.GET(options.BaseURL+"/v1/deployments/:deploymentId/release-targets", wrapper.ListReleaseTargets)
 	router.GET(options.BaseURL+"/v1/jobs/:jobId/verification-status", wrapper.GetJobVerificationStatus)
 	router.POST(options.BaseURL+"/v1/validate/resource-selector", wrapper.ValidateResourceSelector)
+	router.GET(options.BaseURL+"/v1/workspaces/:workspaceId/deployments", wrapper.ListDeployments)
 	router.GET(options.BaseURL+"/v1/workspaces/:workspaceId/release-targets/:releaseTargetKey/state", wrapper.GetReleaseTargetState)
 	router.POST(options.BaseURL+"/v1/workspaces/:workspaceId/resources/aggregates", wrapper.ComputeAggergate)
 	router.POST(options.BaseURL+"/v1/workspaces/:workspaceId/resources/query", wrapper.QueryResources)

--- a/apps/workspace-engine/svc/http/server/openapi/deployments/getters.go
+++ b/apps/workspace-engine/svc/http/server/openapi/deployments/getters.go
@@ -49,23 +49,20 @@ func (g *PostgresGetter) GetSystemsByDeploymentIDs(
 	}
 
 	queries := db.GetQueries(ctx)
+	rows, err := queries.GetSystemsByDeploymentIDs(ctx, deploymentIDs)
+	if err != nil {
+		return nil, fmt.Errorf("get systems by deployment ids: %w", err)
+	}
+
 	result := make(map[uuid.UUID][]db.System, len(deploymentIDs))
-
-	for _, depID := range deploymentIDs {
-		systemIDs, err := queries.GetSystemIDsForDeployment(ctx, depID)
-		if err != nil {
-			return nil, fmt.Errorf("get system ids for deployment %s: %w", depID, err)
-		}
-
-		systems := make([]db.System, 0, len(systemIDs))
-		for _, sysID := range systemIDs {
-			sys, err := queries.GetSystemByID(ctx, sysID)
-			if err != nil {
-				return nil, fmt.Errorf("get system %s: %w", sysID, err)
-			}
-			systems = append(systems, sys)
-		}
-		result[depID] = systems
+	for _, row := range rows {
+		result[row.DeploymentID] = append(result[row.DeploymentID], db.System{
+			ID:          row.ID,
+			Name:        row.Name,
+			Description: row.Description,
+			WorkspaceID: row.WorkspaceID,
+			Metadata:    row.Metadata,
+		})
 	}
 
 	return result, nil

--- a/apps/workspace-engine/svc/http/server/openapi/deployments/getters.go
+++ b/apps/workspace-engine/svc/http/server/openapi/deployments/getters.go
@@ -1,0 +1,72 @@
+package deployments
+
+import (
+	"context"
+	"fmt"
+
+	"github.com/google/uuid"
+	"workspace-engine/pkg/db"
+)
+
+type Getter interface {
+	GetAllDeploymentsByWorkspaceID(
+		ctx context.Context,
+		workspaceID uuid.UUID,
+	) ([]db.Deployment, error)
+	GetSystemsByDeploymentIDs(
+		ctx context.Context,
+		deploymentIDs []uuid.UUID,
+	) (map[uuid.UUID][]db.System, error)
+}
+
+type PostgresGetter struct{}
+
+var _ Getter = &PostgresGetter{}
+
+func (g *PostgresGetter) GetAllDeploymentsByWorkspaceID(
+	ctx context.Context,
+	workspaceID uuid.UUID,
+) ([]db.Deployment, error) {
+	queries := db.GetQueries(ctx)
+	deployments, err := queries.ListDeploymentsByWorkspaceID(
+		ctx,
+		db.ListDeploymentsByWorkspaceIDParams{
+			WorkspaceID: workspaceID,
+		},
+	)
+	if err != nil {
+		return nil, fmt.Errorf("list deployments: %w", err)
+	}
+	return deployments, nil
+}
+
+func (g *PostgresGetter) GetSystemsByDeploymentIDs(
+	ctx context.Context,
+	deploymentIDs []uuid.UUID,
+) (map[uuid.UUID][]db.System, error) {
+	if len(deploymentIDs) == 0 {
+		return make(map[uuid.UUID][]db.System), nil
+	}
+
+	queries := db.GetQueries(ctx)
+	result := make(map[uuid.UUID][]db.System, len(deploymentIDs))
+
+	for _, depID := range deploymentIDs {
+		systemIDs, err := queries.GetSystemIDsForDeployment(ctx, depID)
+		if err != nil {
+			return nil, fmt.Errorf("get system ids for deployment %s: %w", depID, err)
+		}
+
+		systems := make([]db.System, 0, len(systemIDs))
+		for _, sysID := range systemIDs {
+			sys, err := queries.GetSystemByID(ctx, sysID)
+			if err != nil {
+				return nil, fmt.Errorf("get system %s: %w", sysID, err)
+			}
+			systems = append(systems, sys)
+		}
+		result[depID] = systems
+	}
+
+	return result, nil
+}

--- a/apps/workspace-engine/svc/http/server/openapi/deployments/server.go
+++ b/apps/workspace-engine/svc/http/server/openapi/deployments/server.go
@@ -42,14 +42,23 @@ func (d *Deployments) ListDeployments(
 	filtered := allDeployments
 	if params.Cel != nil && *params.Cel != "" {
 		cel := *params.Cel
+		matchable, err := selector.Matchable(ctx, cel)
+		if err != nil {
+			c.JSON(
+				http.StatusBadRequest,
+				gin.H{"error": "Invalid CEL expression: " + err.Error()},
+			)
+			return
+		}
+
 		filtered = make([]db.Deployment, 0, len(allDeployments))
 		for _, dep := range allDeployments {
 			oapiDep := db.ToOapiDeployment(dep)
-			matched, err := selector.Match(ctx, cel, oapiDep)
+			matched, err := matchable.Matches(oapiDep)
 			if err != nil {
 				c.JSON(
 					http.StatusBadRequest,
-					gin.H{"error": "Invalid CEL expression: " + err.Error()},
+					gin.H{"error": "CEL evaluation error: " + err.Error()},
 				)
 				return
 			}

--- a/apps/workspace-engine/svc/http/server/openapi/deployments/server.go
+++ b/apps/workspace-engine/svc/http/server/openapi/deployments/server.go
@@ -70,13 +70,18 @@ func (d *Deployments) ListDeployments(
 		offset = *params.Offset
 	}
 
+	if limit < 1 || limit > 1000 || offset < 0 {
+		c.JSON(
+			http.StatusBadRequest,
+			gin.H{"error": "limit must be between 1 and 1000, offset must be >= 0"},
+		)
+		return
+	}
+
 	if offset > len(filtered) {
 		offset = len(filtered)
 	}
-	end := offset + limit
-	if end > len(filtered) {
-		end = len(filtered)
-	}
+	end := min(offset+limit, len(filtered))
 	page := filtered[offset:end]
 
 	deploymentIDs := make([]uuid.UUID, len(page))

--- a/apps/workspace-engine/svc/http/server/openapi/deployments/server.go
+++ b/apps/workspace-engine/svc/http/server/openapi/deployments/server.go
@@ -12,7 +12,107 @@ import (
 	"workspace-engine/pkg/selector"
 )
 
-type Deployments struct{}
+type Deployments struct {
+	getter Getter
+}
+
+func New() Deployments {
+	return Deployments{getter: &PostgresGetter{}}
+}
+
+func (d *Deployments) ListDeployments(
+	c *gin.Context,
+	workspaceId string,
+	params oapi.ListDeploymentsParams,
+) {
+	ctx := c.Request.Context()
+
+	workspaceUUID, err := uuid.Parse(workspaceId)
+	if err != nil {
+		c.JSON(http.StatusBadRequest, gin.H{"error": "Invalid workspace ID"})
+		return
+	}
+
+	allDeployments, err := d.getter.GetAllDeploymentsByWorkspaceID(ctx, workspaceUUID)
+	if err != nil {
+		c.JSON(http.StatusInternalServerError, gin.H{"error": "Failed to list deployments"})
+		return
+	}
+
+	filtered := allDeployments
+	if params.Cel != nil && *params.Cel != "" {
+		cel := *params.Cel
+		filtered = make([]db.Deployment, 0, len(allDeployments))
+		for _, dep := range allDeployments {
+			oapiDep := db.ToOapiDeployment(dep)
+			matched, err := selector.Match(ctx, cel, oapiDep)
+			if err != nil {
+				c.JSON(
+					http.StatusBadRequest,
+					gin.H{"error": "Invalid CEL expression: " + err.Error()},
+				)
+				return
+			}
+			if matched {
+				filtered = append(filtered, dep)
+			}
+		}
+	}
+
+	total := len(filtered)
+
+	limit := 50
+	if params.Limit != nil {
+		limit = *params.Limit
+	}
+	offset := 0
+	if params.Offset != nil {
+		offset = *params.Offset
+	}
+
+	if offset > len(filtered) {
+		offset = len(filtered)
+	}
+	end := offset + limit
+	if end > len(filtered) {
+		end = len(filtered)
+	}
+	page := filtered[offset:end]
+
+	deploymentIDs := make([]uuid.UUID, len(page))
+	for i, dep := range page {
+		deploymentIDs[i] = dep.ID
+	}
+
+	systemsByDepID, err := d.getter.GetSystemsByDeploymentIDs(ctx, deploymentIDs)
+	if err != nil {
+		c.JSON(http.StatusInternalServerError, gin.H{"error": "Failed to get systems"})
+		return
+	}
+
+	items := make([]gin.H, len(page))
+	for i, dep := range page {
+		oapiDep := db.ToOapiDeployment(dep)
+
+		systems := systemsByDepID[dep.ID]
+		oapiSystems := make([]oapi.System, len(systems))
+		for j, sys := range systems {
+			oapiSystems[j] = *db.ToOapiSystem(sys)
+		}
+
+		items[i] = gin.H{
+			"deployment": oapiDep,
+			"systems":    oapiSystems,
+		}
+	}
+
+	c.JSON(http.StatusOK, gin.H{
+		"items":  items,
+		"total":  total,
+		"limit":  limit,
+		"offset": offset,
+	})
+}
 
 func (d *Deployments) GetJobAgentsForDeployment(c *gin.Context, deploymentId string) {
 	ctx := c.Request.Context()

--- a/apps/workspace-engine/svc/http/server/openapi/deployments/server_test.go
+++ b/apps/workspace-engine/svc/http/server/openapi/deployments/server_test.go
@@ -3,9 +3,9 @@ package deployments
 import (
 	"context"
 	"encoding/json"
-	"fmt"
 	"net/http"
 	"net/http/httptest"
+	"strconv"
 	"testing"
 
 	"github.com/gin-gonic/gin"
@@ -45,16 +45,17 @@ func setupRouter(d *Deployments) *gin.Engine {
 		workspaceId := c.Param("workspaceId")
 		var params oapi.ListDeploymentsParams
 		if v := c.Query("limit"); v != "" {
-			var i int
-			if _, err := fmt.Sscanf(v, "%d", &i); err == nil {
+			if i, err := strconv.Atoi(v); err == nil {
 				params.Limit = &i
 			}
 		}
 		if v := c.Query("offset"); v != "" {
-			var i int
-			if _, err := fmt.Sscanf(v, "%d", &i); err == nil {
+			if i, err := strconv.Atoi(v); err == nil {
 				params.Offset = &i
 			}
+		}
+		if v := c.Query("cel"); v != "" {
+			params.Cel = &v
 		}
 		d.ListDeployments(c, workspaceId, params)
 	})

--- a/apps/workspace-engine/svc/http/server/openapi/deployments/server_test.go
+++ b/apps/workspace-engine/svc/http/server/openapi/deployments/server_test.go
@@ -1,0 +1,148 @@
+package deployments
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/gin-gonic/gin"
+	"github.com/google/uuid"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"workspace-engine/pkg/db"
+	"workspace-engine/pkg/oapi"
+)
+
+type mockGetter struct {
+	deployments []db.Deployment
+	systems     map[uuid.UUID][]db.System
+}
+
+func (m *mockGetter) GetAllDeploymentsByWorkspaceID(
+	_ context.Context,
+	_ uuid.UUID,
+) ([]db.Deployment, error) {
+	return m.deployments, nil
+}
+
+func (m *mockGetter) GetSystemsByDeploymentIDs(
+	_ context.Context,
+	_ []uuid.UUID,
+) (map[uuid.UUID][]db.System, error) {
+	if m.systems == nil {
+		return make(map[uuid.UUID][]db.System), nil
+	}
+	return m.systems, nil
+}
+
+func setupRouter(d *Deployments) *gin.Engine {
+	gin.SetMode(gin.TestMode)
+	r := gin.New()
+	r.GET("/v1/workspaces/:workspaceId/deployments", func(c *gin.Context) {
+		workspaceId := c.Param("workspaceId")
+		var params oapi.ListDeploymentsParams
+		if v := c.Query("limit"); v != "" {
+			var i int
+			if _, err := fmt.Sscanf(v, "%d", &i); err == nil {
+				params.Limit = &i
+			}
+		}
+		if v := c.Query("offset"); v != "" {
+			var i int
+			if _, err := fmt.Sscanf(v, "%d", &i); err == nil {
+				params.Offset = &i
+			}
+		}
+		d.ListDeployments(c, workspaceId, params)
+	})
+	return r
+}
+
+func TestListDeployments_NegativeOffset(t *testing.T) {
+	d := &Deployments{getter: &mockGetter{}}
+	r := setupRouter(d)
+
+	wsID := uuid.New().String()
+	w := httptest.NewRecorder()
+	req, _ := http.NewRequest(http.MethodGet, "/v1/workspaces/"+wsID+"/deployments?offset=-1", nil)
+	r.ServeHTTP(w, req)
+
+	assert.Equal(t, http.StatusBadRequest, w.Code)
+}
+
+func TestListDeployments_ZeroLimit(t *testing.T) {
+	d := &Deployments{getter: &mockGetter{}}
+	r := setupRouter(d)
+
+	wsID := uuid.New().String()
+	w := httptest.NewRecorder()
+	req, _ := http.NewRequest(http.MethodGet, "/v1/workspaces/"+wsID+"/deployments?limit=0", nil)
+	r.ServeHTTP(w, req)
+
+	assert.Equal(t, http.StatusBadRequest, w.Code)
+}
+
+func TestListDeployments_LimitTooLarge(t *testing.T) {
+	d := &Deployments{getter: &mockGetter{}}
+	r := setupRouter(d)
+
+	wsID := uuid.New().String()
+	w := httptest.NewRecorder()
+	req, _ := http.NewRequest(http.MethodGet, "/v1/workspaces/"+wsID+"/deployments?limit=1001", nil)
+	r.ServeHTTP(w, req)
+
+	assert.Equal(t, http.StatusBadRequest, w.Code)
+}
+
+func TestListDeployments_ValidPagination(t *testing.T) {
+	depID := uuid.New()
+	d := &Deployments{getter: &mockGetter{
+		deployments: []db.Deployment{
+			{ID: depID, WorkspaceID: uuid.New(), Name: "test-dep", Metadata: map[string]string{}},
+		},
+	}}
+	r := setupRouter(d)
+
+	wsID := uuid.New().String()
+	w := httptest.NewRecorder()
+	req, _ := http.NewRequest(
+		http.MethodGet, "/v1/workspaces/"+wsID+"/deployments?limit=10&offset=0", nil,
+	)
+	r.ServeHTTP(w, req)
+
+	assert.Equal(t, http.StatusOK, w.Code)
+
+	var body map[string]any
+	require.NoError(t, json.Unmarshal(w.Body.Bytes(), &body))
+	assert.InDelta(t, 1, body["total"], 0)
+	items := body["items"].([]any)
+	assert.Len(t, items, 1)
+}
+
+func TestListDeployments_OffsetBeyondTotal(t *testing.T) {
+	depID := uuid.New()
+	d := &Deployments{getter: &mockGetter{
+		deployments: []db.Deployment{
+			{ID: depID, WorkspaceID: uuid.New(), Name: "test-dep", Metadata: map[string]string{}},
+		},
+	}}
+	r := setupRouter(d)
+
+	wsID := uuid.New().String()
+	w := httptest.NewRecorder()
+	req, _ := http.NewRequest(
+		http.MethodGet, "/v1/workspaces/"+wsID+"/deployments?limit=10&offset=100", nil,
+	)
+	r.ServeHTTP(w, req)
+
+	assert.Equal(t, http.StatusOK, w.Code)
+
+	var body map[string]any
+	require.NoError(t, json.Unmarshal(w.Body.Bytes(), &body))
+	assert.InDelta(t, 1, body["total"], 0)
+	items := body["items"].([]any)
+	assert.Empty(t, items)
+}

--- a/apps/workspace-engine/svc/http/server/openapi/server.go
+++ b/apps/workspace-engine/svc/http/server/openapi/server.go
@@ -13,6 +13,7 @@ import (
 
 func New(pool *pgxpool.Pool) *Server {
 	return &Server{
+		Deployments:    deployments.New(),
 		Workflows:      workflows.NewWorkflows(pool),
 		ReleaseTargets: release_targets.New(),
 		Verifications:  verifications.New(),

--- a/e2e/api/schema.ts
+++ b/e2e/api/schema.ts
@@ -1402,7 +1402,6 @@ export interface components {
             maximumAgeHours?: number;
             /**
              * Format: int32
-             * @deprecated
              * @description Minimum time to wait after the depends on environment is in a success state before the current environment can be deployed. Defaults to 0 if not provided.
              */
             minimumSoakTimeMinutes?: number;
@@ -2960,6 +2959,8 @@ export interface operations {
                 limit?: number;
                 /** @description Number of items to skip */
                 offset?: number;
+                /** @description CEL expression to filter the results */
+                cel?: string;
             };
             header?: never;
             path: {

--- a/e2e/tests/api/deployments.spec.ts
+++ b/e2e/tests/api/deployments.spec.ts
@@ -591,6 +591,54 @@ test.describe("Deployment API", () => {
     expect(listRes.data!.total).toBe(0);
   });
 
+  test("should return 400 for negative offset", async ({
+    api,
+    workspace,
+  }) => {
+    const listRes = await api.GET(
+      "/v1/workspaces/{workspaceId}/deployments",
+      {
+        params: {
+          path: { workspaceId: workspace.id },
+          query: { offset: -1 },
+        },
+      },
+    );
+
+    expect(listRes.response.status).toBe(400);
+  });
+
+  test("should return 400 for zero limit", async ({ api, workspace }) => {
+    const listRes = await api.GET(
+      "/v1/workspaces/{workspaceId}/deployments",
+      {
+        params: {
+          path: { workspaceId: workspace.id },
+          query: { limit: 0 },
+        },
+      },
+    );
+
+    expect(listRes.response.status).toBe(400);
+  });
+
+  test("should return 400 for limit exceeding 1000", async ({
+    api,
+    workspace,
+  }) => {
+    const listRes = await api.GET(
+      "/v1/workspaces/{workspaceId}/deployments",
+      {
+        params: {
+          path: { workspaceId: workspace.id },
+          query: { limit: 1001 },
+        },
+      },
+    );
+
+    expect(listRes.response.status).toBe(400);
+  });
+
   test("should return all deployments when no CEL filter is provided", async ({
     api,
     workspace,

--- a/e2e/tests/api/deployments.spec.ts
+++ b/e2e/tests/api/deployments.spec.ts
@@ -404,4 +404,224 @@ test.describe("Deployment API", () => {
       { params: { path: { workspaceId: workspace.id, deploymentId } } },
     );
   });
+
+  test("should filter deployments by name using CEL", async ({
+    api,
+    workspace,
+  }) => {
+    const uniqueTag = faker.string.alphanumeric(12);
+    const matchName = `cel-match-${uniqueTag}`;
+    const noMatchName = `cel-other-${faker.string.alphanumeric(12)}`;
+
+    const [matchRes, noMatchRes] = await Promise.all([
+      api.POST("/v1/workspaces/{workspaceId}/deployments", {
+        params: { path: { workspaceId: workspace.id } },
+        body: { name: matchName, slug: matchName },
+      }),
+      api.POST("/v1/workspaces/{workspaceId}/deployments", {
+        params: { path: { workspaceId: workspace.id } },
+        body: { name: noMatchName, slug: noMatchName },
+      }),
+    ]);
+
+    expect(matchRes.response.status).toBe(202);
+    expect(noMatchRes.response.status).toBe(202);
+    const matchId = matchRes.data!.id;
+    const noMatchId = noMatchRes.data!.id;
+
+    const listRes = await api.GET(
+      "/v1/workspaces/{workspaceId}/deployments",
+      {
+        params: {
+          path: { workspaceId: workspace.id },
+          query: { cel: `deployment.name.contains('${uniqueTag}')` },
+        },
+      },
+    );
+
+    expect(listRes.response.status).toBe(200);
+    const items = listRes.data!.items;
+    expect(items.some((d) => d.deployment.id === matchId)).toBe(true);
+    expect(items.some((d) => d.deployment.id === noMatchId)).toBe(false);
+
+    await Promise.all([
+      api.DELETE(
+        "/v1/workspaces/{workspaceId}/deployments/{deploymentId}",
+        { params: { path: { workspaceId: workspace.id, deploymentId: matchId } } },
+      ),
+      api.DELETE(
+        "/v1/workspaces/{workspaceId}/deployments/{deploymentId}",
+        { params: { path: { workspaceId: workspace.id, deploymentId: noMatchId } } },
+      ),
+    ]);
+  });
+
+  test("should filter deployments by metadata using CEL", async ({
+    api,
+    workspace,
+  }) => {
+    const uniqueVal = faker.string.alphanumeric(12);
+    const withMeta = `cel-meta-${faker.string.alphanumeric(8)}`;
+    const withoutMeta = `cel-nometa-${faker.string.alphanumeric(8)}`;
+
+    const [metaRes, noMetaRes] = await Promise.all([
+      api.POST("/v1/workspaces/{workspaceId}/deployments", {
+        params: { path: { workspaceId: workspace.id } },
+        body: {
+          name: withMeta,
+          slug: withMeta,
+          metadata: { team: uniqueVal },
+        },
+      }),
+      api.POST("/v1/workspaces/{workspaceId}/deployments", {
+        params: { path: { workspaceId: workspace.id } },
+        body: {
+          name: withoutMeta,
+          slug: withoutMeta,
+          metadata: { team: "other" },
+        },
+      }),
+    ]);
+
+    expect(metaRes.response.status).toBe(202);
+    expect(noMetaRes.response.status).toBe(202);
+    const metaId = metaRes.data!.id;
+    const noMetaId = noMetaRes.data!.id;
+
+    const listRes = await api.GET(
+      "/v1/workspaces/{workspaceId}/deployments",
+      {
+        params: {
+          path: { workspaceId: workspace.id },
+          query: { cel: `deployment.metadata.team == '${uniqueVal}'` },
+        },
+      },
+    );
+
+    expect(listRes.response.status).toBe(200);
+    const items = listRes.data!.items;
+    expect(items.some((d) => d.deployment.id === metaId)).toBe(true);
+    expect(items.some((d) => d.deployment.id === noMetaId)).toBe(false);
+
+    await Promise.all([
+      api.DELETE(
+        "/v1/workspaces/{workspaceId}/deployments/{deploymentId}",
+        { params: { path: { workspaceId: workspace.id, deploymentId: metaId } } },
+      ),
+      api.DELETE(
+        "/v1/workspaces/{workspaceId}/deployments/{deploymentId}",
+        { params: { path: { workspaceId: workspace.id, deploymentId: noMetaId } } },
+      ),
+    ]);
+  });
+
+  test("should return correct total when filtering with CEL", async ({
+    api,
+    workspace,
+  }) => {
+    const tag = faker.string.alphanumeric(12);
+    const names = [
+      `cel-total-${tag}-a`,
+      `cel-total-${tag}-b`,
+      `cel-total-${tag}-c`,
+    ];
+
+    const createResults = await Promise.all(
+      names.map((name) =>
+        api.POST("/v1/workspaces/{workspaceId}/deployments", {
+          params: { path: { workspaceId: workspace.id } },
+          body: { name, slug: name },
+        }),
+      ),
+    );
+
+    const ids = createResults.map((r) => {
+      expect(r.response.status).toBe(202);
+      return r.data!.id;
+    });
+
+    const listRes = await api.GET(
+      "/v1/workspaces/{workspaceId}/deployments",
+      {
+        params: {
+          path: { workspaceId: workspace.id },
+          query: {
+            cel: `deployment.name.contains('${tag}')`,
+            limit: 2,
+            offset: 0,
+          },
+        },
+      },
+    );
+
+    expect(listRes.response.status).toBe(200);
+    expect(listRes.data!.total).toBe(3);
+    expect(listRes.data!.items).toHaveLength(2);
+    expect(listRes.data!.limit).toBe(2);
+    expect(listRes.data!.offset).toBe(0);
+
+    await Promise.all(
+      ids.map((deploymentId) =>
+        api.DELETE(
+          "/v1/workspaces/{workspaceId}/deployments/{deploymentId}",
+          { params: { path: { workspaceId: workspace.id, deploymentId } } },
+        ),
+      ),
+    );
+  });
+
+  test("should return empty list for non-matching CEL filter", async ({
+    api,
+    workspace,
+  }) => {
+    const listRes = await api.GET(
+      "/v1/workspaces/{workspaceId}/deployments",
+      {
+        params: {
+          path: { workspaceId: workspace.id },
+          query: {
+            cel: `deployment.name == 'nonexistent-${faker.string.alphanumeric(20)}'`,
+          },
+        },
+      },
+    );
+
+    expect(listRes.response.status).toBe(200);
+    expect(listRes.data!.items).toHaveLength(0);
+    expect(listRes.data!.total).toBe(0);
+  });
+
+  test("should return all deployments when no CEL filter is provided", async ({
+    api,
+    workspace,
+  }) => {
+    const name = `cel-nofilter-${faker.string.alphanumeric(8)}`;
+    const createRes = await api.POST(
+      "/v1/workspaces/{workspaceId}/deployments",
+      {
+        params: { path: { workspaceId: workspace.id } },
+        body: { name, slug: name },
+      },
+    );
+
+    expect(createRes.response.status).toBe(202);
+    const deploymentId = createRes.data!.id;
+
+    const listRes = await api.GET(
+      "/v1/workspaces/{workspaceId}/deployments",
+      {
+        params: { path: { workspaceId: workspace.id } },
+      },
+    );
+
+    expect(listRes.response.status).toBe(200);
+    expect(listRes.data!.items.some((d) => d.deployment.id === deploymentId)).toBe(
+      true,
+    );
+
+    await api.DELETE(
+      "/v1/workspaces/{workspaceId}/deployments/{deploymentId}",
+      { params: { path: { workspaceId: workspace.id, deploymentId } } },
+    );
+  });
 });

--- a/e2e/tests/api/deployments.spec.ts
+++ b/e2e/tests/api/deployments.spec.ts
@@ -397,7 +397,11 @@ test.describe("Deployment API", () => {
 
     expect(listRes.response.status).toBe(200);
     const items = listRes.data!.items;
-    expect(items.some((d) => d.deployment.id === deploymentId)).toBe(true);
+    const found = items.find((d) => d.deployment.id === deploymentId);
+    expect(found).toBeDefined();
+    expect(found!.deployment.name).toBe(name);
+    expect(found!.deployment.slug).toBe(name);
+    expect(found!.deployment.metadata).toEqual({});
 
     await api.DELETE(
       "/v1/workspaces/{workspaceId}/deployments/{deploymentId}",
@@ -500,7 +504,10 @@ test.describe("Deployment API", () => {
 
     expect(listRes.response.status).toBe(200);
     const items = listRes.data!.items;
-    expect(items.some((d) => d.deployment.id === metaId)).toBe(true);
+    const matched = items.find((d) => d.deployment.id === metaId);
+    expect(matched).toBeDefined();
+    expect(matched!.deployment.slug).toBe(withMeta);
+    expect(matched!.deployment.metadata).toEqual({ team: uniqueVal });
     expect(items.some((d) => d.deployment.id === noMetaId)).toBe(false);
 
     await Promise.all([

--- a/packages/workspace-engine-sdk/src/schema.ts
+++ b/packages/workspace-engine-sdk/src/schema.ts
@@ -72,6 +72,26 @@ export interface paths {
     patch?: never;
     trace?: never;
   };
+  "/v1/workspaces/{workspaceId}/deployments": {
+    parameters: {
+      query?: never;
+      header?: never;
+      path?: never;
+      cookie?: never;
+    };
+    /**
+     * List deployments
+     * @description Returns a paginated list of deployments for a workspace. Optionally filter with a CEL expression using the "deployment" variable.
+     */
+    get: operations["listDeployments"];
+    put?: never;
+    post?: never;
+    delete?: never;
+    options?: never;
+    head?: never;
+    patch?: never;
+    trace?: never;
+  };
   "/v1/workspaces/{workspaceId}/release-targets/{releaseTargetKey}/state": {
     parameters: {
       query?: never;
@@ -1500,6 +1520,53 @@ export interface operations {
             errors: string[];
             valid: boolean;
           };
+        };
+      };
+    };
+  };
+  listDeployments: {
+    parameters: {
+      query?: {
+        /** @description Maximum number of items to return */
+        limit?: number;
+        /** @description Number of items to skip */
+        offset?: number;
+        /** @description CEL expression to filter the results */
+        cel?: string;
+      };
+      header?: never;
+      path: {
+        /** @description ID of the workspace */
+        workspaceId: string;
+      };
+      cookie?: never;
+    };
+    requestBody?: never;
+    responses: {
+      /** @description Paginated list of items */
+      200: {
+        headers: {
+          [name: string]: unknown;
+        };
+        content: {
+          "application/json": {
+            items: components["schemas"]["DeploymentAndSystems"][];
+            /** @description Maximum number of items returned */
+            limit: number;
+            /** @description Number of items skipped */
+            offset: number;
+            /** @description Total number of items available */
+            total: number;
+          };
+        };
+      };
+      /** @description Invalid request */
+      400: {
+        headers: {
+          [name: string]: unknown;
+        };
+        content: {
+          "application/json": components["schemas"]["ErrorResponse"];
         };
       };
     };


### PR DESCRIPTION
fixes #977 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Deployments listing now supports CEL expression filtering (query param `cel`) and returns paginated results (`items`, `total`, `limit`, `offset`).
  * Pagination parameters `limit` and `offset` added with sensible defaults and bounds.

* **Bug Fixes / Validation**
  * Invalid pagination values now return HTTP 400.

* **Tests**
  * Added E2E and handler tests covering CEL filtering, pagination, and validation.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->