### PR TITLE
fix: merge runner config into workflow-triggered jobs

### DIFF
--- a/apps/workspace-engine/svc/http/server/openapi/workflows/setters.go
+++ b/apps/workspace-engine/svc/http/server/openapi/workflows/setters.go
@@ -95,6 +95,18 @@ func (s *PostgresSetter) CreateWorkflowRun(
 	return tx.Commit(ctx)
 }
 
+// mergeWorkflowJobAgentConfig builds the JobAgentConfig that ends up on a
+// workflow-triggered job. The runner row holds shared credentials (e.g.
+// serverUrl, apiKey); the per-job WorkflowJobAgent.Config holds the
+// per-invocation payload (e.g. template, name). Per-job values win on
+// conflict, mirroring the deployment flow's runner < deployment < version
+// precedence in jobeligibility.
+func mergeWorkflowJobAgentConfig(
+	runnerConfig, perJobConfig map[string]any,
+) oapi.JobAgentConfig {
+	return oapi.DeepMergeConfigs(runnerConfig, perJobConfig)
+}
+
 func (s *PostgresSetter) dispatchJobForAgent(
 	ctx context.Context,
 	queries *db.Queries,
@@ -107,7 +119,12 @@ func (s *PostgresSetter) dispatchJobForAgent(
 	if err != nil {
 		return fmt.Errorf("parse job agent id: %w", err)
 	}
-	jobAgentConfig, err := json.Marshal(jobAgent.Config)
+	runner, err := queries.GetJobAgentByID(ctx, jobAgentIDUUID)
+	if err != nil {
+		return fmt.Errorf("get job agent runner: %w", err)
+	}
+	mergedConfig := mergeWorkflowJobAgentConfig(runner.Config, jobAgent.Config)
+	jobAgentConfig, err := json.Marshal(mergedConfig)
 	if err != nil {
 		return fmt.Errorf("marshal job agent config: %w", err)
 	}

--- a/apps/workspace-engine/svc/http/server/openapi/workflows/setters.go
+++ b/apps/workspace-engine/svc/http/server/openapi/workflows/setters.go
@@ -102,7 +102,7 @@ func (s *PostgresSetter) CreateWorkflowRun(
 // conflict, mirroring the deployment flow's runner < deployment < version
 // precedence in jobeligibility.
 func mergeWorkflowJobAgentConfig(
-	runnerConfig, perJobConfig map[string]any,
+	runnerConfig, perJobConfig oapi.JobAgentConfig,
 ) oapi.JobAgentConfig {
 	return oapi.DeepMergeConfigs(runnerConfig, perJobConfig)
 }
@@ -119,9 +119,19 @@ func (s *PostgresSetter) dispatchJobForAgent(
 	if err != nil {
 		return fmt.Errorf("parse job agent id: %w", err)
 	}
+	workspaceIDUUID, err := uuid.Parse(workspaceID)
+	if err != nil {
+		return fmt.Errorf("parse workspace id: %w", err)
+	}
 	runner, err := queries.GetJobAgentByID(ctx, jobAgentIDUUID)
 	if err != nil {
-		return fmt.Errorf("get job agent runner: %w", err)
+		return fmt.Errorf("get job agent: %w", err)
+	}
+	if runner.WorkspaceID != workspaceIDUUID {
+		return fmt.Errorf(
+			"job agent %s does not belong to workspace %s",
+			jobAgentIDUUID, workspaceIDUUID,
+		)
 	}
 	mergedConfig := mergeWorkflowJobAgentConfig(runner.Config, jobAgent.Config)
 	jobAgentConfig, err := json.Marshal(mergedConfig)

--- a/apps/workspace-engine/svc/http/server/openapi/workflows/workflows_test.go
+++ b/apps/workspace-engine/svc/http/server/openapi/workflows/workflows_test.go
@@ -155,6 +155,54 @@ func TestResolveInputs_EmptyWorkflowInputs(t *testing.T) {
 	assert.Equal(t, "value", resolved["extra"])
 }
 
+func TestMergeWorkflowJobAgentConfig_RunnerCredentialsPreserved(t *testing.T) {
+	runner := map[string]any{
+		"serverUrl": "https://argo.example",
+		"apiKey":    "secret",
+	}
+	perJob := map[string]any{
+		"template": "apiVersion: argoproj.io/v1alpha1",
+		"name":     "deploy",
+	}
+
+	merged := mergeWorkflowJobAgentConfig(runner, perJob)
+
+	assert.Equal(t, "https://argo.example", merged["serverUrl"])
+	assert.Equal(t, "secret", merged["apiKey"])
+	assert.Equal(t, "apiVersion: argoproj.io/v1alpha1", merged["template"])
+	assert.Equal(t, "deploy", merged["name"])
+}
+
+func TestMergeWorkflowJobAgentConfig_PerJobOverridesRunner(t *testing.T) {
+	runner := map[string]any{
+		"serverUrl": "https://shared.example",
+		"apiKey":    "secret",
+	}
+	perJob := map[string]any{
+		"serverUrl": "https://override.example",
+		"template":  "spec",
+	}
+
+	merged := mergeWorkflowJobAgentConfig(runner, perJob)
+
+	assert.Equal(t, "https://override.example", merged["serverUrl"])
+	assert.Equal(t, "secret", merged["apiKey"])
+	assert.Equal(t, "spec", merged["template"])
+}
+
+func TestMergeWorkflowJobAgentConfig_NilInputs(t *testing.T) {
+	merged := mergeWorkflowJobAgentConfig(nil, nil)
+	assert.Empty(t, merged)
+
+	runner := map[string]any{"serverUrl": "https://argo.example"}
+	merged = mergeWorkflowJobAgentConfig(runner, nil)
+	assert.Equal(t, "https://argo.example", merged["serverUrl"])
+
+	perJob := map[string]any{"template": "spec"}
+	merged = mergeWorkflowJobAgentConfig(nil, perJob)
+	assert.Equal(t, "spec", merged["template"])
+}
+
 func TestResolveInputs_ExtraProvidedInputsPassThrough(t *testing.T) {
 	workflow := &oapi.Workflow{
 		Inputs: []oapi.WorkflowInput{

--- a/apps/workspace-engine/svc/http/server/openapi/workflows/workflows_test.go
+++ b/apps/workspace-engine/svc/http/server/openapi/workflows/workflows_test.go
@@ -156,11 +156,11 @@ func TestResolveInputs_EmptyWorkflowInputs(t *testing.T) {
 }
 
 func TestMergeWorkflowJobAgentConfig_RunnerCredentialsPreserved(t *testing.T) {
-	runner := map[string]any{
+	runner := oapi.JobAgentConfig{
 		"serverUrl": "https://argo.example",
 		"apiKey":    "secret",
 	}
-	perJob := map[string]any{
+	perJob := oapi.JobAgentConfig{
 		"template": "apiVersion: argoproj.io/v1alpha1",
 		"name":     "deploy",
 	}
@@ -174,11 +174,11 @@ func TestMergeWorkflowJobAgentConfig_RunnerCredentialsPreserved(t *testing.T) {
 }
 
 func TestMergeWorkflowJobAgentConfig_PerJobOverridesRunner(t *testing.T) {
-	runner := map[string]any{
+	runner := oapi.JobAgentConfig{
 		"serverUrl": "https://shared.example",
 		"apiKey":    "secret",
 	}
-	perJob := map[string]any{
+	perJob := oapi.JobAgentConfig{
 		"serverUrl": "https://override.example",
 		"template":  "spec",
 	}
@@ -194,11 +194,11 @@ func TestMergeWorkflowJobAgentConfig_NilInputs(t *testing.T) {
 	merged := mergeWorkflowJobAgentConfig(nil, nil)
 	assert.Empty(t, merged)
 
-	runner := map[string]any{"serverUrl": "https://argo.example"}
+	runner := oapi.JobAgentConfig{"serverUrl": "https://argo.example"}
 	merged = mergeWorkflowJobAgentConfig(runner, nil)
 	assert.Equal(t, "https://argo.example", merged["serverUrl"])
 
-	perJob := map[string]any{"template": "spec"}
+	perJob := oapi.JobAgentConfig{"template": "spec"}
 	merged = mergeWorkflowJobAgentConfig(nil, perJob)
 	assert.Equal(t, "spec", merged["template"])
 }


### PR DESCRIPTION
## Why

Workflow runs were dropping the JobAgent runner's `serverUrl`/`apiKey` when building the job, so the argo-workflow dispatcher had nothing to authenticate with. The deployment path already merges runner + deployment + version configs in `jobeligibility/reconcile.go` — workflows took a shortcut that skipped that step.

## Changes

- Fetch the runner row in `dispatchJobForAgent` and merge its config with the per-job `WorkflowJobAgent.Config` (per-job wins on conflict).
- Tests cover credential preservation, override precedence, and nil inputs.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Improvements**
  * Enhanced configuration handling for workflow-triggered jobs with improved merge logic.

* **Tests**
  * Added test coverage for configuration merge scenarios, including credential preservation and value override handling.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->