### PR TITLE
chore: import instrumentation module in api container entrypoint

### DIFF
--- a/apps/api/Dockerfile
+++ b/apps/api/Dockerfile
@@ -66,4 +66,4 @@ ENV PORT=8081
 
 WORKDIR /app/apps/api/dist/src/
 
-CMD ["node", "index.js"]
+CMD ["node", "--import", "./instrumentation.js", "index.js"]


### PR DESCRIPTION
The API is instrumented with OpenTelemetry but none of its telemetry reaches Datadog, because the SDK only initializes via Node's --import flag and the Dockerfile runs node index.js without it (only the npm scripts pass it), so sdk.start() never runs in prod. Adding the flag to the CMD fixes it — the collector→Datadog path already works, so once this ships the API will start reporting traces/metrics/logs and we can finally monitor it.