### PR TITLE
fix: allow updating status of deployment versions with no jobs

### DIFF
--- a/apps/web/app/routes/ws/deployments/_components/versioncard/VersionCard.tsx
+++ b/apps/web/app/routes/ws/deployments/_components/versioncard/VersionCard.tsx
@@ -132,6 +132,7 @@ const NoActiveDeployments: React.FC<NoActiveDeploymentsProps> = ({
           <span className="grow truncate overflow-ellipsis text-left">
             {displayName}
           </span>
+          <VersionDropdown version={version} />
         </div>
       </div>
     </div>

--- a/apps/web/app/routes/ws/deployments/_components/versioncard/VersionDropdown.tsx
+++ b/apps/web/app/routes/ws/deployments/_components/versioncard/VersionDropdown.tsx
@@ -13,7 +13,6 @@ import {
   DialogFooter,
   DialogHeader,
   DialogTitle,
-  DialogTrigger,
 } from "~/components/ui/dialog";
 import {
   DropdownMenu,
@@ -57,20 +56,19 @@ const useUpdateVersionStatus = (versionId: string) => {
 
 function VersionStatusDialog({
   version,
-  children,
-  onClose,
+  open,
+  onOpenChange,
 }: {
   version: Version;
-  children: React.ReactNode;
-  onClose: () => void;
+  open: boolean;
+  onOpenChange: (open: boolean) => void;
 }) {
   const { updateStatus, isPending } = useUpdateVersionStatus(version.id);
   const [status, setStatus] = useState<VersionStatus>(version.status);
-  const onClick = () => updateStatus(status).then(onClose);
+  const onClick = () => updateStatus(status).then(() => onOpenChange(false));
 
   return (
-    <Dialog>
-      <DialogTrigger asChild>{children}</DialogTrigger>
+    <Dialog open={open} onOpenChange={onOpenChange}>
       <DialogContent>
         <DialogHeader>
           <DialogTitle>Update Version Status</DialogTitle>
@@ -108,30 +106,42 @@ function VersionStatusDialog({
 }
 
 export function VersionDropdown({ version }: { version: Version }) {
-  const [open, setOpen] = useState(false);
+  const [dropdownOpen, setDropdownOpen] = useState(false);
+  const [statusDialogOpen, setStatusDialogOpen] = useState(false);
+
   return (
-    <DropdownMenu open={open} onOpenChange={setOpen}>
-      <DropdownMenuTrigger asChild>
-        <Button
-          variant="ghost"
-          size="icon"
-          className="h-7 w-7 shrink-0 text-muted-foreground"
-          onClick={(e) => e.stopPropagation()}
-        >
-          <EllipsisIcon className="size-3" />
-        </Button>
-      </DropdownMenuTrigger>
-      <DropdownMenuContent align="end" onClick={(e) => e.stopPropagation()}>
-        <VersionStatusDialog version={version} onClose={() => setOpen(false)}>
+    <>
+      <DropdownMenu open={dropdownOpen} onOpenChange={setDropdownOpen}>
+        <DropdownMenuTrigger asChild>
+          <Button
+            variant="ghost"
+            size="icon"
+            className="h-7 w-7 shrink-0 text-muted-foreground"
+            onClick={(e) => e.stopPropagation()}
+          >
+            <EllipsisIcon className="size-3" />
+          </Button>
+        </DropdownMenuTrigger>
+        <DropdownMenuContent align="end" onClick={(e) => e.stopPropagation()}>
           <DropdownMenuItem
-            onSelect={(e) => e.preventDefault()}
+            onSelect={(e) => {
+              e.preventDefault();
+              setDropdownOpen(false);
+              setStatusDialogOpen(true);
+            }}
             className="flex items-center gap-2"
           >
             <Flag className="h-4 w-4" />
             Update Status
           </DropdownMenuItem>
-        </VersionStatusDialog>
-      </DropdownMenuContent>
-    </DropdownMenu>
+        </DropdownMenuContent>
+      </DropdownMenu>
+
+      <VersionStatusDialog
+        version={version}
+        open={statusDialogOpen}
+        onOpenChange={setStatusDialogOpen}
+      />
+    </>
   );
 }


### PR DESCRIPTION
Fixes two related bugs where users could not update the status of a deployment version that has no jobs:

1. **Dialog closes immediately**: `VersionStatusDialog` was nested inside `DropdownMenuContent` as an uncontrolled Radix `Dialog`. When the Dialog overlay appeared, Radix's `DismissableLayer` fired `onOpenChange(false)` on the parent `DropdownMenu`, unmounting `DropdownMenuContent` and the Dialog with it. Fixed by converting to a controlled Dialog with state lifted outside the dropdown.

2. **No Update Status option for zero-job versions**: `NoActiveDeployments` didn't render `VersionDropdown`, so there was no way to trigger "Update Status" for versions with no active deployments. Fixed by adding `VersionDropdown` to the component.

Closes #988

Generated with [Claude Code](https://claude.ai/code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Version dropdown menu now available in the no active deployments state.

* **Refactor**
  * Improved dialog state management for smoother version status update interactions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->