### PR TITLE
chore(deployments): Add link to failed jobs

### DIFF
--- a/apps/web/app/routes/ws/deployments/_components/versioncard/VersionCard.tsx
+++ b/apps/web/app/routes/ws/deployments/_components/versioncard/VersionCard.tsx
@@ -245,6 +245,7 @@ const FailedPopoverContent: React.FC<{
           <Link
             to={`/${workspace.slug}/deployments/${deployment.id}/release-targets?query=${encodeURIComponent(rt.resource.name)}`}
             target="_blank"
+            rel="noopener noreferrer"
             className="font-medium hover:underline"
             onClick={(e) => e.stopPropagation()}
           >

--- a/apps/web/app/routes/ws/deployments/_components/versioncard/VersionCard.tsx
+++ b/apps/web/app/routes/ws/deployments/_components/versioncard/VersionCard.tsx
@@ -241,14 +241,15 @@ const FailedPopoverContent: React.FC<{
     <div className="space-y-1.5">
       <div className="font-medium">Failed deployments:</div>
       {targets.map((rt) => (
-        <Link
-          key={rt.releaseTarget.resourceId}
-          to={`/${workspace.slug}/deployments/${deployment.id}/release-targets?query=${encodeURIComponent(rt.resource.name)}`}
-          target="_blank"
-          className="block text-xs hover:underline"
-          onClick={(e) => e.stopPropagation()}
-        >
-          <span className="font-medium">{rt.resource.name}</span>
+        <div key={rt.releaseTarget.resourceId} className="text-xs">
+          <Link
+            to={`/${workspace.slug}/deployments/${deployment.id}/release-targets?query=${encodeURIComponent(rt.resource.name)}`}
+            target="_blank"
+            className="font-medium hover:underline"
+            onClick={(e) => e.stopPropagation()}
+          >
+            {rt.resource.name}
+          </Link>
           {rt.latestJob?.status && (
             <span className="text-muted-foreground">
               {" "}
@@ -260,7 +261,7 @@ const FailedPopoverContent: React.FC<{
               {rt.latestJob.message}
             </div>
           )}
-        </Link>
+        </div>
       ))}
     </div>
   );

--- a/apps/web/app/routes/ws/deployments/_components/versioncard/VersionCard.tsx
+++ b/apps/web/app/routes/ws/deployments/_components/versioncard/VersionCard.tsx
@@ -234,27 +234,37 @@ const formatJobStatus = (status: string) => {
 
 const FailedPopoverContent: React.FC<{
   targets: ReleaseTargetWithState[];
-}> = ({ targets }) => (
-  <div className="space-y-1.5">
-    <div className="font-medium">Failed deployments:</div>
-    {targets.map((rt) => (
-      <div key={rt.releaseTarget.resourceId} className="text-xs">
-        <span className="font-medium">{rt.resource.name}</span>
-        {rt.latestJob?.status && (
-          <span className="text-muted-foreground">
-            {" "}
-            — {formatJobStatus(rt.latestJob.status)}
-          </span>
-        )}
-        {rt.latestJob?.message && (
-          <div className="mt-0.5 text-muted-foreground">
-            {rt.latestJob.message}
-          </div>
-        )}
-      </div>
-    ))}
-  </div>
-);
+}> = ({ targets }) => {
+  const { workspace } = useWorkspace();
+  const { deployment } = useDeployment();
+  return (
+    <div className="space-y-1.5">
+      <div className="font-medium">Failed deployments:</div>
+      {targets.map((rt) => (
+        <Link
+          key={rt.releaseTarget.resourceId}
+          to={`/${workspace.slug}/deployments/${deployment.id}/release-targets?query=${encodeURIComponent(rt.resource.name)}`}
+          target="_blank"
+          className="block text-xs hover:underline"
+          onClick={(e) => e.stopPropagation()}
+        >
+          <span className="font-medium">{rt.resource.name}</span>
+          {rt.latestJob?.status && (
+            <span className="text-muted-foreground">
+              {" "}
+              — {formatJobStatus(rt.latestJob.status)}
+            </span>
+          )}
+          {rt.latestJob?.message && (
+            <div className="mt-0.5 text-muted-foreground">
+              {rt.latestJob.message}
+            </div>
+          )}
+        </Link>
+      ))}
+    </div>
+  );
+};
 
 const DeploymentIssues: React.FC<{
   pending: number;

--- a/apps/web/app/routes/ws/deployments/page.$deploymentId.release-targets.tsx
+++ b/apps/web/app/routes/ws/deployments/page.$deploymentId.release-targets.tsx
@@ -31,7 +31,7 @@ import { EnvironmentReleaseTargetsGroup } from "./_components/release-targets/En
 
 function useResource() {
   const [searchParams, setSearchParams] = useSearchParams();
-  const query = searchParams.get("resource") ?? "";
+  const query = searchParams.get("query") ?? "";
   const [search, setSearch] = useState(query);
   const [searchDebounced, setSearchDebounced] = useState(search);
   useDebounce(


### PR DESCRIPTION
When checking the failed jobs on the UI, it's currently a bit cumbersome to go from the list of failures to find the job agent run with the link to the run you want to see. This PR makes the failed job name a link to the failed deployment target so it's a bit easier to know where to look and faster to get there


https://github.com/user-attachments/assets/f4e2a10f-6397-4cdc-92d1-5d0c444ee9c3



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Failed deployments are now clickable links. Click any failed deployment to navigate directly to the release-targets page, which opens in a new tab for streamlined investigation and management of deployment issues.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->