### PR TITLE
feat: version list endpoint can filter with CEL expression

### DIFF
--- a/apps/api/openapi/openapi.json
+++ b/apps/api/openapi/openapi.json
@@ -5006,6 +5006,16 @@
                      ],
                      "type": "string"
                   }
+               },
+               {
+                  "allowReserved": true,
+                  "description": "CEL expression to filter the results",
+                  "in": "query",
+                  "name": "cel",
+                  "required": false,
+                  "schema": {
+                     "type": "string"
+                  }
                }
             ],
             "responses": {

--- a/apps/api/openapi/paths/deploymentversions.jsonnet
+++ b/apps/api/openapi/paths/deploymentversions.jsonnet
@@ -11,6 +11,7 @@ local openapi = import '../lib/openapi.libsonnet';
         openapi.limitParam(),
         openapi.offsetParam(),
         openapi.orderParam(),
+        openapi.celParam(),
       ],
       responses: openapi.paginatedResponse(openapi.schemaRef('DeploymentVersion'))
                  + openapi.notFoundResponse()

--- a/apps/api/src/routes/v1/workspaces/deployments.ts
+++ b/apps/api/src/routes/v1/workspaces/deployments.ts
@@ -4,7 +4,7 @@ import { evaluate } from "cel-js";
 import { Router } from "express";
 import { v4 as uuidv4 } from "uuid";
 
-import { and, asc, desc, eq, inArray, takeFirst } from "@ctrlplane/db";
+import { and, asc, count, desc, eq, inArray, takeFirst } from "@ctrlplane/db";
 import { db } from "@ctrlplane/db/client";
 import {
   enqueueDeploymentPlan,
@@ -282,29 +282,52 @@ const listDeploymentVersions: AsyncTypedHandler<
   const order = req.query.order ?? "desc";
   const { cel } = req.query;
 
-  if (cel != null && !validResourceSelector(cel))
+  const orderBy =
+    order === "asc"
+      ? asc(schema.deploymentVersion.createdAt)
+      : desc(schema.deploymentVersion.createdAt);
+
+  if (cel == null) {
+    const { total } = await db
+      .select({ total: count() })
+      .from(schema.deploymentVersion)
+      .where(eq(schema.deploymentVersion.deploymentId, deploymentId))
+      .then(takeFirst);
+
+    const versions = await db
+      .select()
+      .from(schema.deploymentVersion)
+      .where(eq(schema.deploymentVersion.deploymentId, deploymentId))
+      .orderBy(orderBy)
+      .limit(limit)
+      .offset(offset);
+
+    res.status(200).json({
+      items: versions.map(formatDeploymentVersion),
+      total,
+      limit,
+      offset,
+    });
+    return;
+  }
+
+  if (!validResourceSelector(cel))
     throw new ApiError("Invalid CEL expression", 400);
 
-  const allVersions = await db
+  // CEL is evaluated in-memory, so cap the candidate set to bound cost.
+  // Filtering applies to the 1000 most-recent (or oldest, for asc) versions.
+  const candidates = await db
     .select()
     .from(schema.deploymentVersion)
     .where(eq(schema.deploymentVersion.deploymentId, deploymentId))
-    .orderBy(
-      order === "asc"
-        ? asc(schema.deploymentVersion.createdAt)
-        : desc(schema.deploymentVersion.createdAt),
-    )
+    .orderBy(orderBy)
     .limit(1000);
 
-  const filtered =
-    cel != null ? filterDeploymentVersions(allVersions, cel) : allVersions;
-
-  const total = filtered.length;
-  const items = filtered.slice(offset, offset + limit);
+  const filtered = filterDeploymentVersions(candidates, cel);
 
   res.status(200).json({
-    items: items.map(formatDeploymentVersion),
-    total,
+    items: filtered.slice(offset, offset + limit).map(formatDeploymentVersion),
+    total: filtered.length,
     limit,
     offset,
   });

--- a/apps/api/src/routes/v1/workspaces/deployments.ts
+++ b/apps/api/src/routes/v1/workspaces/deployments.ts
@@ -1,9 +1,10 @@
 import type { AsyncTypedHandler } from "@/types/api.js";
 import { ApiError, asyncHandler } from "@/types/api.js";
+import { evaluate } from "cel-js";
 import { Router } from "express";
 import { v4 as uuidv4 } from "uuid";
 
-import { and, asc, count, desc, eq, inArray, takeFirst } from "@ctrlplane/db";
+import { and, asc, desc, eq, inArray, takeFirst } from "@ctrlplane/db";
 import { db } from "@ctrlplane/db/client";
 import {
   enqueueDeploymentPlan,
@@ -258,6 +259,19 @@ const deleteDeployment: AsyncTypedHandler<
     .json({ id: deploymentId, message: "Deployment delete requested" });
 };
 
+function filterDeploymentVersions(
+  versions: (typeof schema.deploymentVersion.$inferSelect)[],
+  cel: string,
+) {
+  return versions.filter((version) => {
+    try {
+      return evaluate(cel, { deploymentVersion: version });
+    } catch {
+      return false;
+    }
+  });
+}
+
 const listDeploymentVersions: AsyncTypedHandler<
   "/v1/workspaces/{workspaceId}/deployments/{deploymentId}/versions",
   "get"
@@ -266,15 +280,12 @@ const listDeploymentVersions: AsyncTypedHandler<
   const limit = req.query.limit ?? 50;
   const offset = req.query.offset ?? 0;
   const order = req.query.order ?? "desc";
+  const { cel } = req.query;
 
-  const [countResult] = await db
-    .select({ total: count() })
-    .from(schema.deploymentVersion)
-    .where(eq(schema.deploymentVersion.deploymentId, deploymentId));
+  if (cel != null && !validResourceSelector(cel))
+    throw new ApiError("Invalid CEL expression", 400);
 
-  const total = countResult?.total ?? 0;
-
-  const versions = await db
+  const allVersions = await db
     .select()
     .from(schema.deploymentVersion)
     .where(eq(schema.deploymentVersion.deploymentId, deploymentId))
@@ -283,11 +294,16 @@ const listDeploymentVersions: AsyncTypedHandler<
         ? asc(schema.deploymentVersion.createdAt)
         : desc(schema.deploymentVersion.createdAt),
     )
-    .limit(limit)
-    .offset(offset);
+    .limit(1000);
+
+  const filtered =
+    cel != null ? filterDeploymentVersions(allVersions, cel) : allVersions;
+
+  const total = filtered.length;
+  const items = filtered.slice(offset, offset + limit);
 
   res.status(200).json({
-    items: versions.map(formatDeploymentVersion),
+    items: items.map(formatDeploymentVersion),
     total,
     limit,
     offset,

--- a/apps/api/src/types/openapi.ts
+++ b/apps/api/src/types/openapi.ts
@@ -3285,6 +3285,8 @@ export interface operations {
                 offset?: number;
                 /** @description Sort order for results */
                 order?: "asc" | "desc";
+                /** @description CEL expression to filter the results */
+                cel?: string;
             };
             header?: never;
             path: {


### PR DESCRIPTION
fixes #1046

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added optional filtering support to the deployment versions endpoint. Clients can now apply custom filter expressions when querying deployment versions from a specific deployment, providing more granular control over returned results and eliminating the need for multiple API requests or additional client-side processing to achieve desired filtering outcomes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->