### PR TITLE
fix: Add instrumentation to docker start cmd

### DIFF
--- a/apps/api/Dockerfile
+++ b/apps/api/Dockerfile
@@ -66,4 +66,4 @@ ENV PORT=8081
 
 WORKDIR /app/apps/api/dist/src/
 
-CMD ["node", "index.js"]
+CMD ["node", "--import", "./instrumentation.js", "index.js"]


### PR DESCRIPTION
I forgot to add this in my previous PR. This should load the instrumentation setup to get OTEL metrics and logs exported

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated container initialization configuration for the API service to enhance application startup handling.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->