### PR TITLE
fix: ability to exclude rule ids from eligible versions endpoint

### DIFF
--- a/apps/api/openapi/openapi.json
+++ b/apps/api/openapi/openapi.json
@@ -7544,6 +7544,14 @@
                   "application/json": {
                      "schema": {
                         "properties": {
+                           "excludeRuleIds": {
+                              "description": "Policy rule IDs to skip during evaluation. Useful when a caller wants to ignore a specific constraint (for example, a versionSelector pin) while still respecting every other rule.",
+                              "items": {
+                                 "format": "uuid",
+                                 "type": "string"
+                              },
+                              "type": "array"
+                           },
                            "filter": {
                               "description": "CEL expression to filter eligible versions. Defaults to \"true\" (all eligible versions).",
                               "type": "string"

--- a/apps/api/openapi/paths/release-targets.jsonnet
+++ b/apps/api/openapi/paths/release-targets.jsonnet
@@ -112,6 +112,11 @@ local openapi = import '../lib/openapi.libsonnet';
                   type: 'string',
                   description: 'CEL expression to filter eligible versions. Defaults to "true" (all eligible versions).',
                 },
+                excludeRuleIds: {
+                  type: 'array',
+                  items: { type: 'string', format: 'uuid' },
+                  description: 'Policy rule IDs to skip during evaluation. Useful when a caller wants to ignore a specific constraint (for example, a versionSelector pin) while still respecting every other rule.',
+                },
               },
             },
           },

--- a/apps/api/src/routes/v1/workspaces/release-targets.ts
+++ b/apps/api/src/routes/v1/workspaces/release-targets.ts
@@ -242,7 +242,7 @@ const listEligibleVersionsForReleaseTarget: AsyncTypedHandler<
 > = async (req, res) => {
   const { workspaceId, releaseTargetKey } = req.params;
   const { limit, offset } = req.query;
-  const { filter } = req.body;
+  const { filter, excludeRuleIds } = req.body;
 
   const { data, error, response } = await getClientFor(workspaceId).POST(
     "/v1/workspaces/{workspaceId}/release-targets/{releaseTargetKey}/eligible-versions",
@@ -251,7 +251,7 @@ const listEligibleVersionsForReleaseTarget: AsyncTypedHandler<
         path: { workspaceId, releaseTargetKey },
         query: { limit, offset },
       },
-      body: { filter },
+      body: { filter, excludeRuleIds },
     },
   );
 

--- a/apps/api/src/types/openapi.ts
+++ b/apps/api/src/types/openapi.ts
@@ -5024,6 +5024,8 @@ export interface operations {
         requestBody: {
             content: {
                 "application/json": {
+                    /** @description Policy rule IDs to skip during evaluation. Useful when a caller wants to ignore a specific constraint (for example, a versionSelector pin) while still respecting every other rule. */
+                    excludeRuleIds?: string[];
                     /** @description CEL expression to filter eligible versions. Defaults to "true" (all eligible versions). */
                     filter?: string;
                 };

--- a/apps/workspace-engine/oapi/openapi.json
+++ b/apps/workspace-engine/oapi/openapi.json
@@ -3636,6 +3636,14 @@
                   "application/json": {
                      "schema": {
                         "properties": {
+                           "excludeRuleIds": {
+                              "description": "Policy rule IDs to skip during evaluation. Useful when a caller wants to ignore a specific constraint (for example, a versionSelector pin) while still respecting every other rule.",
+                              "items": {
+                                 "format": "uuid",
+                                 "type": "string"
+                              },
+                              "type": "array"
+                           },
                            "filter": {
                               "description": "CEL expression to filter eligible versions. Defaults to \"true\" (all eligible versions).",
                               "type": "string"

--- a/apps/workspace-engine/oapi/spec/paths/release_targets.jsonnet
+++ b/apps/workspace-engine/oapi/spec/paths/release_targets.jsonnet
@@ -61,6 +61,11 @@ local openapi = import '../lib/openapi.libsonnet';
                   type: 'string',
                   description: 'CEL expression to filter eligible versions. Defaults to "true" (all eligible versions).',
                 },
+                excludeRuleIds: {
+                  type: 'array',
+                  items: { type: 'string', format: 'uuid' },
+                  description: 'Policy rule IDs to skip during evaluation. Useful when a caller wants to ignore a specific constraint (for example, a versionSelector pin) while still respecting every other rule.',
+                },
               },
             },
           },

--- a/apps/workspace-engine/pkg/oapi/oapi.gen.go
+++ b/apps/workspace-engine/pkg/oapi/oapi.gen.go
@@ -1547,6 +1547,9 @@ type ListDeploymentsParams struct {
 
 // ListEligibleVersionsForReleaseTargetJSONBody defines parameters for ListEligibleVersionsForReleaseTarget.
 type ListEligibleVersionsForReleaseTargetJSONBody struct {
+	// ExcludeRuleIds Policy rule IDs to skip during evaluation. Useful when a caller wants to ignore a specific constraint (for example, a versionSelector pin) while still respecting every other rule.
+	ExcludeRuleIds *[]openapi_types.UUID `json:"excludeRuleIds,omitempty"`
+
 	// Filter CEL expression to filter eligible versions. Defaults to "true" (all eligible versions).
 	Filter *string `json:"filter,omitempty"`
 }

--- a/apps/workspace-engine/svc/controllers/desiredrelease/policyeval/policyeval.go
+++ b/apps/workspace-engine/svc/controllers/desiredrelease/policyeval/policyeval.go
@@ -181,6 +181,30 @@ func FindDeployableVersion(
 	}, nil
 }
 
+// FilterEvaluatorsByRuleID returns evaluators whose RuleId is not in excludeIDs.
+// When excludeIDs is empty, the input slice is returned unchanged. The returned
+// slice does not share backing storage with the input, so the caller can use it
+// without worrying about hidden mutation.
+func FilterEvaluatorsByRuleID(
+	evals []evaluator.Evaluator,
+	excludeIDs []string,
+) []evaluator.Evaluator {
+	if len(excludeIDs) == 0 {
+		return evals
+	}
+	excludeSet := make(map[string]struct{}, len(excludeIDs))
+	for _, id := range excludeIDs {
+		excludeSet[id] = struct{}{}
+	}
+	kept := make([]evaluator.Evaluator, 0, len(evals))
+	for _, e := range evals {
+		if _, skip := excludeSet[e.RuleId()]; !skip {
+			kept = append(kept, e)
+		}
+	}
+	return kept
+}
+
 // ListDeployableVersions iterates candidate versions and returns every version
 // that passes the full evaluator set for the given release target. Unlike
 // FindDeployableVersion it does not short-circuit on the first allowed version;

--- a/apps/workspace-engine/svc/controllers/desiredrelease/policyeval/policyeval.go
+++ b/apps/workspace-engine/svc/controllers/desiredrelease/policyeval/policyeval.go
@@ -182,9 +182,9 @@ func FindDeployableVersion(
 }
 
 // FilterEvaluatorsByRuleID returns evaluators whose RuleId is not in excludeIDs.
-// When excludeIDs is empty, the input slice is returned unchanged. The returned
-// slice does not share backing storage with the input, so the caller can use it
-// without worrying about hidden mutation.
+// The function never mutates the input slice. When excludeIDs is empty the
+// input is returned as-is (shared backing storage); otherwise a freshly
+// allocated slice is returned.
 func FilterEvaluatorsByRuleID(
 	evals []evaluator.Evaluator,
 	excludeIDs []string,

--- a/apps/workspace-engine/svc/controllers/desiredrelease/policyeval/policyeval_test.go
+++ b/apps/workspace-engine/svc/controllers/desiredrelease/policyeval/policyeval_test.go
@@ -1111,6 +1111,82 @@ func TestListDeployableVersions(t *testing.T) {
 }
 
 // ---------------------------------------------------------------------------
+// FilterEvaluatorsByRuleID tests
+// ---------------------------------------------------------------------------
+
+func TestFilterEvaluatorsByRuleID(t *testing.T) {
+	ruleIDs := func(evals []evaluator.Evaluator) []string {
+		ids := make([]string, len(evals))
+		for i, e := range evals {
+			ids[i] = e.RuleId()
+		}
+		return ids
+	}
+
+	build := func(ids ...string) []evaluator.Evaluator {
+		out := make([]evaluator.Evaluator, len(ids))
+		for i, id := range ids {
+			out[i] = &mockEvaluator{ruleID: id}
+		}
+		return out
+	}
+
+	t.Run("nil exclude list returns input unchanged", func(t *testing.T) {
+		evals := build("rule-1", "rule-2")
+		got := FilterEvaluatorsByRuleID(evals, nil)
+		assert.Equal(t, []string{"rule-1", "rule-2"}, ruleIDs(got))
+	})
+
+	t.Run("empty exclude list returns input unchanged", func(t *testing.T) {
+		evals := build("rule-1", "rule-2")
+		got := FilterEvaluatorsByRuleID(evals, []string{})
+		assert.Equal(t, []string{"rule-1", "rule-2"}, ruleIDs(got))
+	})
+
+	t.Run("no matches returns input unchanged", func(t *testing.T) {
+		evals := build("rule-1", "rule-2")
+		got := FilterEvaluatorsByRuleID(evals, []string{"rule-x", "rule-y"})
+		assert.Equal(t, []string{"rule-1", "rule-2"}, ruleIDs(got))
+	})
+
+	t.Run("drops a single matching evaluator", func(t *testing.T) {
+		evals := build("rule-1", "rule-2", "rule-3")
+		got := FilterEvaluatorsByRuleID(evals, []string{"rule-2"})
+		assert.Equal(t, []string{"rule-1", "rule-3"}, ruleIDs(got))
+	})
+
+	t.Run("drops multiple matching evaluators preserving order", func(t *testing.T) {
+		evals := build("a", "b", "c", "d", "e")
+		got := FilterEvaluatorsByRuleID(evals, []string{"b", "d"})
+		assert.Equal(t, []string{"a", "c", "e"}, ruleIDs(got))
+	})
+
+	t.Run("when every evaluator matches, returns empty", func(t *testing.T) {
+		evals := build("rule-1", "rule-2")
+		got := FilterEvaluatorsByRuleID(evals, []string{"rule-1", "rule-2"})
+		assert.Empty(t, got)
+	})
+
+	t.Run("duplicate exclude IDs are no-ops", func(t *testing.T) {
+		evals := build("rule-1", "rule-2", "rule-3")
+		got := FilterEvaluatorsByRuleID(evals, []string{"rule-2", "rule-2", "rule-2"})
+		assert.Equal(t, []string{"rule-1", "rule-3"}, ruleIDs(got))
+	})
+
+	t.Run("empty evaluator input returns empty regardless of exclude list", func(t *testing.T) {
+		got := FilterEvaluatorsByRuleID(nil, []string{"rule-1"})
+		assert.Empty(t, got)
+	})
+
+	t.Run("does not mutate the input slice", func(t *testing.T) {
+		evals := build("rule-1", "rule-2", "rule-3")
+		_ = FilterEvaluatorsByRuleID(evals, []string{"rule-2"})
+		assert.Equal(t, []string{"rule-1", "rule-2", "rule-3"}, ruleIDs(evals),
+			"caller-owned slice must be left intact for safe reuse")
+	})
+}
+
+// ---------------------------------------------------------------------------
 // Conditional evaluator (version-dependent mock)
 // ---------------------------------------------------------------------------
 

--- a/apps/workspace-engine/svc/http/server/openapi/release_targets/eligible_versions.go
+++ b/apps/workspace-engine/svc/http/server/openapi/release_targets/eligible_versions.go
@@ -142,7 +142,19 @@ func (rt *ReleaseTargets) ListEligibleVersionsForReleaseTarget(
 		return
 	}
 
-	evals := policyeval.CollectEvaluators(ctx, getter, oapiRT, rtPolicies)
+	var excludeRuleIDs []string
+	if body.ExcludeRuleIds != nil {
+		excludeRuleIDs = make([]string, len(*body.ExcludeRuleIds))
+		for i, id := range *body.ExcludeRuleIds {
+			excludeRuleIDs[i] = id.String()
+		}
+	}
+
+	evals := policyeval.FilterEvaluatorsByRuleID(
+		policyeval.CollectEvaluators(ctx, getter, oapiRT, rtPolicies),
+		excludeRuleIDs,
+	)
+
 	versions := filterVersionsByCEL(
 		getter.IterCandidateVersions(ctx, drt.DeploymentID, nil, nil),
 		prg,

--- a/e2e/api/schema.ts
+++ b/e2e/api/schema.ts
@@ -5024,6 +5024,8 @@ export interface operations {
         requestBody: {
             content: {
                 "application/json": {
+                    /** @description Policy rule IDs to skip during evaluation. Useful when a caller wants to ignore a specific constraint (for example, a versionSelector pin) while still respecting every other rule. */
+                    excludeRuleIds?: string[];
                     /** @description CEL expression to filter eligible versions. Defaults to "true" (all eligible versions). */
                     filter?: string;
                 };

--- a/e2e/tests/api/release-target-eligible-versions.spec.ts
+++ b/e2e/tests/api/release-target-eligible-versions.spec.ts
@@ -211,6 +211,71 @@ test.describe("Release Target Eligible Versions API", () => {
     }
   });
 
+  test("excludeRuleIds bypasses a versionSelector pin, returning all versions", async ({
+    api,
+    workspace,
+  }) => {
+    await insertVersions(workspace.id, [
+      { tag: "v1.0.0" },
+      { tag: "v1.1.0" },
+      { tag: "v2.0.0" },
+    ]);
+
+    const policyRes = await api.POST(
+      "/v1/workspaces/{workspaceId}/policies",
+      {
+        params: { path: { workspaceId: workspace.id } },
+        body: {
+          name: `evt-pin-${faker.string.alphanumeric(8)}`,
+          selector: "true",
+          rules: [
+            {
+              versionSelector: {
+                selector: 'version.tag == "v2.0.0"',
+                description: "pin to v2.0.0",
+              },
+            },
+          ],
+        },
+      },
+    );
+    expect(policyRes.response.status).toBe(202);
+    const policyId = policyRes.data!.id;
+    const ruleId = policyRes.data!.rules[0]!.id;
+
+    try {
+      const pinned = await api.POST(
+        "/v1/workspaces/{workspaceId}/release-targets/{releaseTargetKey}/eligible-versions",
+        {
+          params: { path: { workspaceId: workspace.id, releaseTargetKey } },
+          body: {},
+        },
+      );
+      expect(pinned.response.status).toBe(200);
+      expect(pinned.data!.total).toBe(1);
+      expect(pinned.data!.items.map((v) => v.tag)).toEqual(["v2.0.0"]);
+
+      const unpinned = await api.POST(
+        "/v1/workspaces/{workspaceId}/release-targets/{releaseTargetKey}/eligible-versions",
+        {
+          params: { path: { workspaceId: workspace.id, releaseTargetKey } },
+          body: { excludeRuleIds: [ruleId] },
+        },
+      );
+      expect(unpinned.response.status).toBe(200);
+      expect(unpinned.data!.total).toBe(3);
+      expect(unpinned.data!.items.map((v) => v.tag).sort()).toEqual([
+        "v1.0.0",
+        "v1.1.0",
+        "v2.0.0",
+      ]);
+    } finally {
+      await api.DELETE("/v1/workspaces/{workspaceId}/policies/{policyId}", {
+        params: { path: { workspaceId: workspace.id, policyId } },
+      });
+    }
+  });
+
   test("CEL filter narrows the eligible set", async ({ api, workspace }) => {
     await insertVersions(workspace.id, [
       { tag: "v1.0.0" },

--- a/packages/workspace-engine-sdk/src/schema.ts
+++ b/packages/workspace-engine-sdk/src/schema.ts
@@ -1642,6 +1642,8 @@ export interface operations {
     requestBody: {
       content: {
         "application/json": {
+          /** @description Policy rule IDs to skip during evaluation. Useful when a caller wants to ignore a specific constraint (for example, a versionSelector pin) while still respecting every other rule. */
+          excludeRuleIds?: string[];
           /** @description CEL expression to filter eligible versions. Defaults to "true" (all eligible versions). */
           filter?: string;
         };


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added ability to exclude specific policy rule IDs when evaluating eligible versions, so callers can view eligible versions while skipping selected policies.

* **Tests**
  * Added end-to-end test verifying excluding a rule ID bypasses a policy pin and restores broader version eligibility.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/ctrlplanedev/ctrlplane/pull/1148?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->