### PR TITLE
fix: align API status codes with OpenAPI specs

### DIFF
--- a/apps/api/src/routes/v1/workspaces/deployment-versions.ts
+++ b/apps/api/src/routes/v1/workspaces/deployment-versions.ts
@@ -106,7 +106,7 @@ const updateDeploymentVersion: AsyncTypedHandler<
     updatedVersion.deploymentId,
   );
 
-  res.status(200).json(updatedVersion);
+  res.status(202).json(updatedVersion);
 };
 
 export const deploymentVersionsRouter = Router({ mergeParams: true })

--- a/apps/api/src/routes/v1/workspaces/deployments.ts
+++ b/apps/api/src/routes/v1/workspaces/deployments.ts
@@ -365,7 +365,7 @@ const createDeploymentVersion: AsyncTypedHandler<
   enqueueReleaseTargetsForDeployment(db, workspaceId, deploymentId);
   enqueuePolicyEval(db, workspaceId, version.id);
 
-  res.status(200).json(formatDeploymentVersion(version));
+  res.status(202).json(formatDeploymentVersion(version));
 };
 
 const createDeploymentPlan: AsyncTypedHandler<

--- a/apps/api/src/routes/v1/workspaces/relationship-rules.ts
+++ b/apps/api/src/routes/v1/workspaces/relationship-rules.ts
@@ -165,7 +165,7 @@ const deleteRelationshipRule: AsyncTypedHandler<
 
   enqueueRelationshipReconciliation(workspaceId);
 
-  res.status(202).json({ id: relationshipRuleId });
+  res.status(202).json(toRuleResponse(rule));
 };
 
 const upsertRelationshipRule: AsyncTypedHandler<

--- a/apps/api/src/routes/v1/workspaces/relationship-rules.ts
+++ b/apps/api/src/routes/v1/workspaces/relationship-rules.ts
@@ -165,7 +165,7 @@ const deleteRelationshipRule: AsyncTypedHandler<
 
   enqueueRelationshipReconciliation(workspaceId);
 
-  res.status(200).json({ id: relationshipRuleId });
+  res.status(202).json({ id: relationshipRuleId });
 };
 
 const upsertRelationshipRule: AsyncTypedHandler<
@@ -202,7 +202,7 @@ const upsertRelationshipRule: AsyncTypedHandler<
 
   enqueueRelationshipReconciliation(workspaceId);
 
-  res.status(200).json(toRuleResponse(upserted));
+  res.status(202).json(toRuleResponse(upserted));
 };
 
 export const relationshipRulesRouter = Router({ mergeParams: true })

--- a/apps/api/src/routes/v1/workspaces/resources.ts
+++ b/apps/api/src/routes/v1/workspaces/resources.ts
@@ -198,7 +198,7 @@ const deleteResourceByIdentifier: AsyncTypedHandler<
     ),
   ]);
 
-  res.status(200).json({
+  res.status(202).json({
     id: resource.id,
     message: "Resource deleted",
   });

--- a/e2e/tests/api/resources.spec.ts
+++ b/e2e/tests/api/resources.spec.ts
@@ -145,7 +145,7 @@ test.describe("Resource API", () => {
       },
     );
 
-    expect(deleteRes.response.status).toBe(200);
+    expect(deleteRes.response.status).toBe(202);
 
     const getRes = await api.GET(
       "/v1/workspaces/{workspaceId}/resources/identifier/{identifier}",


### PR DESCRIPTION
Fix 5 mutation endpoints that were returning HTTP 200 instead of HTTP 202 (Accepted) as declared in the OpenAPI jsonnet specs:

- PATCH `/deploymentversions/{deploymentVersionId}`
- POST `/deployments/{deploymentId}/versions`
- DELETE `/relationship-rules/{relationshipRuleId}`
- PUT `/relationship-rules/{relationshipRuleId}`
- DELETE `/resources/identifier/{identifier}`

Closes #1011

Generated with [Claude Code](https://claude.ai/code)