### PR TITLE
fix: mark password inputs with type="password" and autoComplete attributes

### DIFF
--- a/apps/web/app/routes/auth/login.tsx
+++ b/apps/web/app/routes/auth/login.tsx
@@ -88,7 +88,7 @@ function LoginEmailPassword() {
             <FormItem>
               <FormLabel>Password</FormLabel>
               <FormControl>
-                <Input type="password" {...field} />
+                <Input {...field} type="password" autoComplete="current-password" />
               </FormControl>
               <FormMessage />
             </FormItem>

--- a/apps/web/app/routes/auth/signup.tsx
+++ b/apps/web/app/routes/auth/signup.tsx
@@ -79,7 +79,7 @@ function SignupForm() {
             <FormItem>
               <FormLabel>Password</FormLabel>
               <FormControl>
-                <Input type="password" {...field} />
+                <Input {...field} type="password" autoComplete="new-password" />
               </FormControl>
               <FormMessage />
             </FormItem>


### PR DESCRIPTION
Ensure the password field in login and signup forms is always rendered as an HTML password input (masked), and add appropriate autoComplete hints for browser password managers.

Changes:
- Moved `type="password"` to be placed after `{...field}` spread so it can never be overridden
- Added `autoComplete="current-password"` to login and `autoComplete="new-password"` to signup

Closes #1045

Generated with [Claude Code](https://claude.ai/code)