### PR TITLE
chore: opa plan validation ui

### DIFF
--- a/apps/web/app/routes/ws/deployments/_components/plans/PlanDiffDialog.tsx
+++ b/apps/web/app/routes/ws/deployments/_components/plans/PlanDiffDialog.tsx
@@ -1,14 +1,18 @@
-import { useState } from "react";
+import type { RouterOutputs } from "@ctrlplane/trpc";
+import { useEffect, useState } from "react";
 import { DiffEditor } from "@monaco-editor/react";
 
 import { trpc } from "~/api/trpc";
 import { useTheme } from "~/components/ThemeProvider";
+import { Badge } from "~/components/ui/badge";
 import {
   Dialog,
   DialogContent,
   DialogHeader,
   DialogTitle,
 } from "~/components/ui/dialog";
+import { Label } from "~/components/ui/label";
+import { Switch } from "~/components/ui/switch";
 import { Tabs, TabsList, TabsTrigger } from "~/components/ui/tabs";
 
 type PlanDiffDialogProps = {
@@ -16,67 +20,198 @@ type PlanDiffDialogProps = {
   resultId: string | undefined;
   title: string;
   open: boolean;
+  initialTab?: TopTab;
   onOpenChange: (open: boolean) => void;
 };
 
+type TopTab = "diff" | "validations";
 type DiffView = "split" | "unified";
+
+type Validation =
+  RouterOutputs["deployment"]["plans"]["resultValidations"][number];
+
+function ValidationsTab({
+  deploymentId,
+  resultId,
+  open,
+}: {
+  deploymentId: string;
+  resultId: string;
+  open: boolean;
+}) {
+  const query = trpc.deployment.plans.resultValidations.useQuery(
+    { deploymentId, resultId },
+    { enabled: open },
+  );
+
+  if (query.isLoading)
+    return (
+      <div className="flex h-full items-center justify-center text-sm text-muted-foreground">
+        Loading validations...
+      </div>
+    );
+
+  const validations = query.data ?? [];
+  if (validations.length === 0)
+    return (
+      <div className="flex h-full items-center justify-center text-sm text-muted-foreground">
+        No validations evaluated for this result
+      </div>
+    );
+
+  return (
+    <div className="h-full overflow-auto p-4">
+      <ul className="space-y-3">
+        {validations.map((v) => (
+          <ValidationItem key={v.id} validation={v} />
+        ))}
+      </ul>
+    </div>
+  );
+}
+
+function ValidationItem({ validation }: { validation: Validation }) {
+  return (
+    <li className="rounded-md border p-3">
+      <div className="flex items-center gap-2">
+        <Badge variant={validation.passed ? "secondary" : "destructive"}>
+          {validation.passed ? "Passed" : "Failed"}
+        </Badge>
+        <span className="font-medium">{validation.ruleName}</span>
+      </div>
+      {validation.ruleDescription && (
+        <p className="mt-1 text-sm text-muted-foreground">
+          {validation.ruleDescription}
+        </p>
+      )}
+      {validation.violations.length > 0 && (
+        <ul className="mt-2 space-y-1 text-sm">
+          {validation.violations.map((violation, i) => (
+            <li key={i} className="font-mono text-red-600 dark:text-red-400">
+              {violation.message}
+            </li>
+          ))}
+        </ul>
+      )}
+    </li>
+  );
+}
+
+function DiffTab({
+  deploymentId,
+  resultId,
+  open,
+  view,
+}: {
+  deploymentId: string;
+  resultId: string;
+  open: boolean;
+  view: DiffView;
+}) {
+  const { theme } = useTheme();
+
+  const diffQuery = trpc.deployment.plans.resultDiff.useQuery(
+    { deploymentId, resultId },
+    { enabled: open },
+  );
+
+  if (diffQuery.isLoading)
+    return (
+      <div className="flex h-full items-center justify-center text-sm text-muted-foreground">
+        Loading diff...
+      </div>
+    );
+
+  if (diffQuery.data == null)
+    return (
+      <div className="flex h-full items-center justify-center text-sm text-muted-foreground">
+        No diff available
+      </div>
+    );
+
+  return (
+    <DiffEditor
+      height="100%"
+      language="yaml"
+      theme={theme === "dark" ? "vs-dark" : "vs"}
+      original={diffQuery.data.current}
+      modified={diffQuery.data.proposed}
+      options={{
+        readOnly: true,
+        renderSideBySide: view === "split",
+        minimap: { enabled: true },
+        scrollBeyondLastLine: false,
+        automaticLayout: true,
+        hideUnchangedRegions: {
+          enabled: true,
+          contextLineCount: 3,
+          minimumLineCount: 3,
+          revealLineCount: 20,
+        },
+      }}
+    />
+  );
+}
 
 export function PlanDiffDialog({
   deploymentId,
   resultId,
   title,
   open,
+  initialTab = "diff",
   onOpenChange,
 }: PlanDiffDialogProps) {
-  const [view, setView] = useState<DiffView>("split");
-  const { theme } = useTheme();
+  const [tab, setTab] = useState<TopTab>(initialTab);
+  const [view, setView] = useState<DiffView>("unified");
 
-  const diffQuery = trpc.deployment.plans.resultDiff.useQuery(
-    { deploymentId, resultId: resultId ?? "" },
-    { enabled: open && resultId != null },
-  );
+  useEffect(() => {
+    if (open) setTab(initialTab);
+  }, [open, initialTab]);
 
   return (
     <Dialog open={open} onOpenChange={onOpenChange}>
       <DialogContent className="flex h-[90vh] w-[95vw] max-w-[95vw] flex-col p-0 sm:max-w-[95vw]">
         <DialogHeader className="flex-row items-center justify-between border-b p-4 pr-12">
           <DialogTitle>{title}</DialogTitle>
-          <Tabs value={view} onValueChange={(v) => setView(v as DiffView)}>
-            <TabsList>
-              <TabsTrigger value="split">Split</TabsTrigger>
-              <TabsTrigger value="unified">Unified</TabsTrigger>
-            </TabsList>
-          </Tabs>
+          <div className="flex items-center gap-4">
+            {tab === "diff" && (
+              <div className="flex items-center gap-2">
+                <Switch
+                  id="diff-split"
+                  checked={view === "split"}
+                  onCheckedChange={(checked) =>
+                    setView(checked ? "split" : "unified")
+                  }
+                />
+                <Label
+                  htmlFor="diff-split"
+                  className="text-xs text-muted-foreground"
+                >
+                  Split
+                </Label>
+              </div>
+            )}
+            <Tabs value={tab} onValueChange={(v) => setTab(v as TopTab)}>
+              <TabsList>
+                <TabsTrigger value="diff">Diff</TabsTrigger>
+                <TabsTrigger value="validations">Validations</TabsTrigger>
+              </TabsList>
+            </Tabs>
+          </div>
         </DialogHeader>
         <div className="min-h-0 flex-1">
-          {diffQuery.isLoading ? (
-            <div className="flex h-full items-center justify-center text-sm text-muted-foreground">
-              Loading diff...
-            </div>
-          ) : diffQuery.data == null ? (
-            <div className="flex h-full items-center justify-center text-sm text-muted-foreground">
-              No diff available
-            </div>
+          {resultId == null ? null : tab === "diff" ? (
+            <DiffTab
+              deploymentId={deploymentId}
+              resultId={resultId}
+              open={open}
+              view={view}
+            />
           ) : (
-            <DiffEditor
-              height="100%"
-              language="yaml"
-              theme={theme === "dark" ? "vs-dark" : "vs"}
-              original={diffQuery.data.current}
-              modified={diffQuery.data.proposed}
-              options={{
-                readOnly: true,
-                renderSideBySide: view === "split",
-                minimap: { enabled: true },
-                scrollBeyondLastLine: false,
-                automaticLayout: true,
-                hideUnchangedRegions: {
-                  enabled: true,
-                  contextLineCount: 3,
-                  minimumLineCount: 3,
-                  revealLineCount: 20,
-                },
-              }}
+            <ValidationsTab
+              deploymentId={deploymentId}
+              resultId={resultId}
+              open={open}
             />
           )}
         </div>

--- a/apps/web/app/routes/ws/deployments/page.$deploymentId.plans.$planId.tsx
+++ b/apps/web/app/routes/ws/deployments/page.$deploymentId.plans.$planId.tsx
@@ -1,4 +1,5 @@
 import type { RouterOutputs } from "@ctrlplane/trpc";
+import { useState } from "react";
 import { FileText } from "lucide-react";
 import { Link, useParams } from "react-router";
 
@@ -77,6 +78,38 @@ function ChangesCell({ result }: { result: Result }) {
   return <span className="text-muted-foreground">—</span>;
 }
 
+function ValidationsCell({
+  validations,
+  onClick,
+}: {
+  validations: Result["validations"];
+  onClick: () => void;
+}) {
+  if (validations.total === 0)
+    return <span className="text-muted-foreground">—</span>;
+  return (
+    <button
+      type="button"
+      onClick={(e) => {
+        e.stopPropagation();
+        onClick();
+      }}
+      className="flex items-center gap-2 text-xs hover:underline"
+    >
+      {validations.failed > 0 && (
+        <span className="text-red-600 dark:text-red-400">
+          {validations.failed} failed
+        </span>
+      )}
+      {validations.passed > 0 && (
+        <span className="text-muted-foreground">
+          {validations.passed} passed
+        </span>
+      )}
+    </button>
+  );
+}
+
 function ResultsTableHeader() {
   return (
     <TableHeader>
@@ -86,6 +119,7 @@ function ResultsTableHeader() {
         <TableHead className="font-medium">Agent</TableHead>
         <TableHead className="font-medium">Status</TableHead>
         <TableHead className="font-medium">Changes</TableHead>
+        <TableHead className="font-medium">Validations</TableHead>
       </TableRow>
     </TableHeader>
   );
@@ -93,16 +127,19 @@ function ResultsTableHeader() {
 
 function ResultsTableRow({
   result,
-  onViewDiff,
+  onOpenResult,
 }: {
   result: Result;
-  onViewDiff: (resultId: string) => void;
+  onOpenResult: (resultId: string, tab?: "diff" | "validations") => void;
 }) {
-  const isClickable = result.hasChanges === true;
+  const hasValidations = result.validations.total > 0;
+  const isClickable = result.hasChanges === true || hasValidations;
   return (
     <TableRow
       className={cn("hover:bg-muted/50", isClickable && "cursor-pointer")}
-      onClick={isClickable ? () => onViewDiff(result.resultId) : undefined}
+      onClick={
+        isClickable ? () => onOpenResult(result.resultId, "diff") : undefined
+      }
     >
       <TableCell>{result.environment.name}</TableCell>
       <TableCell>{result.resource.name}</TableCell>
@@ -112,6 +149,12 @@ function ResultsTableRow({
       </TableCell>
       <TableCell>
         <ChangesCell result={result} />
+      </TableCell>
+      <TableCell>
+        <ValidationsCell
+          validations={result.validations}
+          onClick={() => onOpenResult(result.resultId, "validations")}
+        />
       </TableCell>
     </TableRow>
   );
@@ -140,6 +183,7 @@ export default function DeploymentPlanDetail() {
   const { deployment } = useDeployment();
   const { planId } = useParams<{ planId: string }>();
   const { resultId, openResult, closeResult } = usePlanResultParam();
+  const [initialTab, setInitialTab] = useState<"diff" | "validations">("diff");
 
   const resultsQuery = trpc.deployment.plans.results.useQuery(
     { deploymentId: deployment.id, planId: planId! },
@@ -149,6 +193,14 @@ export default function DeploymentPlanDetail() {
   const version = resultsQuery.data?.version;
   const results = resultsQuery.data?.items ?? [];
   const activeResult = results.find((r) => r.resultId === resultId);
+
+  const handleOpenResult = (
+    id: string,
+    tab: "diff" | "validations" = "diff",
+  ) => {
+    setInitialTab(tab);
+    openResult(id);
+  };
 
   return (
     <>
@@ -201,7 +253,7 @@ export default function DeploymentPlanDetail() {
               <ResultsTableRow
                 key={r.resultId}
                 result={r}
-                onViewDiff={openResult}
+                onOpenResult={handleOpenResult}
               />
             ))}
           </TableBody>
@@ -213,6 +265,7 @@ export default function DeploymentPlanDetail() {
         resultId={resultId}
         title={activeResult ? resultTitle(activeResult) : ""}
         open={resultId != null}
+        initialTab={initialTab}
         onOpenChange={(o) => {
           if (!o) closeResult();
         }}

--- a/apps/web/app/routes/ws/deployments/page.$deploymentId.plans.$planId.tsx
+++ b/apps/web/app/routes/ws/deployments/page.$deploymentId.plans.$planId.tsx
@@ -132,13 +132,17 @@ function ResultsTableRow({
   result: Result;
   onOpenResult: (resultId: string, tab?: "diff" | "validations") => void;
 }) {
+  const hasChanges = result.hasChanges === true;
   const hasValidations = result.validations.total > 0;
-  const isClickable = result.hasChanges === true || hasValidations;
+  const isClickable = hasChanges || hasValidations;
+  const defaultTab = hasChanges ? "diff" : "validations";
   return (
     <TableRow
       className={cn("hover:bg-muted/50", isClickable && "cursor-pointer")}
       onClick={
-        isClickable ? () => onOpenResult(result.resultId, "diff") : undefined
+        isClickable
+          ? () => onOpenResult(result.resultId, defaultTab)
+          : undefined
       }
     >
       <TableCell>{result.environment.name}</TableCell>

--- a/packages/trpc/src/routes/deployment-plans.ts
+++ b/packages/trpc/src/routes/deployment-plans.ts
@@ -41,6 +41,42 @@ const emptySummary = (): PlanSummary => ({
   unchanged: 0,
 });
 
+type ValidationCounts = { total: number; passed: number; failed: number };
+
+async function loadValidationCounts(
+  db: Parameters<
+    Parameters<typeof protectedProcedure.query>[0]
+  >[0]["ctx"]["db"],
+  resultIds: string[],
+): Promise<Map<string, ValidationCounts>> {
+  const out = new Map<string, ValidationCounts>();
+  if (resultIds.length === 0) return out;
+
+  const rows = await db
+    .select({
+      resultId: schema.deploymentPlanTargetResultValidation.resultId,
+      passed: schema.deploymentPlanTargetResultValidation.passed,
+      count: count(),
+    })
+    .from(schema.deploymentPlanTargetResultValidation)
+    .where(
+      inArray(schema.deploymentPlanTargetResultValidation.resultId, resultIds),
+    )
+    .groupBy(
+      schema.deploymentPlanTargetResultValidation.resultId,
+      schema.deploymentPlanTargetResultValidation.passed,
+    );
+
+  for (const row of rows) {
+    const c = out.get(row.resultId) ?? { total: 0, passed: 0, failed: 0 };
+    c.total += row.count;
+    if (row.passed) c.passed += row.count;
+    else c.failed += row.count;
+    out.set(row.resultId, c);
+  }
+  return out;
+}
+
 export const deploymentPlansRouter = router({
   list: protectedProcedure
     .meta({
@@ -204,6 +240,11 @@ export const deploymentPlansRouter = router({
         .where(eq(schema.deploymentPlanTarget.planId, input.planId))
         .orderBy(schema.environment.name, schema.resource.name);
 
+      const validationCounts = await loadValidationCounts(
+        ctx.db,
+        rows.map((r) => r.resultId),
+      );
+
       return {
         version: { tag: plan.versionTag, name: plan.versionName },
         items: rows.map((r) => {
@@ -225,9 +266,88 @@ export const deploymentPlansRouter = router({
             contentHash: r.contentHash,
             startedAt: r.startedAt,
             completedAt: r.completedAt,
+            validations: validationCounts.get(r.resultId) ?? {
+              total: 0,
+              passed: 0,
+              failed: 0,
+            },
           };
         }),
       };
+    }),
+
+  resultValidations: protectedProcedure
+    .meta({
+      authorizationCheck: ({ canUser, input }) =>
+        canUser
+          .perform(Permission.DeploymentGet)
+          .on({ type: "deployment", id: input.deploymentId }),
+    })
+    .input(
+      z.object({
+        deploymentId: z.uuid(),
+        resultId: z.uuid(),
+      }),
+    )
+    .query(async ({ input, ctx }) => {
+      const owner = await ctx.db
+        .select({ deploymentId: schema.deploymentPlan.deploymentId })
+        .from(schema.deploymentPlanTargetResult)
+        .innerJoin(
+          schema.deploymentPlanTarget,
+          eq(
+            schema.deploymentPlanTargetResult.targetId,
+            schema.deploymentPlanTarget.id,
+          ),
+        )
+        .innerJoin(
+          schema.deploymentPlan,
+          eq(schema.deploymentPlanTarget.planId, schema.deploymentPlan.id),
+        )
+        .where(eq(schema.deploymentPlanTargetResult.id, input.resultId))
+        .then(takeFirstOrNull);
+
+      if (owner == null || owner.deploymentId !== input.deploymentId)
+        throw new TRPCError({
+          code: "NOT_FOUND",
+          message: "Result not found",
+        });
+
+      const rows = await ctx.db
+        .select({
+          id: schema.deploymentPlanTargetResultValidation.id,
+          ruleId: schema.deploymentPlanTargetResultValidation.ruleId,
+          passed: schema.deploymentPlanTargetResultValidation.passed,
+          violations: schema.deploymentPlanTargetResultValidation.violations,
+          evaluatedAt: schema.deploymentPlanTargetResultValidation.evaluatedAt,
+          ruleName: schema.policyRulePlanValidationOpa.name,
+          ruleDescription: schema.policyRulePlanValidationOpa.description,
+        })
+        .from(schema.deploymentPlanTargetResultValidation)
+        .leftJoin(
+          schema.policyRulePlanValidationOpa,
+          eq(
+            schema.deploymentPlanTargetResultValidation.ruleId,
+            schema.policyRulePlanValidationOpa.id,
+          ),
+        )
+        .where(
+          eq(
+            schema.deploymentPlanTargetResultValidation.resultId,
+            input.resultId,
+          ),
+        )
+        .orderBy(schema.policyRulePlanValidationOpa.name);
+
+      return rows.map((r) => ({
+        id: r.id,
+        ruleId: r.ruleId,
+        ruleName: r.ruleName ?? "(unknown rule)",
+        ruleDescription: r.ruleDescription,
+        passed: r.passed,
+        violations: r.violations,
+        evaluatedAt: r.evaluatedAt,
+      }));
     }),
 
   resultDiff: protectedProcedure


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a validations tab to the plan comparison dialog, displaying validation results with pass/fail status and violation messages.
  * Plan results table now shows passed and failed validation counts.
  * Plan result rows are now clickable to view both diff and validation details with tab-based navigation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->