### PR TITLE
feat: Return job ids when workflows are created (closes: #1155)

### DIFF
--- a/apps/workspace-engine/oapi/openapi.json
+++ b/apps/workspace-engine/oapi/openapi.json
@@ -3241,6 +3241,52 @@
             ],
             "type": "object"
          },
+         "WorkflowRunJob": {
+            "properties": {
+               "jobAgentId": {
+                  "description": "Job agent the job was dispatched to",
+                  "type": "string"
+               },
+               "jobId": {
+                  "description": "Job id; poll its status via GET /v1/workspaces/{workspaceId}/jobs/{jobId}",
+                  "type": "string"
+               }
+            },
+            "required": [
+               "jobId",
+               "jobAgentId"
+            ],
+            "type": "object"
+         },
+         "WorkflowRunResult": {
+            "properties": {
+               "id": {
+                  "description": "Workflow run id",
+                  "type": "string"
+               },
+               "inputs": {
+                  "additionalProperties": true,
+                  "type": "object"
+               },
+               "jobs": {
+                  "description": "Jobs created and dispatched for this run",
+                  "items": {
+                     "$ref": "#/components/schemas/WorkflowRunJob"
+                  },
+                  "type": "array"
+               },
+               "workflowId": {
+                  "type": "string"
+               }
+            },
+            "required": [
+               "id",
+               "workflowId",
+               "inputs",
+               "jobs"
+            ],
+            "type": "object"
+         },
          "WorkflowStringInput": {
             "properties": {
                "default": {
@@ -4037,7 +4083,7 @@
                   "content": {
                      "application/json": {
                         "schema": {
-                           "$ref": "#/components/schemas/WorkflowRun"
+                           "$ref": "#/components/schemas/WorkflowRunResult"
                         }
                      }
                   },

--- a/apps/workspace-engine/oapi/spec/paths/workflows.jsonnet
+++ b/apps/workspace-engine/oapi/spec/paths/workflows.jsonnet
@@ -28,7 +28,7 @@ local openapi = import '../lib/openapi.libsonnet';
           },
         },
       },
-      responses: openapi.okResponse(openapi.schemaRef('WorkflowRun'))
+      responses: openapi.okResponse(openapi.schemaRef('WorkflowRunResult'))
                  + openapi.notFoundResponse()
                  + openapi.badRequestResponse(),
     },

--- a/apps/workspace-engine/oapi/spec/schemas/workflows.jsonnet
+++ b/apps/workspace-engine/oapi/spec/schemas/workflows.jsonnet
@@ -55,6 +55,33 @@ local openapi = import '../lib/openapi.libsonnet';
     },
   },
 
+  WorkflowRunJob: {
+    type: 'object',
+    required: ['jobId', 'jobAgentId'],
+    properties: {
+      jobId: { type: 'string', description: 'Job id; poll its status via GET /v1/workspaces/{workspaceId}/jobs/{jobId}' },
+      jobAgentId: { type: 'string', description: 'Job agent the job was dispatched to' },
+    },
+  },
+
+  WorkflowRunResult: {
+    type: 'object',
+    required: ['id', 'workflowId', 'inputs', 'jobs'],
+    properties: {
+      id: { type: 'string', description: 'Workflow run id' },
+      workflowId: { type: 'string' },
+      inputs: {
+        type: 'object',
+        additionalProperties: true,
+      },
+      jobs: {
+        type: 'array',
+        description: 'Jobs created and dispatched for this run',
+        items: openapi.schemaRef('WorkflowRunJob'),
+      },
+    },
+  },
+
   WorkflowStringInput: {
     type: 'object',
     required: ['key', 'type'],

--- a/apps/workspace-engine/pkg/oapi/oapi.gen.go
+++ b/apps/workspace-engine/pkg/oapi/oapi.gen.go
@@ -1517,6 +1517,26 @@ type WorkflowRun struct {
 	WorkflowId string                 `json:"workflowId"`
 }
 
+// WorkflowRunJob defines model for WorkflowRunJob.
+type WorkflowRunJob struct {
+	// JobAgentId Job agent the job was dispatched to
+	JobAgentId string `json:"jobAgentId"`
+
+	// JobId Job id; poll its status via GET /v1/workspaces/{workspaceId}/jobs/{jobId}
+	JobId string `json:"jobId"`
+}
+
+// WorkflowRunResult defines model for WorkflowRunResult.
+type WorkflowRunResult struct {
+	// Id Workflow run id
+	Id     string                 `json:"id"`
+	Inputs map[string]interface{} `json:"inputs"`
+
+	// Jobs Jobs created and dispatched for this run
+	Jobs       []WorkflowRunJob `json:"jobs"`
+	WorkflowId string           `json:"workflowId"`
+}
+
 // WorkflowStringInput defines model for WorkflowStringInput.
 type WorkflowStringInput struct {
 	Default *string                 `json:"default,omitempty"`

--- a/apps/workspace-engine/svc/http/server/openapi/workflows/setters.go
+++ b/apps/workspace-engine/svc/http/server/openapi/workflows/setters.go
@@ -20,7 +20,7 @@ type Setter interface {
 		workspaceID string,
 		workflow *oapi.Workflow,
 		inputs map[string]any,
-	) error
+	) (*oapi.WorkflowRunResult, error)
 }
 
 var _ Setter = &PostgresSetter{}
@@ -48,17 +48,17 @@ func (s *PostgresSetter) CreateWorkflowRun(
 	workspaceID string,
 	workflow *oapi.Workflow,
 	inputs map[string]any,
-) error {
+) (*oapi.WorkflowRunResult, error) {
 	dispatchContext := s.buildDispatchContext(workflow, inputs)
 
 	workflowIDUUID, err := uuid.Parse(workflow.Id)
 	if err != nil {
-		return fmt.Errorf("parse workflow id: %w", err)
+		return nil, fmt.Errorf("parse workflow id: %w", err)
 	}
 
 	tx, err := db.GetPool(ctx).Begin(ctx)
 	if err != nil {
-		return fmt.Errorf("begin transaction: %w", err)
+		return nil, fmt.Errorf("begin transaction: %w", err)
 	}
 	defer func() { _ = tx.Rollback(ctx) }()
 
@@ -69,30 +69,42 @@ func (s *PostgresSetter) CreateWorkflowRun(
 		Inputs:     inputs,
 	})
 	if err != nil {
-		return fmt.Errorf("insert workflow run: %w", err)
+		return nil, fmt.Errorf("insert workflow run: %w", err)
 	}
 
+	jobs := make([]oapi.WorkflowRunJob, 0, len(workflow.Jobs))
 	for _, jobAgent := range workflow.Jobs {
 		isMatchingSelector, err := selector.Match(ctx, jobAgent.Selector, *dispatchContext)
 		if err != nil {
-			return fmt.Errorf("match selector: %w", err)
+			return nil, fmt.Errorf("match selector: %w", err)
 		}
 		if !isMatchingSelector {
 			continue
 		}
-		if err := s.dispatchJobForAgent(
+		job, err := s.dispatchJobForAgent(
 			ctx,
 			queries,
 			jobAgent,
 			workflowRun.ID,
 			dispatchContext,
 			workspaceID,
-		); err != nil {
-			return err
+		)
+		if err != nil {
+			return nil, err
 		}
+		jobs = append(jobs, job)
 	}
 
-	return tx.Commit(ctx)
+	if err := tx.Commit(ctx); err != nil {
+		return nil, fmt.Errorf("commit transaction: %w", err)
+	}
+
+	return &oapi.WorkflowRunResult{
+		Id:         workflowRun.ID.String(),
+		WorkflowId: workflow.Id,
+		Inputs:     inputs,
+		Jobs:       jobs,
+	}, nil
 }
 
 // mergeWorkflowJobAgentConfig builds the JobAgentConfig that ends up on a
@@ -136,21 +148,21 @@ func (s *PostgresSetter) dispatchJobForAgent(
 	workflowRunID uuid.UUID,
 	dispatchContext *oapi.DispatchContext,
 	workspaceID string,
-) error {
+) (oapi.WorkflowRunJob, error) {
 	jobAgentIDUUID, err := uuid.Parse(jobAgent.Ref)
 	if err != nil {
-		return fmt.Errorf("parse job agent id: %w", err)
+		return oapi.WorkflowRunJob{}, fmt.Errorf("parse job agent id: %w", err)
 	}
 	workspaceIDUUID, err := uuid.Parse(workspaceID)
 	if err != nil {
-		return fmt.Errorf("parse workspace id: %w", err)
+		return oapi.WorkflowRunJob{}, fmt.Errorf("parse workspace id: %w", err)
 	}
 	runner, err := queries.GetJobAgentByID(ctx, jobAgentIDUUID)
 	if err != nil {
-		return fmt.Errorf("get job agent: %w", err)
+		return oapi.WorkflowRunJob{}, fmt.Errorf("get job agent: %w", err)
 	}
 	if runner.WorkspaceID != workspaceIDUUID {
-		return fmt.Errorf(
+		return oapi.WorkflowRunJob{}, fmt.Errorf(
 			"job agent %s does not belong to workspace %s",
 			jobAgentIDUUID, workspaceIDUUID,
 		)
@@ -158,12 +170,12 @@ func (s *PostgresSetter) dispatchJobForAgent(
 	mergedConfig := mergeWorkflowJobAgentConfig(runner.Config, jobAgent.Config)
 	jobAgentConfig, err := json.Marshal(mergedConfig)
 	if err != nil {
-		return fmt.Errorf("marshal job agent config: %w", err)
+		return oapi.WorkflowRunJob{}, fmt.Errorf("marshal job agent config: %w", err)
 	}
 	jobDispatchContext := buildJobDispatchContext(dispatchContext, runner, mergedConfig)
 	dispatchContextJSON, err := json.Marshal(jobDispatchContext)
 	if err != nil {
-		return fmt.Errorf("marshal dispatch context: %w", err)
+		return oapi.WorkflowRunJob{}, fmt.Errorf("marshal dispatch context: %w", err)
 	}
 
 	now := pgtype.Timestamptz{Time: time.Now().UTC(), Valid: true}
@@ -178,14 +190,14 @@ func (s *PostgresSetter) dispatchJobForAgent(
 		CreatedAt:       now,
 		UpdatedAt:       now,
 	}); err != nil {
-		return fmt.Errorf("insert job: %w", err)
+		return oapi.WorkflowRunJob{}, fmt.Errorf("insert job: %w", err)
 	}
 
 	if _, err := queries.InsertWorkflowJob(ctx, db.InsertWorkflowJobParams{
 		WorkflowRunID: workflowRunID,
 		JobID:         jobID,
 	}); err != nil {
-		return fmt.Errorf("insert workflow job: %w", err)
+		return oapi.WorkflowRunJob{}, fmt.Errorf("insert workflow job: %w", err)
 	}
 
 	if err := s.queue.Enqueue(ctx, reconcile.EnqueueParams{
@@ -194,8 +206,11 @@ func (s *PostgresSetter) dispatchJobForAgent(
 		ScopeType:   "job",
 		ScopeID:     jobID.String(),
 	}); err != nil {
-		return fmt.Errorf("enqueue job dispatch: %w", err)
+		return oapi.WorkflowRunJob{}, fmt.Errorf("enqueue job dispatch: %w", err)
 	}
 
-	return nil
+	return oapi.WorkflowRunJob{
+		JobId:      jobID.String(),
+		JobAgentId: jobAgentIDUUID.String(),
+	}, nil
 }

--- a/apps/workspace-engine/svc/http/server/openapi/workflows/workflows.go
+++ b/apps/workspace-engine/svc/http/server/openapi/workflows/workflows.go
@@ -94,15 +94,16 @@ func (w *Workflows) CreateWorkflowRun(
 		return
 	}
 
-	if err := w.setter.CreateWorkflowRun(
+	result, err := w.setter.CreateWorkflowRun(
 		c.Request.Context(),
 		workspaceId,
 		workflow,
 		inputs,
-	); err != nil {
+	)
+	if err != nil {
 		c.JSON(http.StatusInternalServerError, gin.H{"error": err.Error()})
 		return
 	}
 
-	c.JSON(http.StatusOK, gin.H{"message": "Workflow run created"})
+	c.JSON(http.StatusOK, result)
 }


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **API Changes**
  * Workflow run creation endpoint now returns comprehensive execution details including job information (IDs and agent assignments), replacing the previous confirmation message.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->