### PR TITLE
fix: fetch newest workflow runs in ui query

### DIFF
--- a/packages/trpc/src/routes/workflows.ts
+++ b/packages/trpc/src/routes/workflows.ts
@@ -157,11 +157,26 @@ export const workflowsRouter = router({
         z.object({
           workspaceId: z.uuid(),
           workflowId: z.string().uuid(),
-          limit: z.number().min(1).max(1000).default(100),
+          limit: z.number().min(1).max(1000).default(500),
           offset: z.number().min(0).default(0),
         }),
       )
       .query(async ({ ctx, input }) => {
+        const newestRunIds = ctx.db
+          .select({ id: schema.workflowRun.id })
+          .from(schema.workflowRun)
+          .leftJoin(
+            schema.workflowJob,
+            eq(schema.workflowJob.workflowRunId, schema.workflowRun.id),
+          )
+          .leftJoin(schema.job, eq(schema.job.id, schema.workflowJob.jobId))
+          .where(eq(schema.workflowRun.workflowId, input.workflowId))
+          .groupBy(schema.workflowRun.id)
+          .orderBy(sql`min(${schema.job.createdAt}) desc nulls last`)
+          .limit(input.limit)
+          .offset(input.offset)
+          .as("newest_runs");
+
         const rows = await ctx.db
           .select({
             runId: schema.workflowRun.id,
@@ -170,15 +185,16 @@ export const workflowsRouter = router({
             jobStatus: schema.job.status,
             jobCreatedAt: schema.job.createdAt,
           })
-          .from(schema.workflowRun)
+          .from(newestRunIds)
+          .innerJoin(
+            schema.workflowRun,
+            eq(schema.workflowRun.id, newestRunIds.id),
+          )
           .leftJoin(
             schema.workflowJob,
             eq(schema.workflowJob.workflowRunId, schema.workflowRun.id),
           )
-          .leftJoin(schema.job, eq(schema.job.id, schema.workflowJob.jobId))
-          .where(eq(schema.workflowRun.workflowId, input.workflowId))
-          .limit(input.limit)
-          .offset(input.offset);
+          .leftJoin(schema.job, eq(schema.job.id, schema.workflowJob.jobId));
 
         return _.chain(rows)
           .groupBy("runId")


### PR DESCRIPTION
fixes #1128

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Increased default pagination limit for workflow runs list from 100 to 500 results per page.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/ctrlplanedev/ctrlplane/pull/1140?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->