### PR TITLE
fix: show version tag/name in Plans page breadcrumb instead of UUID

### DIFF
--- a/apps/web/app/routes/ws/deployments/page.$deploymentId.plans.$planId.tsx
+++ b/apps/web/app/routes/ws/deployments/page.$deploymentId.plans.$planId.tsx
@@ -35,7 +35,8 @@ export function meta() {
   ];
 }
 
-type Result = RouterOutputs["deployment"]["plans"]["results"][number];
+type Result =
+  RouterOutputs["deployment"]["plans"]["results"]["results"][number];
 
 function resultTitle(result: Result) {
   return `${result.environment.name} · ${result.resource.name} · ${result.agent.name}`;
@@ -142,7 +143,8 @@ export default function DeploymentPlanDetail() {
     { enabled: !!planId, refetchInterval: 5000 },
   );
 
-  const results = resultsQuery.data ?? [];
+  const version = resultsQuery.data?.version;
+  const results = resultsQuery.data?.results ?? [];
   const activeResult = results.find((r) => r.resultId === resultId);
 
   return (
@@ -174,7 +176,9 @@ export default function DeploymentPlanDetail() {
                 </Link>
               </BreadcrumbItem>
               <BreadcrumbSeparator />
-              <BreadcrumbPage className="font-mono">{planId}</BreadcrumbPage>
+              <BreadcrumbPage className="font-mono">
+                {version?.tag ?? version?.name ?? planId}
+              </BreadcrumbPage>
             </BreadcrumbList>
           </Breadcrumb>
         </div>

--- a/apps/web/app/routes/ws/deployments/page.$deploymentId.plans.$planId.tsx
+++ b/apps/web/app/routes/ws/deployments/page.$deploymentId.plans.$planId.tsx
@@ -36,7 +36,7 @@ export function meta() {
 }
 
 type Result =
-  RouterOutputs["deployment"]["plans"]["results"]["results"][number];
+  RouterOutputs["deployment"]["plans"]["results"]["items"][number];
 
 function resultTitle(result: Result) {
   return `${result.environment.name} · ${result.resource.name} · ${result.agent.name}`;
@@ -144,7 +144,7 @@ export default function DeploymentPlanDetail() {
   );
 
   const version = resultsQuery.data?.version;
-  const results = resultsQuery.data?.results ?? [];
+  const results = resultsQuery.data?.items ?? [];
   const activeResult = results.find((r) => r.resultId === resultId);
 
   return (
@@ -176,8 +176,8 @@ export default function DeploymentPlanDetail() {
                 </Link>
               </BreadcrumbItem>
               <BreadcrumbSeparator />
-              <BreadcrumbPage className="font-mono">
-                {version?.tag ?? version?.name ?? planId}
+              <BreadcrumbPage className="max-w-xs truncate font-mono">
+                {version?.name ?? version?.tag ?? planId}
               </BreadcrumbPage>
             </BreadcrumbList>
           </Breadcrumb>

--- a/packages/trpc/src/routes/deployment-plans.ts
+++ b/packages/trpc/src/routes/deployment-plans.ts
@@ -136,7 +136,11 @@ export const deploymentPlansRouter = router({
     )
     .query(async ({ input, ctx }) => {
       const plan = await ctx.db
-        .select({ id: schema.deploymentPlan.id })
+        .select({
+          id: schema.deploymentPlan.id,
+          versionTag: schema.deploymentPlan.versionTag,
+          versionName: schema.deploymentPlan.versionName,
+        })
         .from(schema.deploymentPlan)
         .where(
           and(
@@ -184,26 +188,29 @@ export const deploymentPlansRouter = router({
         .where(eq(schema.deploymentPlanTarget.planId, input.planId))
         .orderBy(schema.environment.name, schema.resource.name);
 
-      return rows.map((r) => {
-        const agent = r.dispatchContext.jobAgent ?? {};
-        return {
-          resultId: r.resultId,
-          targetId: r.targetId,
-          environment: { id: r.environmentId, name: r.environmentName },
-          resource: { id: r.resourceId, name: r.resourceName },
-          agent: {
-            id: (agent.id as string | undefined) ?? "",
-            name: (agent.name as string | undefined) ?? "",
-            type: (agent.type as string | undefined) ?? "",
-          },
-          status: r.status,
-          hasChanges: r.hasChanges,
-          message: r.message,
-          contentHash: r.contentHash,
-          startedAt: r.startedAt,
-          completedAt: r.completedAt,
-        };
-      });
+      return {
+        version: { tag: plan.versionTag, name: plan.versionName },
+        results: rows.map((r) => {
+          const agent = r.dispatchContext.jobAgent ?? {};
+          return {
+            resultId: r.resultId,
+            targetId: r.targetId,
+            environment: { id: r.environmentId, name: r.environmentName },
+            resource: { id: r.resourceId, name: r.resourceName },
+            agent: {
+              id: (agent.id as string | undefined) ?? "",
+              name: (agent.name as string | undefined) ?? "",
+              type: (agent.type as string | undefined) ?? "",
+            },
+            status: r.status,
+            hasChanges: r.hasChanges,
+            message: r.message,
+            contentHash: r.contentHash,
+            startedAt: r.startedAt,
+            completedAt: r.completedAt,
+          };
+        }),
+      };
     }),
 
   resultDiff: protectedProcedure

--- a/packages/trpc/src/routes/deployment-plans.ts
+++ b/packages/trpc/src/routes/deployment-plans.ts
@@ -190,7 +190,7 @@ export const deploymentPlansRouter = router({
 
       return {
         version: { tag: plan.versionTag, name: plan.versionName },
-        results: rows.map((r) => {
+        items: rows.map((r) => {
           const agent = r.dispatchContext.jobAgent ?? {};
           return {
             resultId: r.resultId,


### PR DESCRIPTION
Fixes #1037

The Plans page breadcrumb was showing the raw plan UUID instead of the version tag or name.

Changes:
- Updated the `results` tRPC procedure to include version info in the response
- Updated the breadcrumb to display `version.tag ?? version.name ?? planId`

Generated with [Claude Code](https://claude.ai/code)