### PR TITLE
fix: wrap job status update request body in an object

### DIFF
--- a/apps/api/openapi/openapi.json
+++ b/apps/api/openapi/openapi.json
@@ -6498,7 +6498,15 @@
                "content": {
                   "application/json": {
                      "schema": {
-                        "$ref": "#/components/schemas/JobStatus"
+                        "type": "object",
+                        "required": [
+                           "status"
+                        ],
+                        "properties": {
+                           "status": {
+                              "$ref": "#/components/schemas/JobStatus"
+                           }
+                        }
                      }
                   }
                },

--- a/apps/api/openapi/paths/jobs.jsonnet
+++ b/apps/api/openapi/paths/jobs.jsonnet
@@ -57,7 +57,13 @@ local openapi = import '../lib/openapi.libsonnet';
         required: true,
         content: {
           'application/json': {
-            schema: openapi.schemaRef('JobStatus'),
+            schema: {
+              type: 'object',
+              required: ['status'],
+              properties: {
+                status: openapi.schemaRef('JobStatus'),
+              },
+            },
           },
         },
       },

--- a/apps/api/src/routes/v1/workspaces/jobs.ts
+++ b/apps/api/src/routes/v1/workspaces/jobs.ts
@@ -257,7 +257,7 @@ const updateJobStatus: AsyncTypedHandler<
   "put"
 > = async (req, res) => {
   const { workspaceId, jobId } = req.params;
-  const { body: oapiStatus } = req;
+  const { status: oapiStatus } = req.body;
 
   const dbStatus = oapiToDbStatus[oapiStatus as string];
   if (dbStatus == null) throw new ApiError("Invalid job status", 400);

--- a/apps/api/src/routes/v1/workspaces/jobs.ts
+++ b/apps/api/src/routes/v1/workspaces/jobs.ts
@@ -263,7 +263,7 @@ const updateJobStatus: AsyncTypedHandler<
   const { workspaceId, jobId } = req.params;
   const { status: oapiStatus } = req.body;
 
-  const dbStatus = oapiToDbStatus[oapiStatus as string];
+  const dbStatus = oapiToDbStatus[oapiStatus];
   if (dbStatus == null) throw new ApiError("Invalid job status", 400);
 
   const existing = await db

--- a/apps/api/src/types/openapi.ts
+++ b/apps/api/src/types/openapi.ts
@@ -4363,7 +4363,9 @@ export interface operations {
         };
         requestBody: {
             content: {
-                "application/json": components["schemas"]["JobStatus"];
+                "application/json": {
+                    status: components["schemas"]["JobStatus"];
+                };
             };
         };
         responses: {

--- a/e2e/api/schema.ts
+++ b/e2e/api/schema.ts
@@ -4363,7 +4363,9 @@ export interface operations {
         };
         requestBody: {
             content: {
-                "application/json": components["schemas"]["JobStatus"];
+                "application/json": {
+                    status: components["schemas"]["JobStatus"];
+                };
             };
         };
         responses: {

--- a/e2e/package.json
+++ b/e2e/package.json
@@ -27,6 +27,7 @@
     "test:yaml-template": "pnpm exec playwright test tests/api/template-yaml.spec.ts",
     "test:systems": "pnpm exec playwright test tests/systems.spec.ts",
     "test:workflows": "pnpm exec playwright test tests/api/workflows.spec.ts",
+    "test:job-status-update": "pnpm exec playwright test --project=api-tests tests/api/job-status-update.spec.ts",
     "seed": "tsx seed.ts",
     "clean": "rm -rf .turbo node_modules",
     "show-report": "pnpm exec playwright show-report",

--- a/e2e/tests/api/job-status-update.spec.ts
+++ b/e2e/tests/api/job-status-update.spec.ts
@@ -1,0 +1,169 @@
+import { expect } from "@playwright/test";
+import { faker } from "@faker-js/faker";
+import { v4 as uuidv4 } from "uuid";
+
+import { inArray } from "@ctrlplane/db";
+import { db } from "@ctrlplane/db/client";
+import * as schema from "@ctrlplane/db/schema";
+
+import { test } from "../fixtures";
+
+// Exercises PUT /v1/workspaces/{workspaceId}/jobs/{jobId}/status. The request
+// body is an object `{ status }` — a bare string is rejected by the strict JSON
+// body parser (the bug this endpoint had). Jobs are seeded directly with the
+// release linkage the handler requires: job -> release_job -> release ->
+// deployment(in workspace).
+test.describe("Job Status Update API", () => {
+  const created = {
+    jobIds: [] as string[],
+    releaseIds: [] as string[],
+    versionIds: [] as string[],
+    deploymentIds: [] as string[],
+    environmentIds: [] as string[],
+    resourceIds: [] as string[],
+  };
+
+  const seedJob = async (
+    workspaceId: string,
+    status: "in_progress" | "pending" = "in_progress",
+  ) => {
+    const suffix = faker.string.alphanumeric(8);
+
+    const deployment = await db
+      .insert(schema.deployment)
+      .values({ name: `status-deploy-${suffix}`, workspaceId })
+      .returning()
+      .then((rows) => rows[0]!);
+    const resource = await db
+      .insert(schema.resource)
+      .values({
+        name: `status-res-${suffix}`,
+        kind: "TestKind",
+        identifier: `status-res-${suffix}`,
+        version: "1.0.0",
+        workspaceId,
+      })
+      .returning()
+      .then((rows) => rows[0]!);
+    const environment = await db
+      .insert(schema.environment)
+      .values({ name: `status-env-${suffix}`, workspaceId })
+      .returning()
+      .then((rows) => rows[0]!);
+    const version = await db
+      .insert(schema.deploymentVersion)
+      .values({
+        name: suffix,
+        tag: suffix,
+        deploymentId: deployment.id,
+        workspaceId,
+      })
+      .returning()
+      .then((rows) => rows[0]!);
+    const release = await db
+      .insert(schema.release)
+      .values({
+        resourceId: resource.id,
+        environmentId: environment.id,
+        deploymentId: deployment.id,
+        versionId: version.id,
+      })
+      .returning()
+      .then((rows) => rows[0]!);
+    const job = await db
+      .insert(schema.job)
+      .values({ status })
+      .returning()
+      .then((rows) => rows[0]!);
+    await db
+      .insert(schema.releaseJob)
+      .values({ jobId: job.id, releaseId: release.id });
+
+    created.jobIds.push(job.id);
+    created.releaseIds.push(release.id);
+    created.versionIds.push(version.id);
+    created.deploymentIds.push(deployment.id);
+    created.environmentIds.push(environment.id);
+    created.resourceIds.push(resource.id);
+    return job.id;
+  };
+
+  test.afterAll(async () => {
+    if (created.jobIds.length > 0) {
+      await db
+        .delete(schema.releaseJob)
+        .where(inArray(schema.releaseJob.jobId, created.jobIds));
+      await db.delete(schema.job).where(inArray(schema.job.id, created.jobIds));
+    }
+    if (created.releaseIds.length > 0)
+      await db
+        .delete(schema.release)
+        .where(inArray(schema.release.id, created.releaseIds));
+    if (created.versionIds.length > 0)
+      await db
+        .delete(schema.deploymentVersion)
+        .where(inArray(schema.deploymentVersion.id, created.versionIds));
+    if (created.deploymentIds.length > 0)
+      await db
+        .delete(schema.deployment)
+        .where(inArray(schema.deployment.id, created.deploymentIds));
+    if (created.environmentIds.length > 0)
+      await db
+        .delete(schema.environment)
+        .where(inArray(schema.environment.id, created.environmentIds));
+    if (created.resourceIds.length > 0)
+      await db
+        .delete(schema.resource)
+        .where(inArray(schema.resource.id, created.resourceIds));
+  });
+
+  test("updates a job's status via the { status } body", async ({
+    api,
+    workspace,
+  }) => {
+    const jobId = await seedJob(workspace.id, "in_progress");
+
+    const res = await api.PUT(
+      "/v1/workspaces/{workspaceId}/jobs/{jobId}/status",
+      {
+        params: { path: { workspaceId: workspace.id, jobId } },
+        body: { status: "successful" },
+      },
+    );
+    expect(res.response.status).toBe(202);
+
+    const get = await api.GET("/v1/workspaces/{workspaceId}/jobs/{jobId}", {
+      params: { path: { workspaceId: workspace.id, jobId } },
+    });
+    expect(get.response.status).toBe(200);
+    expect(get.data!.status).toBe("successful");
+    expect(get.data!.completedAt).toBeDefined();
+  });
+
+  test("returns 400 for an invalid status value", async ({
+    api,
+    workspace,
+  }) => {
+    const jobId = await seedJob(workspace.id);
+
+    const res = await api.PUT(
+      "/v1/workspaces/{workspaceId}/jobs/{jobId}/status",
+      {
+        params: { path: { workspaceId: workspace.id, jobId } },
+        body: { status: "bogus" } as { status: "successful" },
+      },
+    );
+    expect(res.response.status).toBe(400);
+  });
+
+  test("returns 404 for a non-existent job", async ({ api, workspace }) => {
+    const res = await api.PUT(
+      "/v1/workspaces/{workspaceId}/jobs/{jobId}/status",
+      {
+        params: { path: { workspaceId: workspace.id, jobId: uuidv4() } },
+        body: { status: "successful" },
+      },
+    );
+    expect(res.response.status).toBe(404);
+  });
+});

--- a/e2e/tests/api/job-status-update.spec.ts
+++ b/e2e/tests/api/job-status-update.spec.ts
@@ -31,7 +31,7 @@ test.describe("Job Status Update API", () => {
 
     const deployment = await db
       .insert(schema.deployment)
-      .values({ name: `status-deploy-${suffix}`, workspaceId })
+      .values({ name: `status-deploy-${suffix}`, description: "", workspaceId })
       .returning()
       .then((rows) => rows[0]!);
     const resource = await db


### PR DESCRIPTION
Fixes #1158

The PUT `/v1/workspaces/{workspaceId}/jobs/{jobId}/status` endpoint was broken because `express.json` strict mode rejects bare top-level strings, but the schema declared the request body as a bare `JobStatus` string.

**Changes:**
- OpenAPI schema: request body changed from bare `JobStatus` string to `{ status: JobStatus }` object
- Handler: reads `req.body.status` instead of `req.body`
- Regenerated `openapi.json` and `openapi.ts` types

Generated with [Claude Code](https://claude.ai/code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Tests**
  * Added end-to-end tests for the job status update endpoint covering success, invalid-status (400), and missing-job (404) scenarios; verifies status and completion timestamp behavior.

* **Chores**
  * API request format for job status updates changed: clients must send a JSON object containing a required "status" field (using the existing JobStatus values).
<!-- end of auto-generated comment: release notes by coderabbit.ai -->