### PR TITLE
chore: include workflow inputs in job get endpoint

### DIFF
--- a/apps/api/openapi/openapi.json
+++ b/apps/api/openapi/openapi.json
@@ -1019,6 +1019,11 @@
                "environment": {
                   "$ref": "#/components/schemas/Environment"
                },
+               "inputs": {
+                  "additionalProperties": true,
+                  "description": "Resolved input values for a workflow run.",
+                  "type": "object"
+               },
                "jobAgent": {
                   "$ref": "#/components/schemas/JobAgent"
                },

--- a/apps/api/openapi/schemas/jobs.jsonnet
+++ b/apps/api/openapi/schemas/jobs.jsonnet
@@ -77,6 +77,11 @@ local JobPropertyKeys = std.objectFields(Job.properties);
       workflowJob: openapi.schemaRef('WorkflowJob'),
       workflowRun: openapi.schemaRef('WorkflowRun'),
       version: openapi.schemaRef('DeploymentVersion'),
+      inputs: {
+        type: 'object',
+        additionalProperties: true,
+        description: 'Resolved input values for a workflow run.',
+      },
       variables: {
         type: 'object',
         additionalProperties: openapi.schemaRef('LiteralValue'),

--- a/apps/api/src/types/openapi.ts
+++ b/apps/api/src/types/openapi.ts
@@ -1583,6 +1583,10 @@ export interface components {
         DispatchContext: {
             deployment?: components["schemas"]["Deployment"];
             environment?: components["schemas"]["Environment"];
+            /** @description Resolved input values for a workflow run. */
+            inputs?: {
+                [key: string]: unknown;
+            };
             jobAgent: components["schemas"]["JobAgent"];
             jobAgentConfig: components["schemas"]["JobAgentConfig"];
             release?: components["schemas"]["Release"];

--- a/github/get-job-inputs/index.js
+++ b/github/get-job-inputs/index.js
@@ -28172,6 +28172,7 @@ async function run() {
         workspace: { id: job.workspaceId },
         environment: dispatchContext?.environment,
         deployment: dispatchContext?.deployment,
+        input: dispatchContext?.inputs,
     };
     setOutputsRecursively(null, ghActionsJobObject);
     const missingOutputs = requiredOutputs.filter((output) => !outputTracker.has(output));

--- a/integrations/github-get-job-inputs/src/index.ts
+++ b/integrations/github-get-job-inputs/src/index.ts
@@ -83,6 +83,7 @@ async function run() {
     workspace: { id: job.workspaceId },
     environment: dispatchContext?.environment,
     deployment: dispatchContext?.deployment,
+    input: dispatchContext?.inputs,
   };
 
   setOutputsRecursively(null, ghActionsJobObject);


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Resolved input values are now accessible for workflow runs through the API dispatch context and GitHub Action outputs. This allows you to retrieve and inspect all input parameters provided to a workflow execution.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->