### PR TITLE
fix: dont retrieve stale target states

### DIFF
--- a/apps/api/src/routes/v1/workspaces/release-targets.ts
+++ b/apps/api/src/routes/v1/workspaces/release-targets.ts
@@ -252,16 +252,46 @@ const getReleaseTargetStates: AsyncTypedHandler<
     eq(schema.releaseTargetDesiredRelease.environmentId, environmentId),
   );
 
+  const deploymentMatch = and(
+    eq(
+      schema.computedDeploymentResource.deploymentId,
+      schema.releaseTargetDesiredRelease.deploymentId,
+    ),
+    eq(
+      schema.computedDeploymentResource.resourceId,
+      schema.releaseTargetDesiredRelease.resourceId,
+    ),
+  );
+
+  const environmentMatch = and(
+    eq(
+      schema.computedEnvironmentResource.environmentId,
+      schema.releaseTargetDesiredRelease.environmentId,
+    ),
+    eq(
+      schema.computedEnvironmentResource.resourceId,
+      schema.releaseTargetDesiredRelease.resourceId,
+    ),
+  );
+
   const [countResult] = await db
     .select({ total: count() })
     .from(schema.releaseTargetDesiredRelease)
+    .innerJoin(schema.computedDeploymentResource, deploymentMatch)
+    .innerJoin(schema.computedEnvironmentResource, environmentMatch)
     .where(filter);
 
   const total = countResult?.total ?? 0;
 
   const releaseTargets = await db
-    .select()
+    .select({
+      resourceId: schema.releaseTargetDesiredRelease.resourceId,
+      environmentId: schema.releaseTargetDesiredRelease.environmentId,
+      deploymentId: schema.releaseTargetDesiredRelease.deploymentId,
+    })
     .from(schema.releaseTargetDesiredRelease)
+    .innerJoin(schema.computedDeploymentResource, deploymentMatch)
+    .innerJoin(schema.computedEnvironmentResource, environmentMatch)
     .where(filter)
     .limit(limitVal)
     .offset(offsetVal);

--- a/apps/api/src/routes/v1/workspaces/release-targets.ts
+++ b/apps/api/src/routes/v1/workspaces/release-targets.ts
@@ -292,7 +292,12 @@ const getReleaseTargetStates: AsyncTypedHandler<
     .from(schema.releaseTargetDesiredRelease)
     .innerJoin(schema.computedDeploymentResource, deploymentMatch)
     .innerJoin(schema.computedEnvironmentResource, environmentMatch)
+    .innerJoin(
+      schema.resource,
+      eq(schema.resource.id, schema.releaseTargetDesiredRelease.resourceId),
+    )
     .where(filter)
+    .orderBy(schema.resource.identifier)
     .limit(limitVal)
     .offset(offsetVal);
 


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed release target data retrieval to correctly filter by deployment and environment resources.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->