### PR TITLE
chore: Fix workspace state in UI

### DIFF
--- a/apps/web/app/routes/ws/_components/WorkspaceSelector.tsx
+++ b/apps/web/app/routes/ws/_components/WorkspaceSelector.tsx
@@ -1,6 +1,7 @@
 import { Check, ChevronDown } from "lucide-react";
 import { NavLink } from "react-router";
 
+import { useWorkspace } from "~/components/WorkspaceProvider";
 import { Button } from "~/components/ui/button";
 import {
   DropdownMenu,
@@ -18,12 +19,9 @@ import {
 
 export const WorkspaceSelector: React.FC<{
   viewer: { email: string };
-  activeWorkspaceId?: string | null;
   workspaces: Array<{ id: string; slug: string; name: string }>;
-}> = ({ viewer, activeWorkspaceId, workspaces }) => {
-  const workspace =
-    workspaces.find((w) => w.id === activeWorkspaceId) ?? workspaces.at(0);
-  if (workspace == null) return;
+}> = ({ viewer, workspaces }) => {
+  const { workspace } = useWorkspace();
   return (
     <DropdownMenu>
       <DropdownMenuTrigger asChild>

--- a/apps/web/app/routes/ws/_layout.tsx
+++ b/apps/web/app/routes/ws/_layout.tsx
@@ -196,11 +196,7 @@ export default function WorkspaceLayout() {
           <SidebarMenu>
             <SidebarMenuItem>
               {viewer != null && (
-                <WorkspaceSelector
-                  viewer={viewer}
-                  activeWorkspaceId={viewer.activeWorkspaceId}
-                  workspaces={workspaces}
-                />
+                <WorkspaceSelector viewer={viewer} workspaces={workspaces} />
               )}
             </SidebarMenuItem>
           </SidebarMenu>


### PR DESCRIPTION
The workspace selector in the top left of the UI is now properly switching after changing the workspace. The resources are switching properly but the UI still shows the stale state. Same when you go to edit the workspace. This fix makes the the selector use the same context the rest of the layout does so it's consistent.

## Before
https://github.com/user-attachments/assets/d43d5080-c847-4103-a841-70ee67d6de64

## After

https://github.com/user-attachments/assets/f8d71016-5e38-4530-bdaa-87a9be6e65d6



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Improved internal state management for workspace selection by streamlining component architecture and reducing unnecessary prop passing.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->